### PR TITLE
Fixing user-after-free in ProgramVar

### DIFF
--- a/clang/include/clang/CConv/ProgramVar.h
+++ b/clang/include/clang/CConv/ProgramVar.h
@@ -355,6 +355,8 @@ private:
   std::string VarName;
   const ProgramVarScope *VScope;
   bool IsConstant;
+  // TODO: All the ProgramVars may not be used. We should try to figure out
+  //  a way to free unused program vars.
   static std::set<ProgramVar *> AllProgramVars;
 
   ProgramVar(BoundsKey VK, std::string VName,

--- a/clang/include/clang/CConv/ProgramVar.h
+++ b/clang/include/clang/CConv/ProgramVar.h
@@ -337,15 +337,6 @@ private:
 // Class that represents a program variable along with its scope.
 class ProgramVar {
 public:
-  ProgramVar(BoundsKey VK, std::string VName,
-             const ProgramVarScope *PVS,
-             bool IsCons) :
-      K(VK), VarName(VName), VScope(PVS), IsConstant(IsCons) { }
-
-  ProgramVar(BoundsKey VK, std::string VName,
-             const ProgramVarScope *PVS) :
-      ProgramVar(VK, VName, PVS, false) { }
-
   const ProgramVarScope *getScope() { return VScope; }
   void setScope(const ProgramVarScope *PVS) { this->VScope = PVS; }
   BoundsKey getKey() { return K; }
@@ -355,11 +346,25 @@ public:
   std::string verboseStr();
   ProgramVar *makeCopy(BoundsKey NK);
   virtual ~ProgramVar() { }
+
+  static ProgramVar *createNewProgramVar(BoundsKey VK, std::string VName,
+                                         const ProgramVarScope *PVS,
+                                         bool IsCons = false);
 private:
   BoundsKey K;
   std::string VarName;
   const ProgramVarScope *VScope;
   bool IsConstant;
+  static std::set<ProgramVar *> AllProgramVars;
+
+  ProgramVar(BoundsKey VK, std::string VName,
+             const ProgramVarScope *PVS,
+             bool IsCons) :
+    K(VK), VarName(VName), VScope(PVS), IsConstant(IsCons) { }
+
+  ProgramVar(BoundsKey VK, std::string VName,
+             const ProgramVarScope *PVS) :
+    ProgramVar(VK, VName, PVS, false) { }
 };
 
 #endif // _BOUNDSVAR_H

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -233,7 +233,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::VarDecl *VD) {
       }
     }
     assert(PVS != nullptr && "Context not null");
-    auto *PVar = new ProgramVar(NK, VD->getNameAsString(), PVS);
+    auto *PVar = ProgramVar::createNewProgramVar(NK, VD->getNameAsString(), PVS);
     insertProgramVar(NK, PVar);
     if (VD->getType()->isPointerType())
       PointerBoundsKey.insert(NK);
@@ -260,7 +260,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::ParmVarDecl *PVD) {
     if (ParamName.empty())
       ParamName = "NONAMEPARAM_" + std::to_string(ParamIdx);
 
-    auto *PVar = new ProgramVar(NK, ParamName, FPS);
+    auto *PVar = ProgramVar::createNewProgramVar(NK, ParamName, FPS);
     insertProgramVar(NK, PVar);
     insertParamKey(ParamKey, NK);
     if (PVD->getType()->isPointerType())
@@ -281,7 +281,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::FunctionDecl *FD) {
           FunctionParamScope::getFunctionParamScope(FD->getNameAsString(),
                                                   FD->isStatic());
 
-    auto *PVar = new ProgramVar(NK, FD->getNameAsString(), FPS);
+    auto *PVar = ProgramVar::createNewProgramVar(NK, FD->getNameAsString(), FPS);
     insertProgramVar(NK, PVar);
     FuncDeclVarMap.insert(FuncKey, NK);
     if (FD->getReturnType()->isPointerType())
@@ -298,7 +298,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::FieldDecl *FD) {
     insertVarKey(PSL, NK);
     std::string StName = FD->getParent()->getNameAsString();
     const StructScope *SS = StructScope::getStructScope(StName);
-    auto *PVar = new ProgramVar(NK, FD->getNameAsString(), SS);
+    auto *PVar = ProgramVar::createNewProgramVar(NK, FD->getNameAsString(), SS);
     insertProgramVar(NK, PVar);
     if (FD->getType()->isPointerType())
       PointerBoundsKey.insert(NK);
@@ -509,8 +509,11 @@ BoundsKey AVarBoundsInfo::getConstKey(uint64_t value) {
     BoundsKey NK = ++BCount;
     ConstVarKeys[value] = NK;
     std::string ConsString = std::to_string(value);
-    ProgramVar *NPV = new ProgramVar(NK, ConsString,
-                                     GlobalScope::getGlobalScope(), true);
+    ProgramVar *NPV =
+              ProgramVar::createNewProgramVar(NK,
+                                              ConsString,
+                                              GlobalScope::getGlobalScope(),
+                                        true);
     insertProgramVar(NK, NPV);
   }
   return ConstVarKeys[value];
@@ -530,11 +533,6 @@ void AVarBoundsInfo::insertParamKey(AVarBoundsInfo::ParamDeclType ParamDecl,
 }
 
 void AVarBoundsInfo::insertProgramVar(BoundsKey NK, ProgramVar *PV) {
-  if (getProgramVar(NK) != nullptr) {
-    // Free the already created variable.
-    auto *E = PVarInfo[NK];
-    delete (E);
-  }
   PVarInfo[NK] = PV;
 }
 

--- a/clang/lib/CConv/ProgramVar.cpp
+++ b/clang/lib/CConv/ProgramVar.cpp
@@ -62,6 +62,7 @@ const FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
   return &(*AllFnScopes.find(TmpFS));
 }
 
+std::set<ProgramVar *> ProgramVar::AllProgramVars;
 
 std::string ProgramVar::mkString(bool GetKey) {
   std::string Ret = "";
@@ -84,4 +85,13 @@ ProgramVar *ProgramVar::makeCopy(BoundsKey NK) {
 std::string ProgramVar::verboseStr() {
   std::string Ret = mkString(true) + "(" + VScope->getStr() + ")";
   return Ret;
+}
+
+ProgramVar *ProgramVar::createNewProgramVar(BoundsKey VK, std::string VName,
+                                            const ProgramVarScope *PVS,
+                                            bool IsCons) {
+  ProgramVar *NewPV = new ProgramVar(VK, VName, PVS, IsCons);
+  AllProgramVars.insert(NewPV);
+  return NewPV;
+
 }


### PR DESCRIPTION
Fixing use-after-free in array bounds inference: https://github.com/correctcomputation/checkedc-clang/runs/1164888459?check_suite_focus=true