### PR TITLE
Refactoring and bug fix changes

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -112,8 +112,6 @@ public:
   virtual bool solutionEqualTo(Constraints &, const ConstraintVariable *) const
     = 0;
 
-  // Constrain all pointers in this ConstraintVariable to be Wild.
-  virtual void constrainToWild(Constraints &CS) const = 0;
   virtual void constrainToWild(Constraints &CS,
                                const std::string &Rsn) const = 0;
   virtual void constrainToWild(Constraints &CS, const std::string &Rsn,
@@ -362,7 +360,7 @@ public:
   void print(llvm::raw_ostream &O) const override ;
   void dump() const override { print(llvm::errs()); }
   void dump_json(llvm::raw_ostream &O) const override;
-  void constrainToWild(Constraints &CS) const override;
+
   void constrainToWild(Constraints &CS, const std::string &Rsn) const override;
   void constrainToWild(Constraints &CS, const std::string &Rsn,
                        PersistentSourceLoc *PL) const override;
@@ -477,7 +475,7 @@ public:
   void print(llvm::raw_ostream &O) const override;
   void dump() const override { print(llvm::errs()); }
   void dump_json(llvm::raw_ostream &O) const override;
-  void constrainToWild(Constraints &CS) const override;
+
   void constrainToWild(Constraints &CS, const std::string &Rsn) const override;
   void constrainToWild(Constraints &CS, const std::string &Rsn,
                        PersistentSourceLoc *PL) const override;

--- a/clang/include/clang/CConv/DeclRewriter.h
+++ b/clang/include/clang/CConv/DeclRewriter.h
@@ -68,7 +68,7 @@ private:
   void doDeclRewrite(SourceRange &SR, DeclReplacement *N);
 
   void rewriteFunctionDecl(FunctionDeclReplacement *N);
-  void getDeclsOnSameLine(DeclReplacement *N, std::set<Decl *> &Decls);
+  void getDeclsOnSameLine(DeclReplacement *N, std::vector<Decl *> &Decls);
   bool isSingleDeclaration(DeclReplacement *N);
   bool areDeclarationsOnSameLine(DeclReplacement *N1, DeclReplacement *N2);
   SourceRange getNextCommaOrSemicolon(SourceLocation L);

--- a/clang/include/clang/CConv/RewriteUtils.h
+++ b/clang/include/clang/CConv/RewriteUtils.h
@@ -186,15 +186,15 @@ typedef std::set<DeclReplacement *, DComp> RSet;
 class GlobalVariableGroups {
 public:
   GlobalVariableGroups(SourceManager &SourceMgr) : SM(SourceMgr) { }
-  void addGlobalDecl(Decl *VD, std::set<Decl *> *VDSet = nullptr);
+  void addGlobalDecl(Decl *VD, std::vector<Decl *> *VDVec = nullptr);
 
-  std::set<Decl *> &getVarsOnSameLine(Decl *VD);
+  std::vector<Decl *> &getVarsOnSameLine(Decl *VD);
 
   virtual ~GlobalVariableGroups();
 
 private:
   SourceManager &SM;
-  std::map<Decl *, std::set<Decl *>*> GlobVarGroups;
+  std::map<Decl *, std::vector<Decl *>*> GlobVarGroups;
 };
 
 // Class that handles rewriting bounds information for all the


### PR DESCRIPTION
Three miscellaneous changes made while working on the root cause of wildness analysis.

1. Calls to allocater functions will now generate a single atom. Previously, two atoms were generated to act as the parameter and argument atoms for the function, even though these function are handled differently than other function, and don't need the separate parameter atom.
2. The function `ConstraintVariable::constrainToWild` now only adds a constraint on the outer pointer level. The inner pointer levels are implicitly constrained by implication constraints.
3.  A bug is fixed in multi-declaration rewriting that was caused by undefined ordering of a set of `Decl*`.  