### PR TITLE
Major refactoring of array bounds code and some performance improvements

### DIFF
--- a/clang/include/clang/CConv/ABounds.h
+++ b/clang/include/clang/CConv/ABounds.h
@@ -44,7 +44,7 @@ public:
   virtual ~ABounds() { }
 
   virtual std::string mkString(AVarBoundsInfo *) = 0;
-  virtual bool areSame(ABounds *) = 0;
+  virtual bool areSame(ABounds *, AVarBoundsInfo *) = 0;
   virtual BoundsKey getBKey() = 0;
   virtual ABounds* makeCopy(BoundsKey NK) = 0;
 
@@ -66,7 +66,7 @@ public:
   virtual ~CountBound() { }
 
   std::string mkString(AVarBoundsInfo *ABI) override ;
-  bool areSame(ABounds *O) override;
+  bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
   BoundsKey getBKey() override;
   ABounds* makeCopy(BoundsKey NK) override;
 
@@ -88,7 +88,7 @@ public:
   virtual ~ByteBound() { }
 
   std::string mkString(AVarBoundsInfo *ABI) override ;
-  bool areSame(ABounds *O) override;
+  bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
   BoundsKey getBKey() override;
   ABounds* makeCopy(BoundsKey NK) override;
 
@@ -111,7 +111,7 @@ public:
   virtual ~RangeBound() { }
 
   std::string mkString(AVarBoundsInfo *ABI) override ;
-  bool areSame(ABounds *O) override;
+  bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
 
   BoundsKey getBKey() override {
     assert (false && "Not implemented.");

--- a/clang/include/clang/CConv/ABounds.h
+++ b/clang/include/clang/CConv/ABounds.h
@@ -49,8 +49,8 @@ public:
   virtual ABounds* makeCopy(BoundsKey NK) = 0;
 
   // Set that maintains all the bound keys that are used inin
+  // TODO: Is this still needed?
   static std::set<BoundsKey> KeysUsedInBounds;
-
   static bool isKeyUsedInBounds(BoundsKey ToCheck);
 
   static ABounds *getBoundsInfo(AVarBoundsInfo *AVBInfo,

--- a/clang/include/clang/CConv/AVarBoundsInfo.h
+++ b/clang/include/clang/CConv/AVarBoundsInfo.h
@@ -100,6 +100,7 @@ public:
   // Clear all possible inferred bounds for all the BoundsKeys
   void clearInferredBounds() {
     CurrIterInferBounds.clear();
+    BKsFailedFlowInference.clear();
   }
 
   // Infer bounds for the given key from the set of given ARR atoms.
@@ -143,11 +144,14 @@ private:
 
   // Potential Bounds for each bounds key inferred for the current iteration.
   std::map<BoundsKey, BndsKindMap> CurrIterInferBounds;
+  // BoundsKey that failed the flow inference.
+  std::set<BoundsKey> BKsFailedFlowInference;
 };
 
 class AVarBoundsInfo {
 public:
-  AVarBoundsInfo() : ProgVarGraph(this), CtxSensProgVarGraph(this) {
+  AVarBoundsInfo() : ProgVarGraph(this), CtxSensProgVarGraph(this),
+                     RevCtxSensProgVarGraph(this) {
     BCount = 1;
     PVarInfo.clear();
     InProgramArrPtrBoundsKeys.clear();
@@ -300,9 +304,11 @@ private:
 
   // Graph of all program variables.
   AVarGraph ProgVarGraph;
-  // Graph that contains only edges between context-sensitive
-  // BoundsKey and corresponding original BoundsKey.
+  // Graph that contains only edges from normal BoundsKey to
+  // context-sensitive BoundsKey.
   AVarGraph CtxSensProgVarGraph;
+  // Same as above but in the reverse direction.
+  AVarGraph RevCtxSensProgVarGraph;
   // Stats on techniques used to find length for various variables.
   AVarBoundsStats BoundsInferStats;
   // This is the map of pointer variable bounds key and set of bounds key
@@ -345,12 +351,10 @@ private:
   bool keepHighestPriorityBounds(std::set<BoundsKey> &ArrPtrs);
 
   // Perform worklist based inference on the requested array variables using
-  // the provided graph.
-  // The flag FromPB requests the algorithm to use potential length variables.
+  // the provided graph and potential length variables.
   bool performWorkListInference(const std::set<BoundsKey> &ArrNeededBounds,
                                 AVarGraph &BKGraph,
-                                AvarBoundsInference &BI,
-                                bool FromPB = false);
+                                AvarBoundsInference &BI);
 
   void insertParamKey(ParamDeclType ParamDecl, BoundsKey NK);
 };

--- a/clang/include/clang/CConv/ArrayBoundsInferenceConsumer.h
+++ b/clang/include/clang/CConv/ArrayBoundsInferenceConsumer.h
@@ -22,6 +22,15 @@
 class LocalVarABVisitor;
 class ConstraintResolver;
 
+class AllocBasedBoundsInference : public ASTConsumer {
+public:
+  explicit AllocBasedBoundsInference(ProgramInfo &I, clang::ASTContext *C) : Info(I) { }
+  virtual void HandleTranslationUnit(ASTContext &Context);
+
+private:
+  ProgramInfo &Info;
+};
+
 // This class handles determining bounds of global array variables.
 // i.e., function parameters, structure fields and global variables.
 class GlobalABVisitor: public clang::RecursiveASTVisitor<GlobalABVisitor> {
@@ -96,7 +105,8 @@ private:
   std::unique_ptr<CFG> Cfg;
 };
 
-void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I);
+void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I,
+                                         bool UseHeuristics = true);
 
 // Add constraints based on heuristics to the parameters of the
 // provided function.

--- a/clang/include/clang/CConv/ConstraintsGraph.h
+++ b/clang/include/clang/CConv/ConstraintsGraph.h
@@ -167,7 +167,6 @@ public:
     // Insert into BFS cache.
     if (BFSCache.find(Start) == BFSCache.end()) {
       std::set<Data> ReachableNodes;
-      ReachableNodes.clear();
       for (auto TNode : llvm::breadth_first(*N)) {
         ReachableNodes.insert(TNode->getData());
       }

--- a/clang/include/clang/CConv/ProgramVar.h
+++ b/clang/include/clang/CConv/ProgramVar.h
@@ -215,6 +215,17 @@ public:
                       const PersistentSourceLoc &CtxPSL) :
     FunctionParamScope(FN, IsSt) {
     PSL = CtxPSL;
+    std::string FileName = PSL.getFileName();
+    CtxIDStr = "";
+    if (!FileName.empty()) {
+      llvm::sys::fs::UniqueID UId;
+      if (llvm::sys::fs::getUniqueID(FileName, UId)) {
+        CtxIDStr = std::to_string(UId.getDevice()) + ":" +
+                   std::to_string(UId.getFile()) + ":";
+      }
+    }
+    CtxIDStr += std::to_string(PSL.getLineNo()) + ":" +
+                std::to_string(PSL.getColSNo());
     this->Kind = CtxFunctionArgScopeKind;
   }
 
@@ -261,7 +272,7 @@ public:
   }
 
   std::string getStr() const {
-    return "CtxFuncArg_" + FName;
+    return FName + "_Ctx_" + CtxIDStr;
   }
 
   static const CtxFunctionArgScope *
@@ -270,7 +281,7 @@ public:
 
 private:
   PersistentSourceLoc PSL;
-
+  std::string CtxIDStr;
   static std::set<CtxFunctionArgScope, PVSComp> AllCtxFnArgScopes;
 };
 

--- a/clang/include/clang/CConv/ProgramVar.h
+++ b/clang/include/clang/CConv/ProgramVar.h
@@ -19,6 +19,8 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/CConv/PersistentSourceLoc.h"
 
+// Unique ID for a program variable or constant literal, both of
+// which could serve as bounds
 typedef uint32_t BoundsKey;
 
 // Class representing scope of a program variable.
@@ -27,9 +29,9 @@ public:
   enum ScopeKind {
     // Function scope.
     FunctionScopeKind,
-    // Function parameter scope.
+    // Parameters of a particular function.
     FunctionParamScopeKind,
-    // Context sensitive argument scope.
+    // All arguments to a particular call
     CtxFunctionArgScopeKind,
     // Struct scope.
     StructScopeKind,
@@ -280,7 +282,7 @@ public:
                            const PersistentSourceLoc &PSL);
 
 private:
-  PersistentSourceLoc PSL;
+  PersistentSourceLoc PSL; // source code location of this function call
   std::string CtxIDStr;
   static std::set<CtxFunctionArgScope, PVSComp> AllCtxFnArgScopes;
 };
@@ -365,7 +367,7 @@ private:
   BoundsKey K;
   std::string VarName;
   const ProgramVarScope *VScope;
-  bool IsConstant;
+  bool IsConstant; // is a literal integer, not a variable
   // TODO: All the ProgramVars may not be used. We should try to figure out
   //  a way to free unused program vars.
   static std::set<ProgramVar *> AllProgramVars;

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -124,6 +124,9 @@ bool isFunctionAllocator(std::string FuncName);
 // Is the given variable built  in type?
 bool isPointerType(clang::ValueDecl *VD);
 
+// Is this a pointer or array type?
+bool isPtrOrArrayType(const clang::QualType &QT);
+
 // Check if provided type is a var arg type?
 bool isVarArgType(const std::string &TypeName);
 

--- a/clang/lib/CConv/ABounds.cpp
+++ b/clang/lib/CConv/ABounds.cpp
@@ -63,11 +63,10 @@ std::string CountBound::mkString(AVarBoundsInfo *ABI) {
   return "count(" + PV->mkString() + ")";
 }
 
-bool CountBound::areSame(ABounds *O) {
+bool CountBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
   if (O != nullptr) {
-    if (CountBound *OT = dyn_cast<CountBound>(O)) {
-      return OT->CountVar == CountVar;
-    }
+    if (CountBound *OT = dyn_cast<CountBound>(O))
+      return ABI->areSameProgramVar(this->CountVar, OT->CountVar);
   }
   return false;
 }
@@ -86,10 +85,10 @@ std::string ByteBound::mkString(AVarBoundsInfo *ABI) {
   return "byte_count(" + PV->mkString() + ")";
 }
 
-bool ByteBound::areSame(ABounds *O) {
+bool ByteBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
   if (O != nullptr) {
     if (ByteBound *BB = dyn_cast<ByteBound>(O)) {
-      return BB->ByteVar == ByteVar;
+      return ABI->areSameProgramVar(this->ByteVar, BB->ByteVar);
     }
   }
   return false;
@@ -111,10 +110,11 @@ std::string RangeBound::mkString(AVarBoundsInfo *ABI) {
   return "bounds(" + LBVar->mkString() + ", " + UBVar->mkString() + ")";
 }
 
-bool RangeBound::areSame(ABounds *O) {
+bool RangeBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
   if (O != nullptr) {
     if (RangeBound *RB = dyn_cast<RangeBound>(O)) {
-      return RB->LB == LB && RB->UB == UB;
+      return ABI->areSameProgramVar(this->LB, RB->LB) &&
+             ABI->areSameProgramVar(this->UB, RB->UB);
     }
   }
   return false;

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -682,6 +682,9 @@ AvarBoundsInference::convergeInferredBounds() {
   return FoundSome;
 }
 
+// This function finds all the BoundsKeys (i.e., variables) in
+// scope `DstScope` that are reachable from `FromVarK` in the
+// graph `BKGraph`. All the reachable bounds key will be stored in `PotK`.
 bool AvarBoundsInference::getReachableBoundKeys(const ProgramVarScope *DstScope,
                                                 BoundsKey FromVarK,
                                                 std::set<BoundsKey> &PotK,
@@ -1198,6 +1201,19 @@ void AVarBoundsInfo::getBoundsNeededArrPointers(const std::set<BoundsKey> &ArrPt
                       std::inserter(AB, AB.end()));
 }
 
+// We first propagate all the bounds information from explicit
+// declarations and mallocs.
+// For other variables that do not have any choice of bounds,
+// we use potential bounds choices (FromPB), these are the variables
+// that are upper bounds to an index variable used in an array indexing
+// operation.
+// For example:
+// if (i < n) {
+//  ...arr[i]...
+// }
+// In the above case, we use n as a potential count bounds for arr.
+// Note: we only use potential bounds for a variable when none of its
+// predecessors have bounds.
 bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
   bool RetVal = false;
   AvarBoundsInference ABI(this);

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -823,7 +823,7 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
           }
         }
       }
-    } else if (IsFuncRet) {
+    } else {
       // If this is a function return we should have bounds from all
       // neighbours.
       ErrorOccurred = true;

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -185,8 +185,10 @@ bool tryGetBoundsKeyVar(Decl *D, BoundsKey &BK, ProgramInfo &Info,
   return CR.resolveBoundsKey(CV, BK) || ABInfo.tryGetVariable(D, BK);
 }
 
-// Check if the provided expression is a call to one of the known
-// memory allocators.
+// Check if the provided expression E is a call to one of the known
+// memory allocators. Will only return true if the argument to the call
+// is a simple expression, and then organizes the ArgVals for determining
+// a possible bound
 static bool isAllocatorCall(Expr *E, std::string &FName, ProgramInfo &I,
                             ASTContext *C,
                             std::vector<Expr *> &ArgVals) {
@@ -251,7 +253,7 @@ static void handleAllocatorCall(QualType LHSType, BoundsKey LK, Expr *E,
   // is the RHS expression a call to allocator function?
   if (isAllocatorCall(E, FnName, Info, Context, ArgVals)) {
     BoundsKey RK;
-    bool FoundKey = false;
+    bool FoundSingleKeyInAllocExpr = false;
     // We consider everything as byte_count unless we see a sizeof
     // expression in which case if the type matches we use count bounds.
     bool IsByteBound = true;
@@ -263,26 +265,26 @@ static void handleAllocatorCall(QualType LHSType, BoundsKey LK, Expr *E,
         if (LHSType == STy) {
           IsByteBound = false;
         } else {
-          FoundKey = false;
+          FoundSingleKeyInAllocExpr = false;
           break;
         }
       } else if (tryGetBoundsKeyVar(TmpE, RK, Info, Context)) {
         // Is this variable?
-        if (!FoundKey) {
-          FoundKey = true;
+        if (!FoundSingleKeyInAllocExpr) {
+          FoundSingleKeyInAllocExpr = true;
         } else {
           // Multiple variables found.
-          FoundKey = false;
+          FoundSingleKeyInAllocExpr = false;
           break;
         }
       } else {
         // Unrecognized expression.
-        FoundKey = false;
+        FoundSingleKeyInAllocExpr = false;
         break;
       }
     }
 
-    if (FoundKey) {
+    if (FoundSingleKeyInAllocExpr) {
       // If we found BoundsKey from the allocate expression?
       auto *PrgLVar = AVarBInfo.getProgramVar(LK);
       auto *PrgRVar = AVarBInfo.getProgramVar(RK);
@@ -315,6 +317,8 @@ static void handleAllocatorCall(QualType LHSType, BoundsKey LK, Expr *E,
         // --- which gets translated to:
         // tmp <- bounds(count)
         // p->arr <- tmp
+        // TODO: This trick of introducing bounds for RHS expressions
+        //  could be useful in other places (e.g., &{1,2,3} would have bounds 3)
         BoundsKey TmpKey = AVarBInfo.getRandomBKey();
         AVarBInfo.replaceBounds(TmpKey, Declared, LBounds);
         AVarBInfo.addAssignment(LK, TmpKey);

--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -9,7 +9,7 @@
 // Implementation of various method in CConv.h
 //
 //===----------------------------------------------------------------------===//
-
+#include "clang/CConv/ArrayBoundsInferenceConsumer.h"
 #include "clang/CConv/CConv.h"
 #include "clang/CConv/ConstraintBuilder.h"
 #include "clang/CConv/IntermediateToolHook.h"
@@ -30,7 +30,7 @@ using namespace llvm;
 #define BEFORE_SOLVING_SUFFIX "_before_solving_"
 #define AFTER_SUBTYPING_SUFFIX "_after_subtyping_"
 
-static cl::OptionCategory ArrBoundsInferCat("Array bounds inference options");
+cl::OptionCategory ArrBoundsInferCat("Array bounds inference options");
 static cl::opt<bool> DebugArrSolver("debug-arr-solver",
                                    cl::desc("Dump array bounds inference graph"),
                                    cl::init(false),
@@ -277,21 +277,38 @@ bool CConvInterface::SolveConstraints(bool ComputeInterimState) {
   if (DumpIntermediate)
     dumpConstraintOutputJson(FINAL_OUTPUT_SUFFIX, GlobalProgramInfo);
 
+
+  ClangTool &Tool = getGlobalClangTool();
   if (AllTypes) {
     if (DebugArrSolver)
       GlobalProgramInfo.getABoundsInfo().dumpAVarGraph(
           "arr_bounds_initial.dot");
 
-    // Propagate initial data-flow information for Array pointers.
+    // Propagate initial data-flow information for Array pointers from
+    // bounds declarations.
     GlobalProgramInfo.getABoundsInfo().performFlowAnalysis(&GlobalProgramInfo);
+
+    // 3. Infer the bounds based on calls to malloc and calloc
+    std::unique_ptr<ToolAction> ABInfTool =
+      newFrontendActionFactoryA
+        <GenericAction<AllocBasedBoundsInference,
+                       ProgramInfo>>(GlobalProgramInfo);
+    if (ABInfTool)
+      Tool.run(ABInfTool.get());
+    else
+      llvm_unreachable("No Action");
+
+    // Propagate the information from allocator bounds.
+    GlobalProgramInfo.getABoundsInfo().performFlowAnalysis(&GlobalProgramInfo);
+
   }
 
-  // 3. Run intermediate tool hook to run visitors that need to be executed
+  // 4. Run intermediate tool hook to run visitors that need to be executed
   // after constraint solving but before rewriting.
-  ClangTool &Tool = getGlobalClangTool();
   std::unique_ptr<ToolAction> IMTool =
       newFrontendActionFactoryA
-          <GenericAction<IntermediateToolHook, ProgramInfo>>(GlobalProgramInfo);
+          <GenericAction<IntermediateToolHook,
+                         ProgramInfo>>(GlobalProgramInfo);
   if (IMTool)
     Tool.run(IMTool.get());
   else

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -41,7 +41,7 @@ void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
         auto VarTy = VD->getType();
         unsigned int BeginLoc = VD->getBeginLoc().getRawEncoding();
         unsigned int EndLoc = VD->getEndLoc().getRawEncoding();
-        IsInLineStruct = !(VarTy->isPointerType() || VarTy->isArrayType()) &&
+        IsInLineStruct = !isPtrOrArrayType(VarTy) &&
                          !VD->hasInit() &&
                          lastRecordLocation >= BeginLoc &&
                          lastRecordLocation <= EndLoc;
@@ -56,7 +56,7 @@ void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
           bool FieldInUnionOrSysHeader =
               (FL.isInSystemHeader() || Definition->isUnion());
           // mark field wild if the above is true and the field is a pointer
-          if ((FieldTy->isPointerType() || FieldTy->isArrayType()) &&
+          if (isPtrOrArrayType(FieldTy) &&
               (FieldInUnionOrSysHeader || IsInLineStruct)) {
             std::string Rsn = "External struct field or union encountered";
             CVarOption CV = Info.getVariable(F, Context);
@@ -92,8 +92,7 @@ public:
           FullSourceLoc FL = Context->getFullLoc(VD->getBeginLoc());
           SourceRange SR = VD->getSourceRange();
           if (SR.isValid() && FL.isValid() &&
-              (VD->getType()->isPointerType() ||
-               VD->getType()->isArrayType())) {
+              isPtrOrArrayType(VD->getType())) {
             if (lastRecordLocation == VD->getBeginLoc().getRawEncoding()) {
               CVarOption CV = Info.getVariable(VD, Context);
               CB.constraintCVarToWild(CV, "Inline struct encountered.");
@@ -423,7 +422,7 @@ public:
   bool VisitVarDecl(VarDecl *G) {
 
     if (G->hasGlobalStorage() &&
-        (G->getType()->isPointerType() || G->getType()->isArrayType())) {
+        isPtrOrArrayType(G->getType())) {
       if (G->hasInit()) {
         CB.constrainLocalAssign(nullptr, G, G->getInit());
       }
@@ -539,7 +538,7 @@ private:
 
   void addVariable(DeclaratorDecl *D) {
     VarAdder.addABoundsVariable(D);
-    if (D->getType()->isPointerType() || D->getType()->isArrayType())
+    if (isPtrOrArrayType(D->getType()))
       VarAdder.addVariable(D, Context);
   }
 };

--- a/clang/lib/CConv/IntermediateToolHook.cpp
+++ b/clang/lib/CConv/IntermediateToolHook.cpp
@@ -15,8 +15,14 @@
 using namespace llvm;
 using namespace clang;
 
+extern cl::OptionCategory ArrBoundsInferCat;
+static cl::opt<bool> DisableArrH("disable-arr-hu",
+                                cl::desc("Disable Array Bounds Inference Heuristics."),
+                                cl::init(false),
+                                cl::cat(ArrBoundsInferCat));
+
 void IntermediateToolHook::HandleTranslationUnit(ASTContext &Context) {
   Info.enterCompilationUnit(Context);
-  HandleArrayVariablesBoundsDetection(&Context, Info);
+  HandleArrayVariablesBoundsDetection(&Context, Info, !DisableArrH);
   Info.exitCompilationUnit();
 }

--- a/clang/lib/CConv/ProgramVar.cpp
+++ b/clang/lib/CConv/ProgramVar.cpp
@@ -32,7 +32,8 @@ const StructScope *StructScope::getStructScope(std::string StName) {
   if (AllStScopes.find(TmpS) == AllStScopes.end()) {
     AllStScopes.insert(TmpS);
   }
-  return &(*AllStScopes.find(TmpS));
+  const auto &SS = *AllStScopes.find(TmpS);
+  return &SS;
 }
 
 const FunctionParamScope *FunctionParamScope::getFunctionParamScope(
@@ -41,7 +42,8 @@ const FunctionParamScope *FunctionParamScope::getFunctionParamScope(
   if (AllFnParamScopes.find(TmpFPS) == AllFnParamScopes.end()) {
     AllFnParamScopes.insert(TmpFPS);
   }
-  return &(*AllFnParamScopes.find(TmpFPS));
+  const auto &FPS = *AllFnParamScopes.find(TmpFPS);
+  return &FPS;
 }
 
 const CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
@@ -50,7 +52,8 @@ const CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
   if (AllCtxFnArgScopes.find(TmpAS) == AllCtxFnArgScopes.end()) {
     AllCtxFnArgScopes.insert(TmpAS);
   }
-  return &(*AllCtxFnArgScopes.find(TmpAS));
+  const auto &CFAS = *AllCtxFnArgScopes.find(TmpAS);
+  return &CFAS;
 }
 
 const FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
@@ -59,7 +62,8 @@ const FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
   if (AllFnScopes.find(TmpFS) == AllFnScopes.end()) {
     AllFnScopes.insert(TmpFS);
   }
-  return &(*AllFnScopes.find(TmpFS));
+  const auto &FS = *AllFnScopes.find(TmpFS);
+  return &FS;
 }
 
 std::set<ProgramVar *> ProgramVar::AllProgramVars;

--- a/clang/lib/CConv/Utils.cpp
+++ b/clang/lib/CConv/Utils.cpp
@@ -177,6 +177,10 @@ bool isPointerType(clang::ValueDecl *VD) {
   return VD->getType().getTypePtr()->isPointerType();
 }
 
+bool isPtrOrArrayType(const clang::QualType &QT) {
+  return QT->isPointerType() || QT->isArrayType();
+}
+
 bool isStructOrUnionType(clang::VarDecl *VD) {
   return VD->getType().getTypePtr()->isStructureType() ||
          VD->getType().getTypePtr()->isUnionType();

--- a/clang/test/CheckedCRewriter/arrboundsmerging.c
+++ b/clang/test/CheckedCRewriter/arrboundsmerging.c
@@ -27,6 +27,11 @@ void foo3(int *x, int c) {
   x[0] = c;
 }
 
+void foo4(int *x, int c) {
+//CHECK: void foo4(_Array_ptr<int> x, int c) {
+  x[0] = c;
+}
+
 void bar(void) {
   int *p = malloc(sizeof(int)*8);
   int *q = malloc(sizeof(int)*8);
@@ -38,18 +43,27 @@ void bar(void) {
 //CHECK: _Array_ptr<int> q1 : count(8) = malloc<int>(sizeof(int)*8);
 
   int n = 8;
-  int l;
+  int l = 4;
   int *q2 = malloc(sizeof(int)*l);
+  int *q4 = malloc(sizeof(int)*n);
 
   // Variation 1
+  // Correct size association: second argument is indeed the size.
   foo(p,n);
   foo(q,8);
 
   // Variation 2
+  // passing fixed size array: No size association.
   foo2(p1,8);
   foo2(q1,28);
 
   // Variation 3
+  // Variable sized arrays: One correct and one wrong bounds.
   foo3(q2,l);
   foo3(q1,28);
+
+  // Variation 4
+  // Passing wrong lengths to check bounds.
+  foo4(q2,n);
+  foo4(q4,l);
 }

--- a/clang/test/CheckedCRewriter/arrboundsmerging.c
+++ b/clang/test/CheckedCRewriter/arrboundsmerging.c
@@ -1,0 +1,55 @@
+// RUN: cconv-standalone -disable-arr-hu -alltypes %s -- | FileCheck -match-full-lines %s
+
+
+/*
+Advanced array-bounds inference (based on control-dependencies).
+*/
+
+typedef unsigned long size_t;
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+// Here x bounds will be c
+void foo(int *x, int c) {
+//CHECK: void foo(_Array_ptr<int> x : count(c), int c) {
+
+  x[3] = c;
+}
+
+// Here x will be of constant size
+void foo2(int *x, int c) {
+//CHECK: void foo2(_Array_ptr<int> x : count(8), int c) {
+  x[3] = c;
+}
+
+// Here x bounds is c but the violates bounds.
+void foo3(int *x, int c) {
+//CHECK: void foo3(_Array_ptr<int> x, int c) {
+  x[0] = c;
+}
+
+void bar(void) {
+  int *p = malloc(sizeof(int)*8);
+  int *q = malloc(sizeof(int)*8);
+  int *p1 = malloc(sizeof(int)*8);
+  int *q1 = malloc(sizeof(int)*8);
+//CHECK: _Array_ptr<int> p : count(8) = malloc<int>(sizeof(int)*8);
+//CHECK: _Array_ptr<int> q : count(8) = malloc<int>(sizeof(int)*8);
+//CHECK: _Array_ptr<int> p1 : count(8) = malloc<int>(sizeof(int)*8);
+//CHECK: _Array_ptr<int> q1 : count(8) = malloc<int>(sizeof(int)*8);
+
+  int n = 8;
+  int l;
+  int *q2 = malloc(sizeof(int)*l);
+
+  // Variation 1
+  foo(p,n);
+  foo(q,8);
+
+  // Variation 2
+  foo2(p1,8);
+  foo2(q1,28);
+
+  // Variation 3
+  foo3(q2,l);
+  foo3(q1,28);
+}


### PR DESCRIPTION
* Implemented the technique similar to the locksmith, where the bounds of a variable is the intersection of the bounds of all array variables that flows into the variable.

* Added a flag to disable array bounds heuristics: `-disable-arr-hu` (By default, they are enabled but we can use this flag to disable them).

* We used same node for all ocurrences of constant numbers, for example, for the below code:
    ```
    int n = 8;
    int l = 8;
    ```
    We would construct our graph as: `n <-> 8 <-> l`, this wrongly leads us to believe that `n` is reachable (i.e., *flows*) into `l`. Which is not true.
    
    We changed the code to create a new node for every occurrence of constants and thereby avoid this.

* Added cache to breadth-first search, realized that we call BFS on the same node many times and it is better to cache this information (provided that the graph didn't change).

* This also fixes:  https://github.com/correctcomputation/checkedc-clang/issues/281
  
### Array bounds inference:

Every variable (both pointers and scalars) are identified by a unique number i.e., `BoundsKey`, There is a mapping from each `BoundsKey` to the corresponding `ProgramVar*` which contains information about program scope, variable name, etc.

The main entry point in this class is: `bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI)`: This as the name suggests performs flow (i.e., `LockSmith` based) analysis to determine the bounds of all the array variables.

It has a fixed point loop, at each iteration, we try to find the possible bounds for all array variables (that do not have bounds) from its predecessors using the following function:
```
bool AvarBoundsInference::predictBounds(BoundsKey K,
                                        std::set<BoundsKey> &Neighbours,
                                        AVarGraph &BKGraph)
```
where `K` is the array variable whose bounds need to be computed and `Neighbours` are the predecessors and `BKGraph` is the graph that contains all the flow information. The possible bounds for `K` will be stored into `CurrIterInferBounds`. 

Later we call `convergeInferredBounds` that will pick the best bounds from the possible bound values, with the following preference: `count` will be the priority over `byte` bounds. Variables will be given priority over constants. If there are multiple choices (i.e., variables or constants) we give up.

We first propagate all the bounds information from explicit declarations and `mallocs`. 
For other variables that do not have any choice of bounds, we use potential bounds choices (`FromPB`), these are the variables that are upper bounds to an index variable used in an array indexing operation. 
For example:
```
if (i < n) {
   ...arr[i]...
}
```
In the above case, we use `n` as a potential count bounds for `arr`.
**Note: we only use potential bounds for a variable when none of its predecessors have bounds.**

Function of interest:
```
AvarBoundsInference::getReachableBoundKeys(const ProgramVarScope *DstScope,
                                                BoundsKey FromVarK,
                                                std::set<BoundsKey> &PotK,
                                                AVarGraph &BKGraph,
                                                bool CheckImmediate)
```
The function: `getReachableBoundKeys` finds all the BoundsKeys (i.e., variables) in scope `DstScope` that are reachable from `FromVarK` in the graph `BKGraph`. All the reachable bounds key will be stored in `PotK`.