### PR TITLE
293 convert partial

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -276,12 +276,6 @@ private:
   // pointers.
   bool IsZeroWidthArray;
 
-  // Was this variable a checked pointer in the input program?
-  // This is important for two reasons: (1) externs that are checked should be
-  // kept that way during solving, (2) nothing that was originally checked
-  // should be modified during rewriting.
-  bool OriginallyChecked;
-
 public:
   // Constructor for when we know a CVars and a type string.
   PointerVariableConstraint(CAtoms V, std::string T, std::string Name,
@@ -290,8 +284,8 @@ public:
           ConstraintVariable(PointerVariable, "" /*not used*/, Name),
           BaseType(T),vars(V),FV(F), ArrPresent(isArr), ItypeStr(is),
           partOFFuncPrototype(false), Parent(nullptr),
-          BoundsAnnotationStr(""), IsGeneric(Generic), IsZeroWidthArray(false),
-          OriginallyChecked(false) {}
+          BoundsAnnotationStr(""), IsGeneric(Generic), IsZeroWidthArray(false)
+          {}
 
   std::string getTy() const { return BaseType; }
   bool getArrPresent() const { return ArrPresent; }
@@ -311,7 +305,9 @@ public:
 
   bool getIsGeneric() const { return IsGeneric; }
 
-  bool getIsOriginallyChecked() const override { return OriginallyChecked; }
+  bool getIsOriginallyChecked() const override {
+    return llvm::any_of(vars, [](Atom *A) { return isa<ConstAtom>(A); });
+  }
 
   bool solutionEqualTo(Constraints &CS,
                        const ConstraintVariable *CV) const override;

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -377,7 +377,7 @@ public:
   // Get the set of constraint variables corresponding to the arguments.
   const std::set<ConstraintVariable *> &getArgumentConstraints() const;
 
-  ConstraintVariable *getCopy(Constraints &CS) override;
+  PointerVariableConstraint *getCopy(Constraints &CS) override;
 
   // Retrieve the atom at the specified index. This function includes special
   // handling for generic constraint variables to create deeper pointers as
@@ -404,10 +404,10 @@ private:
   FunctionVariableConstraint(FunctionVariableConstraint *Ot,
                              Constraints &CS);
   // N constraints on the return value of the function.
-  ConstraintVariable *ReturnVar;
+  PVConstraint *ReturnVar;
   // A vector of K sets of N constraints on the parameter values, for
   // K parameters accepted by the function.
-  std::vector<ConstraintVariable *> ParamVars;
+  std::vector<PVConstraint *> ParamVars;
   // Storing of parameters in the case of untyped prototypes
   std::vector<ParamDeferment> deferredParams;
   // File name in which this declaration is found.
@@ -434,7 +434,7 @@ public:
                              clang::DeclaratorDecl *D, std::string N,
                              ProgramInfo &I, const clang::ASTContext &C);
 
-  ConstraintVariable *getReturnVar() const {
+  PVConstraint *getReturnVar() const {
     return ReturnVar;
   }
 
@@ -458,7 +458,7 @@ public:
   void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
   void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I) override;
 
-  ConstraintVariable *getParamVar(unsigned i) const {
+  PVConstraint *getParamVar(unsigned i) const {
     assert(i < ParamVars.size());
     return ParamVars.at(i);
   }
@@ -484,7 +484,7 @@ public:
 
   void equateArgumentConstraints(ProgramInfo &P) override;
 
-  ConstraintVariable *getCopy(Constraints &CS) override;
+  FunctionVariableConstraint *getCopy(Constraints &CS) override;
 
   bool getIsOriginallyChecked() const override;
 

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -981,13 +981,19 @@ void PointerVariableConstraint::constrainToWild(Constraints &CS,
 void PointerVariableConstraint::constrainToWild(Constraints &CS,
                                                 const std::string &Rsn,
                                                 PersistentSourceLoc *PL) const {
-  // Constrains the outer pointer level to WILD. Inner pointer levels are
+  // Find the first VarAtom. All atoms before this are ConstAtoms, so
+  // constraining them isn't useful;
+  VarAtom *FirstVA = nullptr;
+  for (Atom *A : vars)
+    if (isa<VarAtom>(A)) {
+      FirstVA = cast<VarAtom>(A);
+      break;
+    }
+
+  // Constrains the outer VarAtom to WILD. Inner pointer levels are
   // implicitly WILD because of implication constraints.
-  if (!vars.empty()) {
-    Atom *A = *vars.begin();
-    if (auto *VA = dyn_cast<VarAtom>(A))
-      CS.addConstraint(CS.createGeq(VA, CS.getWild(), Rsn, PL, true));
-  }
+  if (FirstVA)
+    CS.addConstraint(CS.createGeq(FirstVA, CS.getWild(), Rsn, PL, true));
 
   if (FV)
     FV->constrainToWild(CS, Rsn, PL);

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -1269,7 +1269,7 @@ FunctionVariableConstraint::mkString(const EnvironmentMap &E,
 
     Ret = Ret + Ss.str() + ")";
   } else {
-    Ret = Ret + ")";
+    Ret = Ret + "void)";
   }
 
   return Ret;

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -920,7 +920,7 @@ bool FunctionVariableConstraint::hasNtArr(const EnvironmentMap &E,
   return ReturnVar->hasNtArr(E, AIdx);
 }
 
-ConstraintVariable *FunctionVariableConstraint::getCopy(Constraints &CS) {
+FVConstraint *FunctionVariableConstraint::getCopy(Constraints &CS) {
   return new FVConstraint(this, CS);
 }
 
@@ -1055,7 +1055,7 @@ bool PointerVariableConstraint::anyChanges(const EnvironmentMap &E) const {
   return PtrChanged;
 }
 
-ConstraintVariable *PointerVariableConstraint::getCopy(Constraints &CS) {
+PVConstraint *PointerVariableConstraint::getCopy(Constraints &CS) {
   return new PointerVariableConstraint(this, CS);
 }
 

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -498,9 +498,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   // Get rewritten parameter variable declarations
   std::vector<std::string> ParmStrs;
   for (unsigned I = 0; I < Defnc->numParams(); ++I) {
-    auto *Defn = dyn_cast<PVConstraint>(Defnc->getParamVar(I));
-    assert(Defn);
-
+    PVConstraint *Defn = Defnc->getParamVar(I);
     ParmVarDecl *PVDecl = Definition->getParamDecl(I);
     std::string Type, IType;
     this->buildDeclVar(Defn, PVDecl, Type, IType, RewriteParams, RewriteReturn);
@@ -516,7 +514,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   }
 
   // Get rewritten return variable
-  auto *Defn = dyn_cast<PVConstraint>(Defnc->getReturnVar());
+  PVConstraint *Defn = Defnc->getReturnVar();
   std::string ReturnVar, ItypeStr;
   this->buildDeclVar(Defn, FD, ReturnVar, ItypeStr, RewriteParams, RewriteReturn);
 

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -340,15 +340,14 @@ bool ProgramInfo::link() {
       // If there was a checked type on a variable in the input program, it
       // should stay that way. Otherwise, we shouldn't be adding a checked type
       // to an extern function.
-      if (!G->getReturnVar()->getIsOriginallyChecked()) {
-        std::string Rsn = "Return value of an external function:" + FuncName;
+      std::string Rsn =
+        "Unchecked pointer in parameter or return of external function " +
+        FuncName;
+      if (!G->getReturnVar()->getIsGeneric())
         G->getReturnVar()->constrainToWild(CS, Rsn);
-      }
-
-      std::string rsn = "Inner pointer of a parameter to external function.";
-      for (unsigned i = 0; i < G->numParams(); i++)
-        if (!G->getParamVar(i)->getIsOriginallyChecked())
-          G->getParamVar(i)->constrainToWild(CS, rsn);
+      for (unsigned I = 0; I < G->numParams(); I++)
+        if (!G->getParamVar(I)->getIsGeneric())
+          G->getParamVar(I)->constrainToWild(CS, Rsn);
     }
   }
 

--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrboth.checked.c -- | diff %S/arrboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrboth.checked.c -- | count 0
 // RUN: rm %S/arrboth.checked.c
 
 
@@ -108,7 +108,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrbothmulti1.checked.c %S/arrbothmulti2.checked.c
-// RUN: diff %S/arrbothmulti1.checked.convert_again.c %S/arrbothmulti1.checked.c
-// RUN: diff %S/arrbothmulti2.checked.convert_again.c %S/arrbothmulti2.checked.c
+// RUN: test ! -f %S/arrbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrbothmulti2.checked.convert_again.c
 // RUN: rm %S/arrbothmulti1.checkedALL.c %S/arrbothmulti2.checkedALL.c
 // RUN: rm %S/arrbothmulti1.checkedNOALL.c %S/arrbothmulti2.checkedNOALL.c
-// RUN: rm %S/arrbothmulti1.checked.c %S/arrbothmulti2.checked.c %S/arrbothmulti1.checked.convert_again.c %S/arrbothmulti2.checked.convert_again.c
+// RUN: rm %S/arrbothmulti1.checked.c %S/arrbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrbothmulti1.checked2.c %S/arrbothmulti2.checked2.c
-// RUN: diff %S/arrbothmulti1.checked2.convert_again.c %S/arrbothmulti1.checked2.c
-// RUN: diff %S/arrbothmulti2.checked2.convert_again.c %S/arrbothmulti2.checked2.c
+// RUN: test ! -f %S/arrbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrbothmulti2.checked2.convert_again.c
 // RUN: rm %S/arrbothmulti1.checkedALL2.c %S/arrbothmulti2.checkedALL2.c
 // RUN: rm %S/arrbothmulti1.checkedNOALL2.c %S/arrbothmulti2.checkedNOALL2.c
-// RUN: rm %S/arrbothmulti1.checked2.c %S/arrbothmulti2.checked2.c %S/arrbothmulti1.checked2.convert_again.c %S/arrbothmulti2.checked2.convert_again.c
+// RUN: rm %S/arrbothmulti1.checked2.c %S/arrbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -116,7 +116,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrcallee.checked.c -- | diff %S/arrcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrcallee.checked.c -- | count 0
 // RUN: rm %S/arrcallee.checked.c
 
 
@@ -108,7 +108,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrcalleemulti1.checked.c %S/arrcalleemulti2.checked.c
-// RUN: diff %S/arrcalleemulti1.checked.convert_again.c %S/arrcalleemulti1.checked.c
-// RUN: diff %S/arrcalleemulti2.checked.convert_again.c %S/arrcalleemulti2.checked.c
+// RUN: test ! -f %S/arrcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrcalleemulti2.checked.convert_again.c
 // RUN: rm %S/arrcalleemulti1.checkedALL.c %S/arrcalleemulti2.checkedALL.c
 // RUN: rm %S/arrcalleemulti1.checkedNOALL.c %S/arrcalleemulti2.checkedNOALL.c
-// RUN: rm %S/arrcalleemulti1.checked.c %S/arrcalleemulti2.checked.c %S/arrcalleemulti1.checked.convert_again.c %S/arrcalleemulti2.checked.convert_again.c
+// RUN: rm %S/arrcalleemulti1.checked.c %S/arrcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrcalleemulti1.checked2.c %S/arrcalleemulti2.checked2.c
-// RUN: diff %S/arrcalleemulti1.checked2.convert_again.c %S/arrcalleemulti1.checked2.c
-// RUN: diff %S/arrcalleemulti2.checked2.convert_again.c %S/arrcalleemulti2.checked2.c
+// RUN: test ! -f %S/arrcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/arrcalleemulti1.checkedALL2.c %S/arrcalleemulti2.checkedALL2.c
 // RUN: rm %S/arrcalleemulti1.checkedNOALL2.c %S/arrcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/arrcalleemulti1.checked2.c %S/arrcalleemulti2.checked2.c %S/arrcalleemulti1.checked2.convert_again.c %S/arrcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/arrcalleemulti1.checked2.c %S/arrcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -116,7 +116,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrcaller.checked.c -- | diff %S/arrcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrcaller.checked.c -- | count 0
 // RUN: rm %S/arrcaller.checked.c
 
 
@@ -128,7 +128,7 @@ int * foo() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrcallermulti1.checked.c %S/arrcallermulti2.checked.c
-// RUN: diff %S/arrcallermulti1.checked.convert_again.c %S/arrcallermulti1.checked.c
-// RUN: diff %S/arrcallermulti2.checked.convert_again.c %S/arrcallermulti2.checked.c
+// RUN: test ! -f %S/arrcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrcallermulti2.checked.convert_again.c
 // RUN: rm %S/arrcallermulti1.checkedALL.c %S/arrcallermulti2.checkedALL.c
 // RUN: rm %S/arrcallermulti1.checkedNOALL.c %S/arrcallermulti2.checkedNOALL.c
-// RUN: rm %S/arrcallermulti1.checked.c %S/arrcallermulti2.checked.c %S/arrcallermulti1.checked.convert_again.c %S/arrcallermulti2.checked.convert_again.c
+// RUN: rm %S/arrcallermulti1.checked.c %S/arrcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrcallermulti1.checked2.c %S/arrcallermulti2.checked2.c
-// RUN: diff %S/arrcallermulti1.checked2.convert_again.c %S/arrcallermulti1.checked2.c
-// RUN: diff %S/arrcallermulti2.checked2.convert_again.c %S/arrcallermulti2.checked2.c
+// RUN: test ! -f %S/arrcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrcallermulti2.checked2.convert_again.c
 // RUN: rm %S/arrcallermulti1.checkedALL2.c %S/arrcallermulti2.checkedALL2.c
 // RUN: rm %S/arrcallermulti1.checkedNOALL2.c %S/arrcallermulti2.checkedNOALL2.c
-// RUN: rm %S/arrcallermulti1.checked2.c %S/arrcallermulti2.checked2.c %S/arrcallermulti1.checked2.convert_again.c %S/arrcallermulti2.checked2.convert_again.c
+// RUN: rm %S/arrcallermulti1.checked2.c %S/arrcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructboth.checked.c -- | diff %S/arrinstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructboth.checked.c -- | count 0
 // RUN: rm %S/arrinstructboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrinstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructbothmulti1.checked.c %S/arrinstructbothmulti2.checked.c
-// RUN: diff %S/arrinstructbothmulti1.checked.convert_again.c %S/arrinstructbothmulti1.checked.c
-// RUN: diff %S/arrinstructbothmulti2.checked.convert_again.c %S/arrinstructbothmulti2.checked.c
+// RUN: test ! -f %S/arrinstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrinstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/arrinstructbothmulti1.checkedALL.c %S/arrinstructbothmulti2.checkedALL.c
 // RUN: rm %S/arrinstructbothmulti1.checkedNOALL.c %S/arrinstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/arrinstructbothmulti1.checked.c %S/arrinstructbothmulti2.checked.c %S/arrinstructbothmulti1.checked.convert_again.c %S/arrinstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/arrinstructbothmulti1.checked.c %S/arrinstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrinstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructbothmulti1.checked2.c %S/arrinstructbothmulti2.checked2.c
-// RUN: diff %S/arrinstructbothmulti1.checked2.convert_again.c %S/arrinstructbothmulti1.checked2.c
-// RUN: diff %S/arrinstructbothmulti2.checked2.convert_again.c %S/arrinstructbothmulti2.checked2.c
+// RUN: test ! -f %S/arrinstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrinstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/arrinstructbothmulti1.checkedALL2.c %S/arrinstructbothmulti2.checkedALL2.c
 // RUN: rm %S/arrinstructbothmulti1.checkedNOALL2.c %S/arrinstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/arrinstructbothmulti1.checked2.c %S/arrinstructbothmulti2.checked2.c %S/arrinstructbothmulti1.checked2.convert_again.c %S/arrinstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/arrinstructbothmulti1.checked2.c %S/arrinstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructcallee.checked.c -- | diff %S/arrinstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructcallee.checked.c -- | count 0
 // RUN: rm %S/arrinstructcallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrinstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructcalleemulti1.checked.c %S/arrinstructcalleemulti2.checked.c
-// RUN: diff %S/arrinstructcalleemulti1.checked.convert_again.c %S/arrinstructcalleemulti1.checked.c
-// RUN: diff %S/arrinstructcalleemulti2.checked.convert_again.c %S/arrinstructcalleemulti2.checked.c
+// RUN: test ! -f %S/arrinstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrinstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/arrinstructcalleemulti1.checkedALL.c %S/arrinstructcalleemulti2.checkedALL.c
 // RUN: rm %S/arrinstructcalleemulti1.checkedNOALL.c %S/arrinstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/arrinstructcalleemulti1.checked.c %S/arrinstructcalleemulti2.checked.c %S/arrinstructcalleemulti1.checked.convert_again.c %S/arrinstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/arrinstructcalleemulti1.checked.c %S/arrinstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrinstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructcalleemulti1.checked2.c %S/arrinstructcalleemulti2.checked2.c
-// RUN: diff %S/arrinstructcalleemulti1.checked2.convert_again.c %S/arrinstructcalleemulti1.checked2.c
-// RUN: diff %S/arrinstructcalleemulti2.checked2.convert_again.c %S/arrinstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/arrinstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrinstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/arrinstructcalleemulti1.checkedALL2.c %S/arrinstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/arrinstructcalleemulti1.checkedNOALL2.c %S/arrinstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/arrinstructcalleemulti1.checked2.c %S/arrinstructcalleemulti2.checked2.c %S/arrinstructcalleemulti1.checked2.convert_again.c %S/arrinstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/arrinstructcalleemulti1.checked2.c %S/arrinstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructcaller.checked.c -- | diff %S/arrinstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructcaller.checked.c -- | count 0
 // RUN: rm %S/arrinstructcaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrinstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructcallermulti1.checked.c %S/arrinstructcallermulti2.checked.c
-// RUN: diff %S/arrinstructcallermulti1.checked.convert_again.c %S/arrinstructcallermulti1.checked.c
-// RUN: diff %S/arrinstructcallermulti2.checked.convert_again.c %S/arrinstructcallermulti2.checked.c
+// RUN: test ! -f %S/arrinstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrinstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/arrinstructcallermulti1.checkedALL.c %S/arrinstructcallermulti2.checkedALL.c
 // RUN: rm %S/arrinstructcallermulti1.checkedNOALL.c %S/arrinstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/arrinstructcallermulti1.checked.c %S/arrinstructcallermulti2.checked.c %S/arrinstructcallermulti1.checked.convert_again.c %S/arrinstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/arrinstructcallermulti1.checked.c %S/arrinstructcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrinstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructcallermulti1.checked2.c %S/arrinstructcallermulti2.checked2.c
-// RUN: diff %S/arrinstructcallermulti1.checked2.convert_again.c %S/arrinstructcallermulti1.checked2.c
-// RUN: diff %S/arrinstructcallermulti2.checked2.convert_again.c %S/arrinstructcallermulti2.checked2.c
+// RUN: test ! -f %S/arrinstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrinstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/arrinstructcallermulti1.checkedALL2.c %S/arrinstructcallermulti2.checkedALL2.c
 // RUN: rm %S/arrinstructcallermulti1.checkedNOALL2.c %S/arrinstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/arrinstructcallermulti1.checked2.c %S/arrinstructcallermulti2.checked2.c %S/arrinstructcallermulti1.checked2.convert_again.c %S/arrinstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/arrinstructcallermulti1.checked2.c %S/arrinstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructprotoboth.checked.c -- | diff %S/arrinstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/arrinstructprotoboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructprotocallee.checked.c -- | diff %S/arrinstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/arrinstructprotocallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructprotocaller.checked.c -- | diff %S/arrinstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/arrinstructprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructprotosafe.checked.c -- | diff %S/arrinstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/arrinstructprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrinstructsafe.checked.c -- | diff %S/arrinstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrinstructsafe.checked.c -- | count 0
 // RUN: rm %S/arrinstructsafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrinstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructsafemulti1.checked.c %S/arrinstructsafemulti2.checked.c
-// RUN: diff %S/arrinstructsafemulti1.checked.convert_again.c %S/arrinstructsafemulti1.checked.c
-// RUN: diff %S/arrinstructsafemulti2.checked.convert_again.c %S/arrinstructsafemulti2.checked.c
+// RUN: test ! -f %S/arrinstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrinstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/arrinstructsafemulti1.checkedALL.c %S/arrinstructsafemulti2.checkedALL.c
 // RUN: rm %S/arrinstructsafemulti1.checkedNOALL.c %S/arrinstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/arrinstructsafemulti1.checked.c %S/arrinstructsafemulti2.checked.c %S/arrinstructsafemulti1.checked.convert_again.c %S/arrinstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/arrinstructsafemulti1.checked.c %S/arrinstructsafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrinstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrinstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrinstructsafemulti1.checked2.c %S/arrinstructsafemulti2.checked2.c
-// RUN: diff %S/arrinstructsafemulti1.checked2.convert_again.c %S/arrinstructsafemulti1.checked2.c
-// RUN: diff %S/arrinstructsafemulti2.checked2.convert_again.c %S/arrinstructsafemulti2.checked2.c
+// RUN: test ! -f %S/arrinstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrinstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/arrinstructsafemulti1.checkedALL2.c %S/arrinstructsafemulti2.checkedALL2.c
 // RUN: rm %S/arrinstructsafemulti1.checkedNOALL2.c %S/arrinstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/arrinstructsafemulti1.checked2.c %S/arrinstructsafemulti2.checked2.c %S/arrinstructsafemulti1.checked2.convert_again.c %S/arrinstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/arrinstructsafemulti1.checked2.c %S/arrinstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructboth.checked.c -- | diff %S/arrofstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructboth.checked.c -- | count 0
 // RUN: rm %S/arrofstructboth.checked.c
 
 
@@ -109,7 +109,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrofstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructbothmulti1.checked.c %S/arrofstructbothmulti2.checked.c
-// RUN: diff %S/arrofstructbothmulti1.checked.convert_again.c %S/arrofstructbothmulti1.checked.c
-// RUN: diff %S/arrofstructbothmulti2.checked.convert_again.c %S/arrofstructbothmulti2.checked.c
+// RUN: test ! -f %S/arrofstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrofstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/arrofstructbothmulti1.checkedALL.c %S/arrofstructbothmulti2.checkedALL.c
 // RUN: rm %S/arrofstructbothmulti1.checkedNOALL.c %S/arrofstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/arrofstructbothmulti1.checked.c %S/arrofstructbothmulti2.checked.c %S/arrofstructbothmulti1.checked.convert_again.c %S/arrofstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/arrofstructbothmulti1.checked.c %S/arrofstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrofstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructbothmulti1.checked2.c %S/arrofstructbothmulti2.checked2.c
-// RUN: diff %S/arrofstructbothmulti1.checked2.convert_again.c %S/arrofstructbothmulti1.checked2.c
-// RUN: diff %S/arrofstructbothmulti2.checked2.convert_again.c %S/arrofstructbothmulti2.checked2.c
+// RUN: test ! -f %S/arrofstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrofstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/arrofstructbothmulti1.checkedALL2.c %S/arrofstructbothmulti2.checkedALL2.c
 // RUN: rm %S/arrofstructbothmulti1.checkedNOALL2.c %S/arrofstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/arrofstructbothmulti1.checked2.c %S/arrofstructbothmulti2.checked2.c %S/arrofstructbothmulti1.checked2.convert_again.c %S/arrofstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/arrofstructbothmulti1.checked2.c %S/arrofstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructcallee.checked.c -- | diff %S/arrofstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructcallee.checked.c -- | count 0
 // RUN: rm %S/arrofstructcallee.checked.c
 
 
@@ -109,7 +109,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrofstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructcalleemulti1.checked.c %S/arrofstructcalleemulti2.checked.c
-// RUN: diff %S/arrofstructcalleemulti1.checked.convert_again.c %S/arrofstructcalleemulti1.checked.c
-// RUN: diff %S/arrofstructcalleemulti2.checked.convert_again.c %S/arrofstructcalleemulti2.checked.c
+// RUN: test ! -f %S/arrofstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrofstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/arrofstructcalleemulti1.checkedALL.c %S/arrofstructcalleemulti2.checkedALL.c
 // RUN: rm %S/arrofstructcalleemulti1.checkedNOALL.c %S/arrofstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/arrofstructcalleemulti1.checked.c %S/arrofstructcalleemulti2.checked.c %S/arrofstructcalleemulti1.checked.convert_again.c %S/arrofstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/arrofstructcalleemulti1.checked.c %S/arrofstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrofstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructcalleemulti1.checked2.c %S/arrofstructcalleemulti2.checked2.c
-// RUN: diff %S/arrofstructcalleemulti1.checked2.convert_again.c %S/arrofstructcalleemulti1.checked2.c
-// RUN: diff %S/arrofstructcalleemulti2.checked2.convert_again.c %S/arrofstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/arrofstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrofstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/arrofstructcalleemulti1.checkedALL2.c %S/arrofstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/arrofstructcalleemulti1.checkedNOALL2.c %S/arrofstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/arrofstructcalleemulti1.checked2.c %S/arrofstructcalleemulti2.checked2.c %S/arrofstructcalleemulti1.checked2.convert_again.c %S/arrofstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/arrofstructcalleemulti1.checked2.c %S/arrofstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructcaller.checked.c -- | diff %S/arrofstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructcaller.checked.c -- | count 0
 // RUN: rm %S/arrofstructcaller.checked.c
 
 
@@ -143,7 +143,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrofstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructcallermulti1.checked.c %S/arrofstructcallermulti2.checked.c
-// RUN: diff %S/arrofstructcallermulti1.checked.convert_again.c %S/arrofstructcallermulti1.checked.c
-// RUN: diff %S/arrofstructcallermulti2.checked.convert_again.c %S/arrofstructcallermulti2.checked.c
+// RUN: test ! -f %S/arrofstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrofstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/arrofstructcallermulti1.checkedALL.c %S/arrofstructcallermulti2.checkedALL.c
 // RUN: rm %S/arrofstructcallermulti1.checkedNOALL.c %S/arrofstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/arrofstructcallermulti1.checked.c %S/arrofstructcallermulti2.checked.c %S/arrofstructcallermulti1.checked.convert_again.c %S/arrofstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/arrofstructcallermulti1.checked.c %S/arrofstructcallermulti2.checked.c
 
 
 /*********************************************************************************/
@@ -134,7 +134,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrofstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructcallermulti1.checked2.c %S/arrofstructcallermulti2.checked2.c
-// RUN: diff %S/arrofstructcallermulti1.checked2.convert_again.c %S/arrofstructcallermulti1.checked2.c
-// RUN: diff %S/arrofstructcallermulti2.checked2.convert_again.c %S/arrofstructcallermulti2.checked2.c
+// RUN: test ! -f %S/arrofstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrofstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/arrofstructcallermulti1.checkedALL2.c %S/arrofstructcallermulti2.checkedALL2.c
 // RUN: rm %S/arrofstructcallermulti1.checkedNOALL2.c %S/arrofstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/arrofstructcallermulti1.checked2.c %S/arrofstructcallermulti2.checked2.c %S/arrofstructcallermulti1.checked2.convert_again.c %S/arrofstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/arrofstructcallermulti1.checked2.c %S/arrofstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructprotoboth.checked.c -- | diff %S/arrofstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/arrofstructprotoboth.checked.c
 
 
@@ -163,7 +163,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructprotocallee.checked.c -- | diff %S/arrofstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/arrofstructprotocallee.checked.c
 
 
@@ -162,7 +162,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z = calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructprotocaller.checked.c -- | diff %S/arrofstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/arrofstructprotocaller.checked.c
 
 
@@ -129,7 +129,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructprotosafe.checked.c -- | diff %S/arrofstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/arrofstructprotosafe.checked.c
 
 
@@ -107,6 +107,7 @@ int *mul2(int *x) {
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general * x, _Ptr<struct general> y) : count(5);
+
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) : count(5) {
@@ -127,7 +128,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {
@@ -150,7 +151,7 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrofstructsafe.checked.c -- | diff %S/arrofstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrofstructsafe.checked.c -- | count 0
 // RUN: rm %S/arrofstructsafe.checked.c
 
 
@@ -142,7 +142,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {
@@ -165,5 +165,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrofstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructsafemulti1.checked.c %S/arrofstructsafemulti2.checked.c
-// RUN: diff %S/arrofstructsafemulti1.checked.convert_again.c %S/arrofstructsafemulti1.checked.c
-// RUN: diff %S/arrofstructsafemulti2.checked.convert_again.c %S/arrofstructsafemulti2.checked.c
+// RUN: test ! -f %S/arrofstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrofstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/arrofstructsafemulti1.checkedALL.c %S/arrofstructsafemulti2.checkedALL.c
 // RUN: rm %S/arrofstructsafemulti1.checkedNOALL.c %S/arrofstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/arrofstructsafemulti1.checked.c %S/arrofstructsafemulti2.checked.c %S/arrofstructsafemulti1.checked.convert_again.c %S/arrofstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/arrofstructsafemulti1.checked.c %S/arrofstructsafemulti2.checked.c
 
 
 /*********************************************************************************/
@@ -133,7 +133,7 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }
 
 struct general ** bar() {
@@ -156,5 +156,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrofstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrofstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrofstructsafemulti1.checked2.c %S/arrofstructsafemulti2.checked2.c
-// RUN: diff %S/arrofstructsafemulti1.checked2.convert_again.c %S/arrofstructsafemulti1.checked2.c
-// RUN: diff %S/arrofstructsafemulti2.checked2.convert_again.c %S/arrofstructsafemulti2.checked2.c
+// RUN: test ! -f %S/arrofstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrofstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/arrofstructsafemulti1.checkedALL2.c %S/arrofstructsafemulti2.checkedALL2.c
 // RUN: rm %S/arrofstructsafemulti1.checkedNOALL2.c %S/arrofstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/arrofstructsafemulti1.checked2.c %S/arrofstructsafemulti2.checked2.c %S/arrofstructsafemulti1.checked2.convert_again.c %S/arrofstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/arrofstructsafemulti1.checked2.c %S/arrofstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrprotoboth.checked.c -- | diff %S/arrprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrprotoboth.checked.c -- | count 0
 // RUN: rm %S/arrprotoboth.checked.c
 
 
@@ -140,7 +140,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrprotocallee.checked.c -- | diff %S/arrprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrprotocallee.checked.c -- | count 0
 // RUN: rm %S/arrprotocallee.checked.c
 
 
@@ -139,7 +139,7 @@ x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrprotocaller.checked.c -- | diff %S/arrprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrprotocaller.checked.c -- | count 0
 // RUN: rm %S/arrprotocaller.checked.c
 
 
@@ -117,7 +117,7 @@ int * foo() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrprotosafe.checked.c -- | diff %S/arrprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrprotosafe.checked.c -- | count 0
 // RUN: rm %S/arrprotosafe.checked.c
 
 
@@ -116,7 +116,7 @@ int * foo() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -128,7 +128,7 @@ int * bar() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * sus(int * x, int * y) {

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrsafe.checked.c -- | diff %S/arrsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrsafe.checked.c -- | count 0
 // RUN: rm %S/arrsafe.checked.c
 
 
@@ -127,7 +127,7 @@ int * foo() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -139,5 +139,5 @@ int * bar() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrsafemulti1.checked.c %S/arrsafemulti2.checked.c
-// RUN: diff %S/arrsafemulti1.checked.convert_again.c %S/arrsafemulti1.checked.c
-// RUN: diff %S/arrsafemulti2.checked.convert_again.c %S/arrsafemulti2.checked.c
+// RUN: test ! -f %S/arrsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrsafemulti2.checked.convert_again.c
 // RUN: rm %S/arrsafemulti1.checkedALL.c %S/arrsafemulti2.checkedALL.c
 // RUN: rm %S/arrsafemulti1.checkedNOALL.c %S/arrsafemulti2.checkedNOALL.c
-// RUN: rm %S/arrsafemulti1.checked.c %S/arrsafemulti2.checked.c %S/arrsafemulti1.checked.convert_again.c %S/arrsafemulti2.checked.convert_again.c
+// RUN: rm %S/arrsafemulti1.checked.c %S/arrsafemulti2.checked.c
 
 
 /*********************************************************************************/
@@ -121,7 +121,7 @@ int * foo() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -133,5 +133,5 @@ int * bar() {
 	//CHECK: _Ptr<int> y = malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrsafemulti1.checked2.c %S/arrsafemulti2.checked2.c
-// RUN: diff %S/arrsafemulti1.checked2.convert_again.c %S/arrsafemulti1.checked2.c
-// RUN: diff %S/arrsafemulti2.checked2.convert_again.c %S/arrsafemulti2.checked2.c
+// RUN: test ! -f %S/arrsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrsafemulti2.checked2.convert_again.c
 // RUN: rm %S/arrsafemulti1.checkedALL2.c %S/arrsafemulti2.checkedALL2.c
 // RUN: rm %S/arrsafemulti1.checkedNOALL2.c %S/arrsafemulti2.checkedNOALL2.c
-// RUN: rm %S/arrsafemulti1.checked2.c %S/arrsafemulti2.checked2.c %S/arrsafemulti1.checked2.convert_again.c %S/arrsafemulti2.checked2.convert_again.c
+// RUN: rm %S/arrsafemulti1.checked2.c %S/arrsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructboth.checked.c -- | diff %S/arrstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructboth.checked.c -- | count 0
 // RUN: rm %S/arrstructboth.checked.c
 
 
@@ -108,7 +108,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructbothmulti1.checked.c %S/arrstructbothmulti2.checked.c
-// RUN: diff %S/arrstructbothmulti1.checked.convert_again.c %S/arrstructbothmulti1.checked.c
-// RUN: diff %S/arrstructbothmulti2.checked.convert_again.c %S/arrstructbothmulti2.checked.c
+// RUN: test ! -f %S/arrstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/arrstructbothmulti1.checkedALL.c %S/arrstructbothmulti2.checkedALL.c
 // RUN: rm %S/arrstructbothmulti1.checkedNOALL.c %S/arrstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/arrstructbothmulti1.checked.c %S/arrstructbothmulti2.checked.c %S/arrstructbothmulti1.checked.convert_again.c %S/arrstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/arrstructbothmulti1.checked.c %S/arrstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructbothmulti1.checked2.c %S/arrstructbothmulti2.checked2.c
-// RUN: diff %S/arrstructbothmulti1.checked2.convert_again.c %S/arrstructbothmulti1.checked2.c
-// RUN: diff %S/arrstructbothmulti2.checked2.convert_again.c %S/arrstructbothmulti2.checked2.c
+// RUN: test ! -f %S/arrstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/arrstructbothmulti1.checkedALL2.c %S/arrstructbothmulti2.checkedALL2.c
 // RUN: rm %S/arrstructbothmulti1.checkedNOALL2.c %S/arrstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/arrstructbothmulti1.checked2.c %S/arrstructbothmulti2.checked2.c %S/arrstructbothmulti1.checked2.convert_again.c %S/arrstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/arrstructbothmulti1.checked2.c %S/arrstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -116,7 +116,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructcallee.checked.c -- | diff %S/arrstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructcallee.checked.c -- | count 0
 // RUN: rm %S/arrstructcallee.checked.c
 
 
@@ -108,7 +108,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructcalleemulti1.checked.c %S/arrstructcalleemulti2.checked.c
-// RUN: diff %S/arrstructcalleemulti1.checked.convert_again.c %S/arrstructcalleemulti1.checked.c
-// RUN: diff %S/arrstructcalleemulti2.checked.convert_again.c %S/arrstructcalleemulti2.checked.c
+// RUN: test ! -f %S/arrstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/arrstructcalleemulti1.checkedALL.c %S/arrstructcalleemulti2.checkedALL.c
 // RUN: rm %S/arrstructcalleemulti1.checkedNOALL.c %S/arrstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/arrstructcalleemulti1.checked.c %S/arrstructcalleemulti2.checked.c %S/arrstructcalleemulti1.checked.convert_again.c %S/arrstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/arrstructcalleemulti1.checked.c %S/arrstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructcalleemulti1.checked2.c %S/arrstructcalleemulti2.checked2.c
-// RUN: diff %S/arrstructcalleemulti1.checked2.convert_again.c %S/arrstructcalleemulti1.checked2.c
-// RUN: diff %S/arrstructcalleemulti2.checked2.convert_again.c %S/arrstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/arrstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/arrstructcalleemulti1.checkedALL2.c %S/arrstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/arrstructcalleemulti1.checkedNOALL2.c %S/arrstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/arrstructcalleemulti1.checked2.c %S/arrstructcalleemulti2.checked2.c %S/arrstructcalleemulti1.checked2.convert_again.c %S/arrstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/arrstructcalleemulti1.checked2.c %S/arrstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -116,7 +116,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructcaller.checked.c -- | diff %S/arrstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructcaller.checked.c -- | count 0
 // RUN: rm %S/arrstructcaller.checked.c
 
 
@@ -138,7 +138,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructcallermulti1.checked.c %S/arrstructcallermulti2.checked.c
-// RUN: diff %S/arrstructcallermulti1.checked.convert_again.c %S/arrstructcallermulti1.checked.c
-// RUN: diff %S/arrstructcallermulti2.checked.convert_again.c %S/arrstructcallermulti2.checked.c
+// RUN: test ! -f %S/arrstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/arrstructcallermulti1.checkedALL.c %S/arrstructcallermulti2.checkedALL.c
 // RUN: rm %S/arrstructcallermulti1.checkedNOALL.c %S/arrstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/arrstructcallermulti1.checked.c %S/arrstructcallermulti2.checked.c %S/arrstructcallermulti1.checked.convert_again.c %S/arrstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/arrstructcallermulti1.checked.c %S/arrstructcallermulti2.checked.c
 
 
 /*********************************************************************************/
@@ -131,7 +131,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructcallermulti1.checked2.c %S/arrstructcallermulti2.checked2.c
-// RUN: diff %S/arrstructcallermulti1.checked2.convert_again.c %S/arrstructcallermulti1.checked2.c
-// RUN: diff %S/arrstructcallermulti2.checked2.convert_again.c %S/arrstructcallermulti2.checked2.c
+// RUN: test ! -f %S/arrstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/arrstructcallermulti1.checkedALL2.c %S/arrstructcallermulti2.checkedALL2.c
 // RUN: rm %S/arrstructcallermulti1.checkedNOALL2.c %S/arrstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/arrstructcallermulti1.checked2.c %S/arrstructcallermulti2.checked2.c %S/arrstructcallermulti1.checked2.convert_again.c %S/arrstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/arrstructcallermulti1.checked2.c %S/arrstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructprotoboth.checked.c -- | diff %S/arrstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/arrstructprotoboth.checked.c
 
 
@@ -158,7 +158,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructprotocallee.checked.c -- | diff %S/arrstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/arrstructprotocallee.checked.c
 
 
@@ -157,7 +157,7 @@ x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructprotocaller.checked.c -- | diff %S/arrstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/arrstructprotocaller.checked.c
 
 
@@ -126,7 +126,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructprotosafe.checked.c -- | diff %S/arrstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/arrstructprotosafe.checked.c
 
 
@@ -125,7 +125,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -146,7 +146,7 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * sus(struct general * x, struct general * y) {

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/arrstructsafe.checked.c -- | diff %S/arrstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/arrstructsafe.checked.c -- | count 0
 // RUN: rm %S/arrstructsafe.checked.c
 
 
@@ -137,7 +137,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -158,5 +158,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/arrstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructsafemulti1.checked.c %S/arrstructsafemulti2.checked.c
-// RUN: diff %S/arrstructsafemulti1.checked.convert_again.c %S/arrstructsafemulti1.checked.c
-// RUN: diff %S/arrstructsafemulti2.checked.convert_again.c %S/arrstructsafemulti2.checked.c
+// RUN: test ! -f %S/arrstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/arrstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/arrstructsafemulti1.checkedALL.c %S/arrstructsafemulti2.checkedALL.c
 // RUN: rm %S/arrstructsafemulti1.checkedNOALL.c %S/arrstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/arrstructsafemulti1.checked.c %S/arrstructsafemulti2.checked.c %S/arrstructsafemulti1.checked.convert_again.c %S/arrstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/arrstructsafemulti1.checked.c %S/arrstructsafemulti2.checked.c
 
 
 /*********************************************************************************/
@@ -130,7 +130,7 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }
 
 int * bar() {
@@ -151,5 +151,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/arrstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/arrstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/arrstructsafemulti1.checked2.c %S/arrstructsafemulti2.checked2.c
-// RUN: diff %S/arrstructsafemulti1.checked2.convert_again.c %S/arrstructsafemulti1.checked2.c
-// RUN: diff %S/arrstructsafemulti2.checked2.convert_again.c %S/arrstructsafemulti2.checked2.c
+// RUN: test ! -f %S/arrstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/arrstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/arrstructsafemulti1.checkedALL2.c %S/arrstructsafemulti2.checkedALL2.c
 // RUN: rm %S/arrstructsafemulti1.checkedNOALL2.c %S/arrstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/arrstructsafemulti1.checked2.c %S/arrstructsafemulti2.checked2.c %S/arrstructsafemulti1.checked2.convert_again.c %S/arrstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/arrstructsafemulti1.checked2.c %S/arrstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/definedType.c
+++ b/clang/test/CheckedCRewriter/definedType.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/definedType.checked.c -- | diff %S/definedType.checked.c -
+// RUN: cconv-standalone -alltypes %S/definedType.checked.c -- | count 0
 // RUN: rm %S/definedType.checked.c
 
 #define size_t unsigned long

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrboth.checked.c -- | diff %S/fptrarrboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrboth.checked.c
 
 
@@ -110,7 +110,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrbothmulti1.checked.c %S/fptrarrbothmulti2.checked.c
-// RUN: diff %S/fptrarrbothmulti1.checked.convert_again.c %S/fptrarrbothmulti1.checked.c
-// RUN: diff %S/fptrarrbothmulti2.checked.convert_again.c %S/fptrarrbothmulti2.checked.c
+// RUN: test ! -f %S/fptrarrbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrbothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrbothmulti1.checkedALL.c %S/fptrarrbothmulti2.checkedALL.c
 // RUN: rm %S/fptrarrbothmulti1.checkedNOALL.c %S/fptrarrbothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrbothmulti1.checked.c %S/fptrarrbothmulti2.checked.c %S/fptrarrbothmulti1.checked.convert_again.c %S/fptrarrbothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrbothmulti1.checked.c %S/fptrarrbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrbothmulti1.checked2.c %S/fptrarrbothmulti2.checked2.c
-// RUN: diff %S/fptrarrbothmulti1.checked2.convert_again.c %S/fptrarrbothmulti1.checked2.c
-// RUN: diff %S/fptrarrbothmulti2.checked2.convert_again.c %S/fptrarrbothmulti2.checked2.c
+// RUN: test ! -f %S/fptrarrbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrbothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrbothmulti1.checkedALL2.c %S/fptrarrbothmulti2.checkedALL2.c
 // RUN: rm %S/fptrarrbothmulti1.checkedNOALL2.c %S/fptrarrbothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrbothmulti1.checked2.c %S/fptrarrbothmulti2.checked2.c %S/fptrarrbothmulti1.checked2.convert_again.c %S/fptrarrbothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrbothmulti1.checked2.c %S/fptrarrbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -118,7 +118,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrcallee.checked.c -- | diff %S/fptrarrcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrcallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrcallee.checked.c
 
 
@@ -110,7 +110,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrcalleemulti1.checked.c %S/fptrarrcalleemulti2.checked.c
-// RUN: diff %S/fptrarrcalleemulti1.checked.convert_again.c %S/fptrarrcalleemulti1.checked.c
-// RUN: diff %S/fptrarrcalleemulti2.checked.convert_again.c %S/fptrarrcalleemulti2.checked.c
+// RUN: test ! -f %S/fptrarrcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrcalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrcalleemulti1.checkedALL.c %S/fptrarrcalleemulti2.checkedALL.c
 // RUN: rm %S/fptrarrcalleemulti1.checkedNOALL.c %S/fptrarrcalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrcalleemulti1.checked.c %S/fptrarrcalleemulti2.checked.c %S/fptrarrcalleemulti1.checked.convert_again.c %S/fptrarrcalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrcalleemulti1.checked.c %S/fptrarrcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrcalleemulti1.checked2.c %S/fptrarrcalleemulti2.checked2.c
-// RUN: diff %S/fptrarrcalleemulti1.checked2.convert_again.c %S/fptrarrcalleemulti1.checked2.c
-// RUN: diff %S/fptrarrcalleemulti2.checked2.convert_again.c %S/fptrarrcalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrcalleemulti1.checkedALL2.c %S/fptrarrcalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrcalleemulti1.checkedNOALL2.c %S/fptrarrcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrcalleemulti1.checked2.c %S/fptrarrcalleemulti2.checked2.c %S/fptrarrcalleemulti1.checked2.convert_again.c %S/fptrarrcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrcalleemulti1.checked2.c %S/fptrarrcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -118,7 +118,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrcaller.checked.c -- | diff %S/fptrarrcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrcaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrcaller.checked.c
 
 
@@ -140,7 +140,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrcallermulti1.checked.c %S/fptrarrcallermulti2.checked.c
-// RUN: diff %S/fptrarrcallermulti1.checked.convert_again.c %S/fptrarrcallermulti1.checked.c
-// RUN: diff %S/fptrarrcallermulti2.checked.convert_again.c %S/fptrarrcallermulti2.checked.c
+// RUN: test ! -f %S/fptrarrcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrcallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrcallermulti1.checkedALL.c %S/fptrarrcallermulti2.checkedALL.c
 // RUN: rm %S/fptrarrcallermulti1.checkedNOALL.c %S/fptrarrcallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrcallermulti1.checked.c %S/fptrarrcallermulti2.checked.c %S/fptrarrcallermulti1.checked.convert_again.c %S/fptrarrcallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrcallermulti1.checked.c %S/fptrarrcallermulti2.checked.c
 
 
 /*********************************************************************************/
@@ -131,7 +131,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrcallermulti1.checked2.c %S/fptrarrcallermulti2.checked2.c
-// RUN: diff %S/fptrarrcallermulti1.checked2.convert_again.c %S/fptrarrcallermulti1.checked2.c
-// RUN: diff %S/fptrarrcallermulti2.checked2.convert_again.c %S/fptrarrcallermulti2.checked2.c
+// RUN: test ! -f %S/fptrarrcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrcallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrcallermulti1.checkedALL2.c %S/fptrarrcallermulti2.checkedALL2.c
 // RUN: rm %S/fptrarrcallermulti1.checkedNOALL2.c %S/fptrarrcallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrcallermulti1.checked2.c %S/fptrarrcallermulti2.checked2.c %S/fptrarrcallermulti1.checked2.convert_again.c %S/fptrarrcallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrcallermulti1.checked2.c %S/fptrarrcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructboth.checked.c -- | diff %S/fptrarrinstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrinstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructbothmulti1.checked.c %S/fptrarrinstructbothmulti2.checked.c
-// RUN: diff %S/fptrarrinstructbothmulti1.checked.convert_again.c %S/fptrarrinstructbothmulti1.checked.c
-// RUN: diff %S/fptrarrinstructbothmulti2.checked.convert_again.c %S/fptrarrinstructbothmulti2.checked.c
+// RUN: test ! -f %S/fptrarrinstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrinstructbothmulti1.checkedALL.c %S/fptrarrinstructbothmulti2.checkedALL.c
 // RUN: rm %S/fptrarrinstructbothmulti1.checkedNOALL.c %S/fptrarrinstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrinstructbothmulti1.checked.c %S/fptrarrinstructbothmulti2.checked.c %S/fptrarrinstructbothmulti1.checked.convert_again.c %S/fptrarrinstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrinstructbothmulti1.checked.c %S/fptrarrinstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrinstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructbothmulti1.checked2.c %S/fptrarrinstructbothmulti2.checked2.c
-// RUN: diff %S/fptrarrinstructbothmulti1.checked2.convert_again.c %S/fptrarrinstructbothmulti1.checked2.c
-// RUN: diff %S/fptrarrinstructbothmulti2.checked2.convert_again.c %S/fptrarrinstructbothmulti2.checked2.c
+// RUN: test ! -f %S/fptrarrinstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrinstructbothmulti1.checkedALL2.c %S/fptrarrinstructbothmulti2.checkedALL2.c
 // RUN: rm %S/fptrarrinstructbothmulti1.checkedNOALL2.c %S/fptrarrinstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrinstructbothmulti1.checked2.c %S/fptrarrinstructbothmulti2.checked2.c %S/fptrarrinstructbothmulti1.checked2.convert_again.c %S/fptrarrinstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrinstructbothmulti1.checked2.c %S/fptrarrinstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructcallee.checked.c -- | diff %S/fptrarrinstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructcallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructcallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrinstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructcalleemulti1.checked.c %S/fptrarrinstructcalleemulti2.checked.c
-// RUN: diff %S/fptrarrinstructcalleemulti1.checked.convert_again.c %S/fptrarrinstructcalleemulti1.checked.c
-// RUN: diff %S/fptrarrinstructcalleemulti2.checked.convert_again.c %S/fptrarrinstructcalleemulti2.checked.c
+// RUN: test ! -f %S/fptrarrinstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrinstructcalleemulti1.checkedALL.c %S/fptrarrinstructcalleemulti2.checkedALL.c
 // RUN: rm %S/fptrarrinstructcalleemulti1.checkedNOALL.c %S/fptrarrinstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrinstructcalleemulti1.checked.c %S/fptrarrinstructcalleemulti2.checked.c %S/fptrarrinstructcalleemulti1.checked.convert_again.c %S/fptrarrinstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrinstructcalleemulti1.checked.c %S/fptrarrinstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrinstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructcalleemulti1.checked2.c %S/fptrarrinstructcalleemulti2.checked2.c
-// RUN: diff %S/fptrarrinstructcalleemulti1.checked2.convert_again.c %S/fptrarrinstructcalleemulti1.checked2.c
-// RUN: diff %S/fptrarrinstructcalleemulti2.checked2.convert_again.c %S/fptrarrinstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrinstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrinstructcalleemulti1.checkedALL2.c %S/fptrarrinstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrinstructcalleemulti1.checkedNOALL2.c %S/fptrarrinstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrinstructcalleemulti1.checked2.c %S/fptrarrinstructcalleemulti2.checked2.c %S/fptrarrinstructcalleemulti1.checked2.convert_again.c %S/fptrarrinstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrinstructcalleemulti1.checked2.c %S/fptrarrinstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructcaller.checked.c -- | diff %S/fptrarrinstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructcaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructcaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrinstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructcallermulti1.checked.c %S/fptrarrinstructcallermulti2.checked.c
-// RUN: diff %S/fptrarrinstructcallermulti1.checked.convert_again.c %S/fptrarrinstructcallermulti1.checked.c
-// RUN: diff %S/fptrarrinstructcallermulti2.checked.convert_again.c %S/fptrarrinstructcallermulti2.checked.c
+// RUN: test ! -f %S/fptrarrinstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrinstructcallermulti1.checkedALL.c %S/fptrarrinstructcallermulti2.checkedALL.c
 // RUN: rm %S/fptrarrinstructcallermulti1.checkedNOALL.c %S/fptrarrinstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrinstructcallermulti1.checked.c %S/fptrarrinstructcallermulti2.checked.c %S/fptrarrinstructcallermulti1.checked.convert_again.c %S/fptrarrinstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrinstructcallermulti1.checked.c %S/fptrarrinstructcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrinstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructcallermulti1.checked2.c %S/fptrarrinstructcallermulti2.checked2.c
-// RUN: diff %S/fptrarrinstructcallermulti1.checked2.convert_again.c %S/fptrarrinstructcallermulti1.checked2.c
-// RUN: diff %S/fptrarrinstructcallermulti2.checked2.convert_again.c %S/fptrarrinstructcallermulti2.checked2.c
+// RUN: test ! -f %S/fptrarrinstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrinstructcallermulti1.checkedALL2.c %S/fptrarrinstructcallermulti2.checkedALL2.c
 // RUN: rm %S/fptrarrinstructcallermulti1.checkedNOALL2.c %S/fptrarrinstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrinstructcallermulti1.checked2.c %S/fptrarrinstructcallermulti2.checked2.c %S/fptrarrinstructcallermulti1.checked2.convert_again.c %S/fptrarrinstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrinstructcallermulti1.checked2.c %S/fptrarrinstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotoboth.checked.c -- | diff %S/fptrarrinstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructprotoboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotocallee.checked.c -- | diff %S/fptrarrinstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructprotocallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotocaller.checked.c -- | diff %S/fptrarrinstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotosafe.checked.c -- | diff %S/fptrarrinstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrinstructsafe.checked.c -- | diff %S/fptrarrinstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrinstructsafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrinstructsafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrinstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructsafemulti1.checked.c %S/fptrarrinstructsafemulti2.checked.c
-// RUN: diff %S/fptrarrinstructsafemulti1.checked.convert_again.c %S/fptrarrinstructsafemulti1.checked.c
-// RUN: diff %S/fptrarrinstructsafemulti2.checked.convert_again.c %S/fptrarrinstructsafemulti2.checked.c
+// RUN: test ! -f %S/fptrarrinstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrinstructsafemulti1.checkedALL.c %S/fptrarrinstructsafemulti2.checkedALL.c
 // RUN: rm %S/fptrarrinstructsafemulti1.checkedNOALL.c %S/fptrarrinstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrinstructsafemulti1.checked.c %S/fptrarrinstructsafemulti2.checked.c %S/fptrarrinstructsafemulti1.checked.convert_again.c %S/fptrarrinstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrinstructsafemulti1.checked.c %S/fptrarrinstructsafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrinstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrinstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrinstructsafemulti1.checked2.c %S/fptrarrinstructsafemulti2.checked2.c
-// RUN: diff %S/fptrarrinstructsafemulti1.checked2.convert_again.c %S/fptrarrinstructsafemulti1.checked2.c
-// RUN: diff %S/fptrarrinstructsafemulti2.checked2.convert_again.c %S/fptrarrinstructsafemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrinstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrinstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrinstructsafemulti1.checkedALL2.c %S/fptrarrinstructsafemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrinstructsafemulti1.checkedNOALL2.c %S/fptrarrinstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrinstructsafemulti1.checked2.c %S/fptrarrinstructsafemulti2.checked2.c %S/fptrarrinstructsafemulti1.checked2.convert_again.c %S/fptrarrinstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrinstructsafemulti1.checked2.c %S/fptrarrinstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrprotoboth.checked.c -- | diff %S/fptrarrprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrprotoboth.checked.c
 
 
@@ -160,7 +160,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrprotocallee.checked.c -- | diff %S/fptrarrprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrprotocallee.checked.c
 
 
@@ -159,7 +159,7 @@ int ** sus(int *x, int *y) {
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z = calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr = mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr = mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrprotocaller.checked.c -- | diff %S/fptrarrprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrprotocaller.checked.c
 
 
@@ -126,7 +126,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrprotosafe.checked.c -- | diff %S/fptrarrprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrprotosafe.checked.c
 
 
@@ -125,7 +125,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -146,7 +146,7 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrsafe.checked.c -- | diff %S/fptrarrsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrsafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrsafe.checked.c
 
 
@@ -139,7 +139,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -160,6 +160,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrsafemulti1.checked.c %S/fptrarrsafemulti2.checked.c
-// RUN: diff %S/fptrarrsafemulti1.checked.convert_again.c %S/fptrarrsafemulti1.checked.c
-// RUN: diff %S/fptrarrsafemulti2.checked.convert_again.c %S/fptrarrsafemulti2.checked.c
+// RUN: test ! -f %S/fptrarrsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrsafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrsafemulti1.checkedALL.c %S/fptrarrsafemulti2.checkedALL.c
 // RUN: rm %S/fptrarrsafemulti1.checkedNOALL.c %S/fptrarrsafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrsafemulti1.checked.c %S/fptrarrsafemulti2.checked.c %S/fptrarrsafemulti1.checked.convert_again.c %S/fptrarrsafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrsafemulti1.checked.c %S/fptrarrsafemulti2.checked.c
 
 
 /*********************************************************************************/
@@ -130,7 +130,7 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -151,6 +151,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) = sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrsafemulti1.checked2.c %S/fptrarrsafemulti2.checked2.c
-// RUN: diff %S/fptrarrsafemulti1.checked2.convert_again.c %S/fptrarrsafemulti1.checked2.c
-// RUN: diff %S/fptrarrsafemulti2.checked2.convert_again.c %S/fptrarrsafemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrsafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrsafemulti1.checkedALL2.c %S/fptrarrsafemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrsafemulti1.checkedNOALL2.c %S/fptrarrsafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrsafemulti1.checked2.c %S/fptrarrsafemulti2.checked2.c %S/fptrarrsafemulti1.checked2.convert_again.c %S/fptrarrsafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrsafemulti1.checked2.c %S/fptrarrsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructboth.checked.c -- | diff %S/fptrarrstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructbothmulti1.checked.c %S/fptrarrstructbothmulti2.checked.c
-// RUN: diff %S/fptrarrstructbothmulti1.checked.convert_again.c %S/fptrarrstructbothmulti1.checked.c
-// RUN: diff %S/fptrarrstructbothmulti2.checked.convert_again.c %S/fptrarrstructbothmulti2.checked.c
+// RUN: test ! -f %S/fptrarrstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrstructbothmulti1.checkedALL.c %S/fptrarrstructbothmulti2.checkedALL.c
 // RUN: rm %S/fptrarrstructbothmulti1.checkedNOALL.c %S/fptrarrstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrstructbothmulti1.checked.c %S/fptrarrstructbothmulti2.checked.c %S/fptrarrstructbothmulti1.checked.convert_again.c %S/fptrarrstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrstructbothmulti1.checked.c %S/fptrarrstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructbothmulti1.checked2.c %S/fptrarrstructbothmulti2.checked2.c
-// RUN: diff %S/fptrarrstructbothmulti1.checked2.convert_again.c %S/fptrarrstructbothmulti1.checked2.c
-// RUN: diff %S/fptrarrstructbothmulti2.checked2.convert_again.c %S/fptrarrstructbothmulti2.checked2.c
+// RUN: test ! -f %S/fptrarrstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrstructbothmulti1.checkedALL2.c %S/fptrarrstructbothmulti2.checkedALL2.c
 // RUN: rm %S/fptrarrstructbothmulti1.checkedNOALL2.c %S/fptrarrstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrstructbothmulti1.checked2.c %S/fptrarrstructbothmulti2.checked2.c %S/fptrarrstructbothmulti1.checked2.convert_again.c %S/fptrarrstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrstructbothmulti1.checked2.c %S/fptrarrstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructcallee.checked.c -- | diff %S/fptrarrstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructcallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructcallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructcalleemulti1.checked.c %S/fptrarrstructcalleemulti2.checked.c
-// RUN: diff %S/fptrarrstructcalleemulti1.checked.convert_again.c %S/fptrarrstructcalleemulti1.checked.c
-// RUN: diff %S/fptrarrstructcalleemulti2.checked.convert_again.c %S/fptrarrstructcalleemulti2.checked.c
+// RUN: test ! -f %S/fptrarrstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrstructcalleemulti1.checkedALL.c %S/fptrarrstructcalleemulti2.checkedALL.c
 // RUN: rm %S/fptrarrstructcalleemulti1.checkedNOALL.c %S/fptrarrstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrstructcalleemulti1.checked.c %S/fptrarrstructcalleemulti2.checked.c %S/fptrarrstructcalleemulti1.checked.convert_again.c %S/fptrarrstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrstructcalleemulti1.checked.c %S/fptrarrstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructcalleemulti1.checked2.c %S/fptrarrstructcalleemulti2.checked2.c
-// RUN: diff %S/fptrarrstructcalleemulti1.checked2.convert_again.c %S/fptrarrstructcalleemulti1.checked2.c
-// RUN: diff %S/fptrarrstructcalleemulti2.checked2.convert_again.c %S/fptrarrstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrstructcalleemulti1.checkedALL2.c %S/fptrarrstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrstructcalleemulti1.checkedNOALL2.c %S/fptrarrstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrstructcalleemulti1.checked2.c %S/fptrarrstructcalleemulti2.checked2.c %S/fptrarrstructcalleemulti1.checked2.convert_again.c %S/fptrarrstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrstructcalleemulti1.checked2.c %S/fptrarrstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructcaller.checked.c -- | diff %S/fptrarrstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructcaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructcaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructcallermulti1.checked.c %S/fptrarrstructcallermulti2.checked.c
-// RUN: diff %S/fptrarrstructcallermulti1.checked.convert_again.c %S/fptrarrstructcallermulti1.checked.c
-// RUN: diff %S/fptrarrstructcallermulti2.checked.convert_again.c %S/fptrarrstructcallermulti2.checked.c
+// RUN: test ! -f %S/fptrarrstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrstructcallermulti1.checkedALL.c %S/fptrarrstructcallermulti2.checkedALL.c
 // RUN: rm %S/fptrarrstructcallermulti1.checkedNOALL.c %S/fptrarrstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrstructcallermulti1.checked.c %S/fptrarrstructcallermulti2.checked.c %S/fptrarrstructcallermulti1.checked.convert_again.c %S/fptrarrstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrstructcallermulti1.checked.c %S/fptrarrstructcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructcallermulti1.checked2.c %S/fptrarrstructcallermulti2.checked2.c
-// RUN: diff %S/fptrarrstructcallermulti1.checked2.convert_again.c %S/fptrarrstructcallermulti1.checked2.c
-// RUN: diff %S/fptrarrstructcallermulti2.checked2.convert_again.c %S/fptrarrstructcallermulti2.checked2.c
+// RUN: test ! -f %S/fptrarrstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrstructcallermulti1.checkedALL2.c %S/fptrarrstructcallermulti2.checkedALL2.c
 // RUN: rm %S/fptrarrstructcallermulti1.checkedNOALL2.c %S/fptrarrstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrstructcallermulti1.checked2.c %S/fptrarrstructcallermulti2.checked2.c %S/fptrarrstructcallermulti1.checked2.convert_again.c %S/fptrarrstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrstructcallermulti1.checked2.c %S/fptrarrstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructprotoboth.checked.c -- | diff %S/fptrarrstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructprotoboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructprotocallee.checked.c -- | diff %S/fptrarrstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructprotocallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructprotocaller.checked.c -- | diff %S/fptrarrstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructprotosafe.checked.c -- | diff %S/fptrarrstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrarrstructsafe.checked.c -- | diff %S/fptrarrstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrarrstructsafe.checked.c -- | count 0
 // RUN: rm %S/fptrarrstructsafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrarrstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructsafemulti1.checked.c %S/fptrarrstructsafemulti2.checked.c
-// RUN: diff %S/fptrarrstructsafemulti1.checked.convert_again.c %S/fptrarrstructsafemulti1.checked.c
-// RUN: diff %S/fptrarrstructsafemulti2.checked.convert_again.c %S/fptrarrstructsafemulti2.checked.c
+// RUN: test ! -f %S/fptrarrstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrarrstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrarrstructsafemulti1.checkedALL.c %S/fptrarrstructsafemulti2.checkedALL.c
 // RUN: rm %S/fptrarrstructsafemulti1.checkedNOALL.c %S/fptrarrstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrarrstructsafemulti1.checked.c %S/fptrarrstructsafemulti2.checked.c %S/fptrarrstructsafemulti1.checked.convert_again.c %S/fptrarrstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrarrstructsafemulti1.checked.c %S/fptrarrstructsafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrarrstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrarrstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrarrstructsafemulti1.checked2.c %S/fptrarrstructsafemulti2.checked2.c
-// RUN: diff %S/fptrarrstructsafemulti1.checked2.convert_again.c %S/fptrarrstructsafemulti1.checked2.c
-// RUN: diff %S/fptrarrstructsafemulti2.checked2.convert_again.c %S/fptrarrstructsafemulti2.checked2.c
+// RUN: test ! -f %S/fptrarrstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrarrstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrarrstructsafemulti1.checkedALL2.c %S/fptrarrstructsafemulti2.checkedALL2.c
 // RUN: rm %S/fptrarrstructsafemulti1.checkedNOALL2.c %S/fptrarrstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrarrstructsafemulti1.checked2.c %S/fptrarrstructsafemulti2.checked2.c %S/fptrarrstructsafemulti1.checked2.convert_again.c %S/fptrarrstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrarrstructsafemulti1.checked2.c %S/fptrarrstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructboth.checked.c -- | diff %S/fptrinstructboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructboth.checked.c -- | count 0
 // RUN: rm %S/fptrinstructboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrinstructbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructbothmulti1.checked.c %S/fptrinstructbothmulti2.checked.c
-// RUN: diff %S/fptrinstructbothmulti1.checked.convert_again.c %S/fptrinstructbothmulti1.checked.c
-// RUN: diff %S/fptrinstructbothmulti2.checked.convert_again.c %S/fptrinstructbothmulti2.checked.c
+// RUN: test ! -f %S/fptrinstructbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrinstructbothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrinstructbothmulti1.checkedALL.c %S/fptrinstructbothmulti2.checkedALL.c
 // RUN: rm %S/fptrinstructbothmulti1.checkedNOALL.c %S/fptrinstructbothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrinstructbothmulti1.checked.c %S/fptrinstructbothmulti2.checked.c %S/fptrinstructbothmulti1.checked.convert_again.c %S/fptrinstructbothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrinstructbothmulti1.checked.c %S/fptrinstructbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrinstructbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructbothmulti1.checked2.c %S/fptrinstructbothmulti2.checked2.c
-// RUN: diff %S/fptrinstructbothmulti1.checked2.convert_again.c %S/fptrinstructbothmulti1.checked2.c
-// RUN: diff %S/fptrinstructbothmulti2.checked2.convert_again.c %S/fptrinstructbothmulti2.checked2.c
+// RUN: test ! -f %S/fptrinstructbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrinstructbothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrinstructbothmulti1.checkedALL2.c %S/fptrinstructbothmulti2.checkedALL2.c
 // RUN: rm %S/fptrinstructbothmulti1.checkedNOALL2.c %S/fptrinstructbothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrinstructbothmulti1.checked2.c %S/fptrinstructbothmulti2.checked2.c %S/fptrinstructbothmulti1.checked2.convert_again.c %S/fptrinstructbothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrinstructbothmulti1.checked2.c %S/fptrinstructbothmulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructcallee.checked.c -- | diff %S/fptrinstructcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructcallee.checked.c -- | count 0
 // RUN: rm %S/fptrinstructcallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrinstructcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructcalleemulti1.checked.c %S/fptrinstructcalleemulti2.checked.c
-// RUN: diff %S/fptrinstructcalleemulti1.checked.convert_again.c %S/fptrinstructcalleemulti1.checked.c
-// RUN: diff %S/fptrinstructcalleemulti2.checked.convert_again.c %S/fptrinstructcalleemulti2.checked.c
+// RUN: test ! -f %S/fptrinstructcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrinstructcalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrinstructcalleemulti1.checkedALL.c %S/fptrinstructcalleemulti2.checkedALL.c
 // RUN: rm %S/fptrinstructcalleemulti1.checkedNOALL.c %S/fptrinstructcalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrinstructcalleemulti1.checked.c %S/fptrinstructcalleemulti2.checked.c %S/fptrinstructcalleemulti1.checked.convert_again.c %S/fptrinstructcalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrinstructcalleemulti1.checked.c %S/fptrinstructcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrinstructcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructcalleemulti1.checked2.c %S/fptrinstructcalleemulti2.checked2.c
-// RUN: diff %S/fptrinstructcalleemulti1.checked2.convert_again.c %S/fptrinstructcalleemulti1.checked2.c
-// RUN: diff %S/fptrinstructcalleemulti2.checked2.convert_again.c %S/fptrinstructcalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrinstructcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrinstructcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrinstructcalleemulti1.checkedALL2.c %S/fptrinstructcalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrinstructcalleemulti1.checkedNOALL2.c %S/fptrinstructcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrinstructcalleemulti1.checked2.c %S/fptrinstructcalleemulti2.checked2.c %S/fptrinstructcalleemulti1.checked2.convert_again.c %S/fptrinstructcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrinstructcalleemulti1.checked2.c %S/fptrinstructcalleemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructcaller.checked.c -- | diff %S/fptrinstructcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructcaller.checked.c -- | count 0
 // RUN: rm %S/fptrinstructcaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrinstructcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructcallermulti1.checked.c %S/fptrinstructcallermulti2.checked.c
-// RUN: diff %S/fptrinstructcallermulti1.checked.convert_again.c %S/fptrinstructcallermulti1.checked.c
-// RUN: diff %S/fptrinstructcallermulti2.checked.convert_again.c %S/fptrinstructcallermulti2.checked.c
+// RUN: test ! -f %S/fptrinstructcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrinstructcallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrinstructcallermulti1.checkedALL.c %S/fptrinstructcallermulti2.checkedALL.c
 // RUN: rm %S/fptrinstructcallermulti1.checkedNOALL.c %S/fptrinstructcallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrinstructcallermulti1.checked.c %S/fptrinstructcallermulti2.checked.c %S/fptrinstructcallermulti1.checked.convert_again.c %S/fptrinstructcallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrinstructcallermulti1.checked.c %S/fptrinstructcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrinstructcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructcallermulti1.checked2.c %S/fptrinstructcallermulti2.checked2.c
-// RUN: diff %S/fptrinstructcallermulti1.checked2.convert_again.c %S/fptrinstructcallermulti1.checked2.c
-// RUN: diff %S/fptrinstructcallermulti2.checked2.convert_again.c %S/fptrinstructcallermulti2.checked2.c
+// RUN: test ! -f %S/fptrinstructcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrinstructcallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrinstructcallermulti1.checkedALL2.c %S/fptrinstructcallermulti2.checkedALL2.c
 // RUN: rm %S/fptrinstructcallermulti1.checkedNOALL2.c %S/fptrinstructcallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrinstructcallermulti1.checked2.c %S/fptrinstructcallermulti2.checked2.c %S/fptrinstructcallermulti1.checked2.convert_again.c %S/fptrinstructcallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrinstructcallermulti1.checked2.c %S/fptrinstructcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructprotoboth.checked.c -- | diff %S/fptrinstructprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrinstructprotoboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructprotocallee.checked.c -- | diff %S/fptrinstructprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrinstructprotocallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructprotocaller.checked.c -- | diff %S/fptrinstructprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrinstructprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructprotosafe.checked.c -- | diff %S/fptrinstructprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrinstructprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrinstructsafe.checked.c -- | diff %S/fptrinstructsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrinstructsafe.checked.c -- | count 0
 // RUN: rm %S/fptrinstructsafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrinstructsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructsafemulti1.checked.c %S/fptrinstructsafemulti2.checked.c
-// RUN: diff %S/fptrinstructsafemulti1.checked.convert_again.c %S/fptrinstructsafemulti1.checked.c
-// RUN: diff %S/fptrinstructsafemulti2.checked.convert_again.c %S/fptrinstructsafemulti2.checked.c
+// RUN: test ! -f %S/fptrinstructsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrinstructsafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrinstructsafemulti1.checkedALL.c %S/fptrinstructsafemulti2.checkedALL.c
 // RUN: rm %S/fptrinstructsafemulti1.checkedNOALL.c %S/fptrinstructsafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrinstructsafemulti1.checked.c %S/fptrinstructsafemulti2.checked.c %S/fptrinstructsafemulti1.checked.convert_again.c %S/fptrinstructsafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrinstructsafemulti1.checked.c %S/fptrinstructsafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrinstructsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrinstructsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrinstructsafemulti1.checked2.c %S/fptrinstructsafemulti2.checked2.c
-// RUN: diff %S/fptrinstructsafemulti1.checked2.convert_again.c %S/fptrinstructsafemulti1.checked2.c
-// RUN: diff %S/fptrinstructsafemulti2.checked2.convert_again.c %S/fptrinstructsafemulti2.checked2.c
+// RUN: test ! -f %S/fptrinstructsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrinstructsafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrinstructsafemulti1.checkedALL2.c %S/fptrinstructsafemulti2.checkedALL2.c
 // RUN: rm %S/fptrinstructsafemulti1.checkedNOALL2.c %S/fptrinstructsafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrinstructsafemulti1.checked2.c %S/fptrinstructsafemulti2.checked2.c %S/fptrinstructsafemulti1.checked2.convert_again.c %S/fptrinstructsafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrinstructsafemulti1.checked2.c %S/fptrinstructsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafeboth.checked.c -- | diff %S/fptrsafeboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafeboth.checked.c -- | count 0
 // RUN: rm %S/fptrsafeboth.checked.c
 
 
@@ -109,7 +109,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafebothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrsafebothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafebothmulti1.checked.c %S/fptrsafebothmulti2.checked.c
-// RUN: diff %S/fptrsafebothmulti1.checked.convert_again.c %S/fptrsafebothmulti1.checked.c
-// RUN: diff %S/fptrsafebothmulti2.checked.convert_again.c %S/fptrsafebothmulti2.checked.c
+// RUN: test ! -f %S/fptrsafebothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrsafebothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrsafebothmulti1.checkedALL.c %S/fptrsafebothmulti2.checkedALL.c
 // RUN: rm %S/fptrsafebothmulti1.checkedNOALL.c %S/fptrsafebothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrsafebothmulti1.checked.c %S/fptrsafebothmulti2.checked.c %S/fptrsafebothmulti1.checked.convert_again.c %S/fptrsafebothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrsafebothmulti1.checked.c %S/fptrsafebothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafebothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrsafebothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafebothmulti1.checked2.c %S/fptrsafebothmulti2.checked2.c
-// RUN: diff %S/fptrsafebothmulti1.checked2.convert_again.c %S/fptrsafebothmulti1.checked2.c
-// RUN: diff %S/fptrsafebothmulti2.checked2.convert_again.c %S/fptrsafebothmulti2.checked2.c
+// RUN: test ! -f %S/fptrsafebothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrsafebothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrsafebothmulti1.checkedALL2.c %S/fptrsafebothmulti2.checkedALL2.c
 // RUN: rm %S/fptrsafebothmulti1.checkedNOALL2.c %S/fptrsafebothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrsafebothmulti1.checked2.c %S/fptrsafebothmulti2.checked2.c %S/fptrsafebothmulti1.checked2.convert_again.c %S/fptrsafebothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrsafebothmulti1.checked2.c %S/fptrsafebothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafecallee.checked.c -- | diff %S/fptrsafecallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafecallee.checked.c -- | count 0
 // RUN: rm %S/fptrsafecallee.checked.c
 
 
@@ -109,7 +109,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafecalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrsafecalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafecalleemulti1.checked.c %S/fptrsafecalleemulti2.checked.c
-// RUN: diff %S/fptrsafecalleemulti1.checked.convert_again.c %S/fptrsafecalleemulti1.checked.c
-// RUN: diff %S/fptrsafecalleemulti2.checked.convert_again.c %S/fptrsafecalleemulti2.checked.c
+// RUN: test ! -f %S/fptrsafecalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrsafecalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrsafecalleemulti1.checkedALL.c %S/fptrsafecalleemulti2.checkedALL.c
 // RUN: rm %S/fptrsafecalleemulti1.checkedNOALL.c %S/fptrsafecalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrsafecalleemulti1.checked.c %S/fptrsafecalleemulti2.checked.c %S/fptrsafecalleemulti1.checked.convert_again.c %S/fptrsafecalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrsafecalleemulti1.checked.c %S/fptrsafecalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafecalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrsafecalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafecalleemulti1.checked2.c %S/fptrsafecalleemulti2.checked2.c
-// RUN: diff %S/fptrsafecalleemulti1.checked2.convert_again.c %S/fptrsafecalleemulti1.checked2.c
-// RUN: diff %S/fptrsafecalleemulti2.checked2.convert_again.c %S/fptrsafecalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrsafecalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrsafecalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrsafecalleemulti1.checkedALL2.c %S/fptrsafecalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrsafecalleemulti1.checkedNOALL2.c %S/fptrsafecalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrsafecalleemulti1.checked2.c %S/fptrsafecalleemulti2.checked2.c %S/fptrsafecalleemulti1.checked2.convert_again.c %S/fptrsafecalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrsafecalleemulti1.checked2.c %S/fptrsafecalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafecaller.checked.c -- | diff %S/fptrsafecaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafecaller.checked.c -- | count 0
 // RUN: rm %S/fptrsafecaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafecallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrsafecallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafecallermulti1.checked.c %S/fptrsafecallermulti2.checked.c
-// RUN: diff %S/fptrsafecallermulti1.checked.convert_again.c %S/fptrsafecallermulti1.checked.c
-// RUN: diff %S/fptrsafecallermulti2.checked.convert_again.c %S/fptrsafecallermulti2.checked.c
+// RUN: test ! -f %S/fptrsafecallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrsafecallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrsafecallermulti1.checkedALL.c %S/fptrsafecallermulti2.checkedALL.c
 // RUN: rm %S/fptrsafecallermulti1.checkedNOALL.c %S/fptrsafecallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrsafecallermulti1.checked.c %S/fptrsafecallermulti2.checked.c %S/fptrsafecallermulti1.checked.convert_again.c %S/fptrsafecallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrsafecallermulti1.checked.c %S/fptrsafecallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafecallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrsafecallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafecallermulti1.checked2.c %S/fptrsafecallermulti2.checked2.c
-// RUN: diff %S/fptrsafecallermulti1.checked2.convert_again.c %S/fptrsafecallermulti1.checked2.c
-// RUN: diff %S/fptrsafecallermulti2.checked2.convert_again.c %S/fptrsafecallermulti2.checked2.c
+// RUN: test ! -f %S/fptrsafecallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrsafecallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrsafecallermulti1.checkedALL2.c %S/fptrsafecallermulti2.checkedALL2.c
 // RUN: rm %S/fptrsafecallermulti1.checkedNOALL2.c %S/fptrsafecallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrsafecallermulti1.checked2.c %S/fptrsafecallermulti2.checked2.c %S/fptrsafecallermulti1.checked2.convert_again.c %S/fptrsafecallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrsafecallermulti1.checked2.c %S/fptrsafecallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafeprotoboth.checked.c -- | diff %S/fptrsafeprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafeprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrsafeprotoboth.checked.c
 
 
@@ -167,7 +167,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafeprotocallee.checked.c -- | diff %S/fptrsafeprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafeprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrsafeprotocallee.checked.c
 
 
@@ -166,7 +166,7 @@ int * sus(struct general *x, struct general *y) {
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p = y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafeprotocaller.checked.c -- | diff %S/fptrsafeprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafeprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrsafeprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafeprotosafe.checked.c -- | diff %S/fptrsafeprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafeprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrsafeprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrsafesafe.checked.c -- | diff %S/fptrsafesafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrsafesafe.checked.c -- | count 0
 // RUN: rm %S/fptrsafesafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafesafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrsafesafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafesafemulti1.checked.c %S/fptrsafesafemulti2.checked.c
-// RUN: diff %S/fptrsafesafemulti1.checked.convert_again.c %S/fptrsafesafemulti1.checked.c
-// RUN: diff %S/fptrsafesafemulti2.checked.convert_again.c %S/fptrsafesafemulti2.checked.c
+// RUN: test ! -f %S/fptrsafesafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrsafesafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrsafesafemulti1.checkedALL.c %S/fptrsafesafemulti2.checkedALL.c
 // RUN: rm %S/fptrsafesafemulti1.checkedNOALL.c %S/fptrsafesafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrsafesafemulti1.checked.c %S/fptrsafesafemulti2.checked.c %S/fptrsafesafemulti1.checked.convert_again.c %S/fptrsafesafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrsafesafemulti1.checked.c %S/fptrsafesafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrsafesafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrsafesafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrsafesafemulti1.checked2.c %S/fptrsafesafemulti2.checked2.c
-// RUN: diff %S/fptrsafesafemulti1.checked2.convert_again.c %S/fptrsafesafemulti1.checked2.c
-// RUN: diff %S/fptrsafesafemulti2.checked2.convert_again.c %S/fptrsafesafemulti2.checked2.c
+// RUN: test ! -f %S/fptrsafesafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrsafesafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrsafesafemulti1.checkedALL2.c %S/fptrsafesafemulti2.checkedALL2.c
 // RUN: rm %S/fptrsafesafemulti1.checkedNOALL2.c %S/fptrsafesafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrsafesafemulti1.checked2.c %S/fptrsafesafemulti2.checked2.c %S/fptrsafesafemulti1.checked2.convert_again.c %S/fptrsafesafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrsafesafemulti1.checked2.c %S/fptrsafesafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafeboth.checked.c -- | diff %S/fptrunsafeboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafeboth.checked.c -- | count 0
 // RUN: rm %S/fptrunsafeboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafebothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrunsafebothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafebothmulti1.checked.c %S/fptrunsafebothmulti2.checked.c
-// RUN: diff %S/fptrunsafebothmulti1.checked.convert_again.c %S/fptrunsafebothmulti1.checked.c
-// RUN: diff %S/fptrunsafebothmulti2.checked.convert_again.c %S/fptrunsafebothmulti2.checked.c
+// RUN: test ! -f %S/fptrunsafebothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrunsafebothmulti2.checked.convert_again.c
 // RUN: rm %S/fptrunsafebothmulti1.checkedALL.c %S/fptrunsafebothmulti2.checkedALL.c
 // RUN: rm %S/fptrunsafebothmulti1.checkedNOALL.c %S/fptrunsafebothmulti2.checkedNOALL.c
-// RUN: rm %S/fptrunsafebothmulti1.checked.c %S/fptrunsafebothmulti2.checked.c %S/fptrunsafebothmulti1.checked.convert_again.c %S/fptrunsafebothmulti2.checked.convert_again.c
+// RUN: rm %S/fptrunsafebothmulti1.checked.c %S/fptrunsafebothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafebothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrunsafebothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafebothmulti1.checked2.c %S/fptrunsafebothmulti2.checked2.c
-// RUN: diff %S/fptrunsafebothmulti1.checked2.convert_again.c %S/fptrunsafebothmulti1.checked2.c
-// RUN: diff %S/fptrunsafebothmulti2.checked2.convert_again.c %S/fptrunsafebothmulti2.checked2.c
+// RUN: test ! -f %S/fptrunsafebothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrunsafebothmulti2.checked2.convert_again.c
 // RUN: rm %S/fptrunsafebothmulti1.checkedALL2.c %S/fptrunsafebothmulti2.checkedALL2.c
 // RUN: rm %S/fptrunsafebothmulti1.checkedNOALL2.c %S/fptrunsafebothmulti2.checkedNOALL2.c
-// RUN: rm %S/fptrunsafebothmulti1.checked2.c %S/fptrunsafebothmulti2.checked2.c %S/fptrunsafebothmulti1.checked2.convert_again.c %S/fptrunsafebothmulti2.checked2.convert_again.c
+// RUN: rm %S/fptrunsafebothmulti1.checked2.c %S/fptrunsafebothmulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafecallee.checked.c -- | diff %S/fptrunsafecallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafecallee.checked.c -- | count 0
 // RUN: rm %S/fptrunsafecallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafecalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrunsafecalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafecalleemulti1.checked.c %S/fptrunsafecalleemulti2.checked.c
-// RUN: diff %S/fptrunsafecalleemulti1.checked.convert_again.c %S/fptrunsafecalleemulti1.checked.c
-// RUN: diff %S/fptrunsafecalleemulti2.checked.convert_again.c %S/fptrunsafecalleemulti2.checked.c
+// RUN: test ! -f %S/fptrunsafecalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrunsafecalleemulti2.checked.convert_again.c
 // RUN: rm %S/fptrunsafecalleemulti1.checkedALL.c %S/fptrunsafecalleemulti2.checkedALL.c
 // RUN: rm %S/fptrunsafecalleemulti1.checkedNOALL.c %S/fptrunsafecalleemulti2.checkedNOALL.c
-// RUN: rm %S/fptrunsafecalleemulti1.checked.c %S/fptrunsafecalleemulti2.checked.c %S/fptrunsafecalleemulti1.checked.convert_again.c %S/fptrunsafecalleemulti2.checked.convert_again.c
+// RUN: rm %S/fptrunsafecalleemulti1.checked.c %S/fptrunsafecalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafecalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrunsafecalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafecalleemulti1.checked2.c %S/fptrunsafecalleemulti2.checked2.c
-// RUN: diff %S/fptrunsafecalleemulti1.checked2.convert_again.c %S/fptrunsafecalleemulti1.checked2.c
-// RUN: diff %S/fptrunsafecalleemulti2.checked2.convert_again.c %S/fptrunsafecalleemulti2.checked2.c
+// RUN: test ! -f %S/fptrunsafecalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrunsafecalleemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrunsafecalleemulti1.checkedALL2.c %S/fptrunsafecalleemulti2.checkedALL2.c
 // RUN: rm %S/fptrunsafecalleemulti1.checkedNOALL2.c %S/fptrunsafecalleemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrunsafecalleemulti1.checked2.c %S/fptrunsafecalleemulti2.checked2.c %S/fptrunsafecalleemulti1.checked2.convert_again.c %S/fptrunsafecalleemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrunsafecalleemulti1.checked2.c %S/fptrunsafecalleemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafecaller.checked.c -- | diff %S/fptrunsafecaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafecaller.checked.c -- | count 0
 // RUN: rm %S/fptrunsafecaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafecallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrunsafecallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafecallermulti1.checked.c %S/fptrunsafecallermulti2.checked.c
-// RUN: diff %S/fptrunsafecallermulti1.checked.convert_again.c %S/fptrunsafecallermulti1.checked.c
-// RUN: diff %S/fptrunsafecallermulti2.checked.convert_again.c %S/fptrunsafecallermulti2.checked.c
+// RUN: test ! -f %S/fptrunsafecallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrunsafecallermulti2.checked.convert_again.c
 // RUN: rm %S/fptrunsafecallermulti1.checkedALL.c %S/fptrunsafecallermulti2.checkedALL.c
 // RUN: rm %S/fptrunsafecallermulti1.checkedNOALL.c %S/fptrunsafecallermulti2.checkedNOALL.c
-// RUN: rm %S/fptrunsafecallermulti1.checked.c %S/fptrunsafecallermulti2.checked.c %S/fptrunsafecallermulti1.checked.convert_again.c %S/fptrunsafecallermulti2.checked.convert_again.c
+// RUN: rm %S/fptrunsafecallermulti1.checked.c %S/fptrunsafecallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafecallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrunsafecallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafecallermulti1.checked2.c %S/fptrunsafecallermulti2.checked2.c
-// RUN: diff %S/fptrunsafecallermulti1.checked2.convert_again.c %S/fptrunsafecallermulti1.checked2.c
-// RUN: diff %S/fptrunsafecallermulti2.checked2.convert_again.c %S/fptrunsafecallermulti2.checked2.c
+// RUN: test ! -f %S/fptrunsafecallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrunsafecallermulti2.checked2.convert_again.c
 // RUN: rm %S/fptrunsafecallermulti1.checkedALL2.c %S/fptrunsafecallermulti2.checkedALL2.c
 // RUN: rm %S/fptrunsafecallermulti1.checkedNOALL2.c %S/fptrunsafecallermulti2.checkedNOALL2.c
-// RUN: rm %S/fptrunsafecallermulti1.checked2.c %S/fptrunsafecallermulti2.checked2.c %S/fptrunsafecallermulti1.checked2.convert_again.c %S/fptrunsafecallermulti2.checked2.convert_again.c
+// RUN: rm %S/fptrunsafecallermulti1.checked2.c %S/fptrunsafecallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafeprotoboth.checked.c -- | diff %S/fptrunsafeprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafeprotoboth.checked.c -- | count 0
 // RUN: rm %S/fptrunsafeprotoboth.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafeprotocallee.checked.c -- | diff %S/fptrunsafeprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafeprotocallee.checked.c -- | count 0
 // RUN: rm %S/fptrunsafeprotocallee.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafeprotocaller.checked.c -- | diff %S/fptrunsafeprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafeprotocaller.checked.c -- | count 0
 // RUN: rm %S/fptrunsafeprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafeprotosafe.checked.c -- | diff %S/fptrunsafeprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafeprotosafe.checked.c -- | count 0
 // RUN: rm %S/fptrunsafeprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/fptrunsafesafe.checked.c -- | diff %S/fptrunsafesafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/fptrunsafesafe.checked.c -- | count 0
 // RUN: rm %S/fptrunsafesafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafesafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/fptrunsafesafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafesafemulti1.checked.c %S/fptrunsafesafemulti2.checked.c
-// RUN: diff %S/fptrunsafesafemulti1.checked.convert_again.c %S/fptrunsafesafemulti1.checked.c
-// RUN: diff %S/fptrunsafesafemulti2.checked.convert_again.c %S/fptrunsafesafemulti2.checked.c
+// RUN: test ! -f %S/fptrunsafesafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/fptrunsafesafemulti2.checked.convert_again.c
 // RUN: rm %S/fptrunsafesafemulti1.checkedALL.c %S/fptrunsafesafemulti2.checkedALL.c
 // RUN: rm %S/fptrunsafesafemulti1.checkedNOALL.c %S/fptrunsafesafemulti2.checkedNOALL.c
-// RUN: rm %S/fptrunsafesafemulti1.checked.c %S/fptrunsafesafemulti2.checked.c %S/fptrunsafesafemulti1.checked.convert_again.c %S/fptrunsafesafemulti2.checked.convert_again.c
+// RUN: rm %S/fptrunsafesafemulti1.checked.c %S/fptrunsafesafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/fptrunsafesafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/fptrunsafesafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/fptrunsafesafemulti1.checked2.c %S/fptrunsafesafemulti2.checked2.c
-// RUN: diff %S/fptrunsafesafemulti1.checked2.convert_again.c %S/fptrunsafesafemulti1.checked2.c
-// RUN: diff %S/fptrunsafesafemulti2.checked2.convert_again.c %S/fptrunsafesafemulti2.checked2.c
+// RUN: test ! -f %S/fptrunsafesafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/fptrunsafesafemulti2.checked2.convert_again.c
 // RUN: rm %S/fptrunsafesafemulti1.checkedALL2.c %S/fptrunsafesafemulti2.checkedALL2.c
 // RUN: rm %S/fptrunsafesafemulti1.checkedNOALL2.c %S/fptrunsafesafemulti2.checkedNOALL2.c
-// RUN: rm %S/fptrunsafesafemulti1.checked2.c %S/fptrunsafesafemulti2.checked2.c %S/fptrunsafesafemulti1.checked2.convert_again.c %S/fptrunsafesafemulti2.checked2.convert_again.c
+// RUN: rm %S/fptrunsafesafemulti1.checked2.c %S/fptrunsafesafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/graphs.c
+++ b/clang/test/CheckedCRewriter/graphs.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -output-postfix=checked -alltypes %s
-// RUN: cconv-standalone -alltypes %S/graphs.checked.c -- | diff -w %S/graphs.checked.c -
+// RUN: cconv-standalone -alltypes %S/graphs.checked.c -- | count 0
 // RUN: rm %S/graphs.checked.c
 
 #include <stdio.h>

--- a/clang/test/CheckedCRewriter/multivardecls.c
+++ b/clang/test/CheckedCRewriter/multivardecls.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/multivardecls.checked.c -- | diff %S/multivardecls.checked.c -
+// RUN: cconv-standalone -alltypes %S/multivardecls.checked.c -- | count 0
 // RUN: rm %S/multivardecls.checked.c
 
 typedef unsigned long size_t;

--- a/clang/test/CheckedCRewriter/partial_checked.c
+++ b/clang/test/CheckedCRewriter/partial_checked.c
@@ -1,0 +1,67 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: cconv-standalone -alltypes -output-postfix=checked %s
+// RUN: cconv-standalone -alltypes %S/partial_checked.checked.c -- | count 0
+// RUN: rm %S/partial_checked.checked.c
+
+void test0(_Ptr<int *> a) { }
+// CHECK: void test0(_Ptr<_Ptr<int>> a) _Checked { }
+
+void test1(_Ptr<int **> a) { }
+// CHECK: void test1(_Ptr<_Ptr<_Ptr<int>>> a) _Checked { }
+
+void test2(_Ptr<int **> a) { 
+// CHECK: void test2(_Ptr<_Ptr<int *>> a) { 
+  **a = 1;
+}
+
+void test3(_Ptr<int *> a) {
+// CHECK: void test3(_Ptr<int *> a) {
+  *a = 1;
+}
+
+void test4() {
+  _Ptr<int *> a;
+  // CHECK: _Ptr<_Ptr<int>> a = ((void *)0);
+
+  _Ptr<int *> b = 0;
+  // CHECK: _Ptr<int *> b = 0;
+  *b = 1;
+
+  _Ptr<_Ptr<int *>> c;
+  // CHECK: _Ptr<_Ptr<_Ptr<int>>> c = ((void *)0);
+
+  int *d _Checked[4];
+  // CHECK: _Ptr<int> d _Checked[4] = {((void *)0)};
+
+  _Ptr<int *> e _Checked[4];
+  // CHECK: _Ptr<_Ptr<int>> e _Checked[4] = {((void *)0)};
+
+  _Ptr<int *> f _Checked[4] = {0};
+  // CHECK: _Ptr<int *> f _Checked[4] = {0};
+  (*f[0]) = 1;
+
+  _Ptr<int **> g, h, i _Checked[1];
+  // CHECK: _Ptr<_Ptr<_Ptr<int>>> g = ((void *)0);
+  // CHECK: _Ptr<_Ptr<int *>> h = ((void *)0);
+  // CHECK: _Ptr<_Ptr<_Ptr<int>>> i _Checked[1] = {((void *)0)};
+  **h = 1;
+}
+
+void test5(_Ptr<int *> a, _Ptr<int *> b, _Ptr<_Ptr<int>> c, int **d) {
+// CHECK: void test5(_Ptr<_Ptr<int>> a, _Ptr<int *> b, _Ptr<_Ptr<int>> c, _Ptr<_Ptr<int>> d) {
+  *b  = 1;
+}
+
+struct s0  {
+  _Ptr<int *> a,b;
+  _Ptr<_Ptr<int *>> c;
+  _Ptr<_Ptr<int>> d;
+  int * e _Checked[1];
+// CHECK:  _Ptr<_Ptr<int>> a;
+// CHECK:  _Ptr<_Ptr<int>> b;
+// CHECK:  _Ptr<_Ptr<_Ptr<int>>> c;
+// CHECK:  _Ptr<_Ptr<int>> d;
+// CHECK:  _Ptr<int> e _Checked[1];
+};

--- a/clang/test/CheckedCRewriter/partial_checked.c
+++ b/clang/test/CheckedCRewriter/partial_checked.c
@@ -79,3 +79,20 @@ struct s0  {
 // CHECK:  _Ptr<_Ptr<int>> d;
 // CHECK:  _Ptr<int> e _Checked[1];
 };
+
+extern void thing(_Ptr<int *> a);
+// CHECK: extern void thing(_Ptr<int *> a);
+
+void test6() {
+  _Ptr<int *> a = 0;
+  // CHECK: _Ptr<int *> a = 0;
+  thing(a);
+
+  int **b = 0;
+  // CHECK: _Ptr<int *> b = 0;
+  thing(b);
+
+  _Ptr<int **> c = 0;
+  // CHECK: _Ptr<_Ptr<int *>> c = 0;
+  thing(*c);
+}

--- a/clang/test/CheckedCRewriter/partial_checked.c
+++ b/clang/test/CheckedCRewriter/partial_checked.c
@@ -47,6 +47,20 @@ void test4() {
   // CHECK: _Ptr<_Ptr<int *>> h = ((void *)0);
   // CHECK: _Ptr<_Ptr<_Ptr<int>>> i _Checked[1] = {((void *)0)};
   **h = 1;
+
+
+  _Ptr<void (int*)> j = 0;
+  // CHECK: _Ptr<void (_Ptr<int> )> j = 0;
+
+  _Ptr<int *(void)> k = 0;
+  // CHECK: _Ptr<_Ptr<int> (void)> k = 0;
+
+  _Ptr<int> (*l)(void) = 0;
+  // CHECK: _Ptr<_Ptr<int> (void)> l = 0;
+
+  _Ptr<int *(void)> m = 0, n = 0;
+  // CHECK:_Ptr<_Ptr<int> (void)> m = 0;
+  // CHECK:_Ptr<_Ptr<int> (void)> n = 0;
 }
 
 void test5(_Ptr<int *> a, _Ptr<int *> b, _Ptr<_Ptr<int>> c, int **d) {

--- a/clang/test/CheckedCRewriter/partial_checked_arr.c
+++ b/clang/test/CheckedCRewriter/partial_checked_arr.c
@@ -1,0 +1,51 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -alltypes -output-postfix=checked %s
+// RUN: cconv-standalone -alltypes %S/partial_checked_arr.checked.c -- | count 0
+// RUN: rm %S/partial_checked_arr.checked.c
+
+int strcmp(const char *src1 : itype(_Nt_array_ptr<const char>),
+           const char *src2 : itype(_Nt_array_ptr<const char>));
+
+void test0() {
+  _Ptr<int *> a = 0;
+  // CHECK_ALL: _Ptr<_Array_ptr<int>> a = 0;
+  // CHECK_NOALL: _Ptr<int *> a = 0;
+  (*a)[0] = 1;
+  (*a)[1] = 1;
+
+  _Array_ptr<int *> b = 0;
+  // CHECK: _Array_ptr<_Ptr<int>> b = 0;
+
+  _Array_ptr<int *> c = 0;
+  // CHECK_ALL: _Array_ptr<_Ptr<int>> c : count(10) = 0;
+  // CHECK_NOALL: _Array_ptr<_Ptr<int>> c = 0;
+  for (int i = 0; i < 10; i++) {
+    c[i] = 0;
+  }
+
+  _Ptr<_Array_ptr<char **>> d = 0;
+  // CHECK_ALL: _Ptr<_Array_ptr<_Array_ptr<_Ptr<char>>>> d = 0;
+  // CHECK_NOALL: _Ptr<_Array_ptr<char **>> d = 0;
+  (**d)[0] = 0;
+
+  _Nt_array_ptr<char **> e;
+  // CHECK: _Nt_array_ptr<_Ptr<_Ptr<char>>> e = ((void *)0);
+  
+  
+  _Ptr<char *> f;
+  _Ptr<char *> g;
+  // CHECK_ALL: _Ptr<_Nt_array_ptr<char>> f = ((void *)0);
+  // CHECK_ALL: _Ptr<_Nt_array_ptr<char>> g = ((void *)0);
+  // CHECK_NOALL: _Ptr<char *> f;
+  // CHECK_NOALL: _Ptr<char *> g;
+
+  strcmp(*f, *g);
+}
+
+_Ptr<char *> test1(_Ptr<char *> d) {
+// CHECK_ALL: _Ptr<_Array_ptr<char>> test1(_Ptr<_Array_ptr<char>> d) _Checked {
+// CHECK_NOALL: _Ptr<char *> test1(_Ptr<char *> d) {
+  (*d)[0] = 0;
+  return d;
+}

--- a/clang/test/CheckedCRewriter/ptrTOptrboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrboth.checked.c -- | diff %S/ptrTOptrboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrboth.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrboth.checked.c
 
 
@@ -110,7 +110,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/ptrTOptrbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrbothmulti1.checked.c %S/ptrTOptrbothmulti2.checked.c
-// RUN: diff %S/ptrTOptrbothmulti1.checked.convert_again.c %S/ptrTOptrbothmulti1.checked.c
-// RUN: diff %S/ptrTOptrbothmulti2.checked.convert_again.c %S/ptrTOptrbothmulti2.checked.c
+// RUN: test ! -f %S/ptrTOptrbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/ptrTOptrbothmulti2.checked.convert_again.c
 // RUN: rm %S/ptrTOptrbothmulti1.checkedALL.c %S/ptrTOptrbothmulti2.checkedALL.c
 // RUN: rm %S/ptrTOptrbothmulti1.checkedNOALL.c %S/ptrTOptrbothmulti2.checkedNOALL.c
-// RUN: rm %S/ptrTOptrbothmulti1.checked.c %S/ptrTOptrbothmulti2.checked.c %S/ptrTOptrbothmulti1.checked.convert_again.c %S/ptrTOptrbothmulti2.checked.convert_again.c
+// RUN: rm %S/ptrTOptrbothmulti1.checked.c %S/ptrTOptrbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/ptrTOptrbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrbothmulti1.checked2.c %S/ptrTOptrbothmulti2.checked2.c
-// RUN: diff %S/ptrTOptrbothmulti1.checked2.convert_again.c %S/ptrTOptrbothmulti1.checked2.c
-// RUN: diff %S/ptrTOptrbothmulti2.checked2.convert_again.c %S/ptrTOptrbothmulti2.checked2.c
+// RUN: test ! -f %S/ptrTOptrbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/ptrTOptrbothmulti2.checked2.convert_again.c
 // RUN: rm %S/ptrTOptrbothmulti1.checkedALL2.c %S/ptrTOptrbothmulti2.checkedALL2.c
 // RUN: rm %S/ptrTOptrbothmulti1.checkedNOALL2.c %S/ptrTOptrbothmulti2.checkedNOALL2.c
-// RUN: rm %S/ptrTOptrbothmulti1.checked2.c %S/ptrTOptrbothmulti2.checked2.c %S/ptrTOptrbothmulti1.checked2.convert_again.c %S/ptrTOptrbothmulti2.checked2.convert_again.c
+// RUN: rm %S/ptrTOptrbothmulti1.checked2.c %S/ptrTOptrbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -118,7 +118,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrcallee.checked.c -- | diff %S/ptrTOptrcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrcallee.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrcallee.checked.c
 
 
@@ -110,7 +110,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/ptrTOptrcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrcalleemulti1.checked.c %S/ptrTOptrcalleemulti2.checked.c
-// RUN: diff %S/ptrTOptrcalleemulti1.checked.convert_again.c %S/ptrTOptrcalleemulti1.checked.c
-// RUN: diff %S/ptrTOptrcalleemulti2.checked.convert_again.c %S/ptrTOptrcalleemulti2.checked.c
+// RUN: test ! -f %S/ptrTOptrcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/ptrTOptrcalleemulti2.checked.convert_again.c
 // RUN: rm %S/ptrTOptrcalleemulti1.checkedALL.c %S/ptrTOptrcalleemulti2.checkedALL.c
 // RUN: rm %S/ptrTOptrcalleemulti1.checkedNOALL.c %S/ptrTOptrcalleemulti2.checkedNOALL.c
-// RUN: rm %S/ptrTOptrcalleemulti1.checked.c %S/ptrTOptrcalleemulti2.checked.c %S/ptrTOptrcalleemulti1.checked.convert_again.c %S/ptrTOptrcalleemulti2.checked.convert_again.c
+// RUN: rm %S/ptrTOptrcalleemulti1.checked.c %S/ptrTOptrcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/ptrTOptrcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrcalleemulti1.checked2.c %S/ptrTOptrcalleemulti2.checked2.c
-// RUN: diff %S/ptrTOptrcalleemulti1.checked2.convert_again.c %S/ptrTOptrcalleemulti1.checked2.c
-// RUN: diff %S/ptrTOptrcalleemulti2.checked2.convert_again.c %S/ptrTOptrcalleemulti2.checked2.c
+// RUN: test ! -f %S/ptrTOptrcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/ptrTOptrcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/ptrTOptrcalleemulti1.checkedALL2.c %S/ptrTOptrcalleemulti2.checkedALL2.c
 // RUN: rm %S/ptrTOptrcalleemulti1.checkedNOALL2.c %S/ptrTOptrcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/ptrTOptrcalleemulti1.checked2.c %S/ptrTOptrcalleemulti2.checked2.c %S/ptrTOptrcalleemulti1.checked2.convert_again.c %S/ptrTOptrcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/ptrTOptrcalleemulti1.checked2.c %S/ptrTOptrcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -118,7 +118,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrcaller.checked.c -- | diff %S/ptrTOptrcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrcaller.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrcaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/ptrTOptrcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrcallermulti1.checked.c %S/ptrTOptrcallermulti2.checked.c
-// RUN: diff %S/ptrTOptrcallermulti1.checked.convert_again.c %S/ptrTOptrcallermulti1.checked.c
-// RUN: diff %S/ptrTOptrcallermulti2.checked.convert_again.c %S/ptrTOptrcallermulti2.checked.c
+// RUN: test ! -f %S/ptrTOptrcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/ptrTOptrcallermulti2.checked.convert_again.c
 // RUN: rm %S/ptrTOptrcallermulti1.checkedALL.c %S/ptrTOptrcallermulti2.checkedALL.c
 // RUN: rm %S/ptrTOptrcallermulti1.checkedNOALL.c %S/ptrTOptrcallermulti2.checkedNOALL.c
-// RUN: rm %S/ptrTOptrcallermulti1.checked.c %S/ptrTOptrcallermulti2.checked.c %S/ptrTOptrcallermulti1.checked.convert_again.c %S/ptrTOptrcallermulti2.checked.convert_again.c
+// RUN: rm %S/ptrTOptrcallermulti1.checked.c %S/ptrTOptrcallermulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/ptrTOptrcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrcallermulti1.checked2.c %S/ptrTOptrcallermulti2.checked2.c
-// RUN: diff %S/ptrTOptrcallermulti1.checked2.convert_again.c %S/ptrTOptrcallermulti1.checked2.c
-// RUN: diff %S/ptrTOptrcallermulti2.checked2.convert_again.c %S/ptrTOptrcallermulti2.checked2.c
+// RUN: test ! -f %S/ptrTOptrcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/ptrTOptrcallermulti2.checked2.convert_again.c
 // RUN: rm %S/ptrTOptrcallermulti1.checkedALL2.c %S/ptrTOptrcallermulti2.checkedALL2.c
 // RUN: rm %S/ptrTOptrcallermulti1.checkedNOALL2.c %S/ptrTOptrcallermulti2.checkedNOALL2.c
-// RUN: rm %S/ptrTOptrcallermulti1.checked2.c %S/ptrTOptrcallermulti2.checked2.c %S/ptrTOptrcallermulti1.checked2.convert_again.c %S/ptrTOptrcallermulti2.checked2.convert_again.c
+// RUN: rm %S/ptrTOptrcallermulti1.checked2.c %S/ptrTOptrcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrprotoboth.checked.c -- | diff %S/ptrTOptrprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrprotoboth.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrprotoboth.checked.c
 
 
@@ -142,7 +142,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrprotocallee.checked.c -- | diff %S/ptrTOptrprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrprotocallee.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrprotocallee.checked.c
 
 
@@ -141,7 +141,7 @@ x = (char * * *) 5;
         *ch = 'A'; /*Capital A*/
         char *** z = malloc(5*sizeof(char**)); 
 	//CHECK_NOALL: char *** z = malloc<char **>(5*sizeof(char**)); 
-	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z =  malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<char *>> z = malloc<_Array_ptr<char *>>(5*sizeof(char**)); 
         for(int i = 0; i < 5; i++) { 
             z[i] = malloc(5*sizeof(char *)); 
 	//CHECK: z[i] = malloc<char *>(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrprotocaller.checked.c -- | diff %S/ptrTOptrprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrprotocaller.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrprotocaller.checked.c
 
 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrprotosafe.checked.c -- | diff %S/ptrTOptrprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrprotosafe.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrprotosafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrTOptrsafe.checked.c -- | diff %S/ptrTOptrsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrTOptrsafe.checked.c -- | count 0
 // RUN: rm %S/ptrTOptrsafe.checked.c
 
 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/ptrTOptrsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrsafemulti1.checked.c %S/ptrTOptrsafemulti2.checked.c
-// RUN: diff %S/ptrTOptrsafemulti1.checked.convert_again.c %S/ptrTOptrsafemulti1.checked.c
-// RUN: diff %S/ptrTOptrsafemulti2.checked.convert_again.c %S/ptrTOptrsafemulti2.checked.c
+// RUN: test ! -f %S/ptrTOptrsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/ptrTOptrsafemulti2.checked.convert_again.c
 // RUN: rm %S/ptrTOptrsafemulti1.checkedALL.c %S/ptrTOptrsafemulti2.checkedALL.c
 // RUN: rm %S/ptrTOptrsafemulti1.checkedNOALL.c %S/ptrTOptrsafemulti2.checkedNOALL.c
-// RUN: rm %S/ptrTOptrsafemulti1.checked.c %S/ptrTOptrsafemulti2.checked.c %S/ptrTOptrsafemulti1.checked.convert_again.c %S/ptrTOptrsafemulti2.checked.convert_again.c
+// RUN: rm %S/ptrTOptrsafemulti1.checked.c %S/ptrTOptrsafemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/ptrTOptrsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/ptrTOptrsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/ptrTOptrsafemulti1.checked2.c %S/ptrTOptrsafemulti2.checked2.c
-// RUN: diff %S/ptrTOptrsafemulti1.checked2.convert_again.c %S/ptrTOptrsafemulti1.checked2.c
-// RUN: diff %S/ptrTOptrsafemulti2.checked2.convert_again.c %S/ptrTOptrsafemulti2.checked2.c
+// RUN: test ! -f %S/ptrTOptrsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/ptrTOptrsafemulti2.checked2.convert_again.c
 // RUN: rm %S/ptrTOptrsafemulti1.checkedALL2.c %S/ptrTOptrsafemulti2.checkedALL2.c
 // RUN: rm %S/ptrTOptrsafemulti1.checkedNOALL2.c %S/ptrTOptrsafemulti2.checkedNOALL2.c
-// RUN: rm %S/ptrTOptrsafemulti1.checked2.c %S/ptrTOptrsafemulti2.checked2.c %S/ptrTOptrsafemulti1.checked2.convert_again.c %S/ptrTOptrsafemulti2.checked2.convert_again.c
+// RUN: rm %S/ptrTOptrsafemulti1.checked2.c %S/ptrTOptrsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/ptr_array.c
+++ b/clang/test/CheckedCRewriter/ptr_array.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -output-postfix=checked -alltypes %s
-// RUN: cconv-standalone -alltypes %S/ptr_array.checked.c -- | diff -w %S/ptr_array.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptr_array.checked.c -- | count 0
 // RUN: rm %S/ptr_array.checked.c
 
 /* Tests for issue 60. Array initialization had not been implemented, so wild

--- a/clang/test/CheckedCRewriter/ptrptr.c
+++ b/clang/test/CheckedCRewriter/ptrptr.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -output-postfix=checked -alltypes %s
-// RUN: cconv-standalone -alltypes %S/ptrptr.checked.c -- | diff -w %S/ptrptr.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrptr.checked.c -- | count 0
 // RUN: rm %S/ptrptr.checked.c
 
 #include <stddef.h>

--- a/clang/test/CheckedCRewriter/ptrtoconstarr.c
+++ b/clang/test/CheckedCRewriter/ptrtoconstarr.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone --addcr --alltypes %s -- | %clang_cc1  -fcheckedc-extension -x c -
 //
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/ptrtoconstarr.checked.c -- | diff %S/ptrtoconstarr.checked.c -
+// RUN: cconv-standalone -alltypes %S/ptrtoconstarr.checked.c -- | count 0
 // RUN: rm %S/ptrtoconstarr.checked.c
 
 extern _Unchecked unsigned long strlen(const char * restrict src : itype(restrict _Nt_array_ptr<const char>));

--- a/clang/test/CheckedCRewriter/safefptrargboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargboth.checked.c -- | diff %S/safefptrargboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargboth.checked.c -- | count 0
 // RUN: rm %S/safefptrargboth.checked.c
 
 
@@ -109,7 +109,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargbothmulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/safefptrargbothmulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargbothmulti1.checked.c %S/safefptrargbothmulti2.checked.c
-// RUN: diff %S/safefptrargbothmulti1.checked.convert_again.c %S/safefptrargbothmulti1.checked.c
-// RUN: diff %S/safefptrargbothmulti2.checked.convert_again.c %S/safefptrargbothmulti2.checked.c
+// RUN: test ! -f %S/safefptrargbothmulti1.checked.convert_again.c
+// RUN: test ! -f %S/safefptrargbothmulti2.checked.convert_again.c
 // RUN: rm %S/safefptrargbothmulti1.checkedALL.c %S/safefptrargbothmulti2.checkedALL.c
 // RUN: rm %S/safefptrargbothmulti1.checkedNOALL.c %S/safefptrargbothmulti2.checkedNOALL.c
-// RUN: rm %S/safefptrargbothmulti1.checked.c %S/safefptrargbothmulti2.checked.c %S/safefptrargbothmulti1.checked.convert_again.c %S/safefptrargbothmulti2.checked.convert_again.c
+// RUN: rm %S/safefptrargbothmulti1.checked.c %S/safefptrargbothmulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargbothmulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/safefptrargbothmulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargbothmulti1.checked2.c %S/safefptrargbothmulti2.checked2.c
-// RUN: diff %S/safefptrargbothmulti1.checked2.convert_again.c %S/safefptrargbothmulti1.checked2.c
-// RUN: diff %S/safefptrargbothmulti2.checked2.convert_again.c %S/safefptrargbothmulti2.checked2.c
+// RUN: test ! -f %S/safefptrargbothmulti1.checked2.convert_again.c
+// RUN: test ! -f %S/safefptrargbothmulti2.checked2.convert_again.c
 // RUN: rm %S/safefptrargbothmulti1.checkedALL2.c %S/safefptrargbothmulti2.checkedALL2.c
 // RUN: rm %S/safefptrargbothmulti1.checkedNOALL2.c %S/safefptrargbothmulti2.checkedNOALL2.c
-// RUN: rm %S/safefptrargbothmulti1.checked2.c %S/safefptrargbothmulti2.checked2.c %S/safefptrargbothmulti1.checked2.convert_again.c %S/safefptrargbothmulti2.checked2.convert_again.c
+// RUN: rm %S/safefptrargbothmulti1.checked2.c %S/safefptrargbothmulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargcallee.checked.c -- | diff %S/safefptrargcallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargcallee.checked.c -- | count 0
 // RUN: rm %S/safefptrargcallee.checked.c
 
 
@@ -109,7 +109,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargcalleemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/safefptrargcalleemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargcalleemulti1.checked.c %S/safefptrargcalleemulti2.checked.c
-// RUN: diff %S/safefptrargcalleemulti1.checked.convert_again.c %S/safefptrargcalleemulti1.checked.c
-// RUN: diff %S/safefptrargcalleemulti2.checked.convert_again.c %S/safefptrargcalleemulti2.checked.c
+// RUN: test ! -f %S/safefptrargcalleemulti1.checked.convert_again.c
+// RUN: test ! -f %S/safefptrargcalleemulti2.checked.convert_again.c
 // RUN: rm %S/safefptrargcalleemulti1.checkedALL.c %S/safefptrargcalleemulti2.checkedALL.c
 // RUN: rm %S/safefptrargcalleemulti1.checkedNOALL.c %S/safefptrargcalleemulti2.checkedNOALL.c
-// RUN: rm %S/safefptrargcalleemulti1.checked.c %S/safefptrargcalleemulti2.checked.c %S/safefptrargcalleemulti1.checked.convert_again.c %S/safefptrargcalleemulti2.checked.convert_again.c
+// RUN: rm %S/safefptrargcalleemulti1.checked.c %S/safefptrargcalleemulti2.checked.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargcalleemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/safefptrargcalleemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargcalleemulti1.checked2.c %S/safefptrargcalleemulti2.checked2.c
-// RUN: diff %S/safefptrargcalleemulti1.checked2.convert_again.c %S/safefptrargcalleemulti1.checked2.c
-// RUN: diff %S/safefptrargcalleemulti2.checked2.convert_again.c %S/safefptrargcalleemulti2.checked2.c
+// RUN: test ! -f %S/safefptrargcalleemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/safefptrargcalleemulti2.checked2.convert_again.c
 // RUN: rm %S/safefptrargcalleemulti1.checkedALL2.c %S/safefptrargcalleemulti2.checkedALL2.c
 // RUN: rm %S/safefptrargcalleemulti1.checkedNOALL2.c %S/safefptrargcalleemulti2.checkedNOALL2.c
-// RUN: rm %S/safefptrargcalleemulti1.checked2.c %S/safefptrargcalleemulti2.checked2.c %S/safefptrargcalleemulti1.checked2.convert_again.c %S/safefptrargcalleemulti2.checked2.convert_again.c
+// RUN: rm %S/safefptrargcalleemulti1.checked2.c %S/safefptrargcalleemulti2.checked2.c
 
 
 /*********************************************************************************/
@@ -117,7 +117,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargcaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargcaller.checked.c -- | diff %S/safefptrargcaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargcaller.checked.c -- | count 0
 // RUN: rm %S/safefptrargcaller.checked.c
 
 
@@ -129,7 +129,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargcallermulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/safefptrargcallermulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargcallermulti1.checked.c %S/safefptrargcallermulti2.checked.c
-// RUN: diff %S/safefptrargcallermulti1.checked.convert_again.c %S/safefptrargcallermulti1.checked.c
-// RUN: diff %S/safefptrargcallermulti2.checked.convert_again.c %S/safefptrargcallermulti2.checked.c
+// RUN: test ! -f %S/safefptrargcallermulti1.checked.convert_again.c
+// RUN: test ! -f %S/safefptrargcallermulti2.checked.convert_again.c
 // RUN: rm %S/safefptrargcallermulti1.checkedALL.c %S/safefptrargcallermulti2.checkedALL.c
 // RUN: rm %S/safefptrargcallermulti1.checkedNOALL.c %S/safefptrargcallermulti2.checkedNOALL.c
-// RUN: rm %S/safefptrargcallermulti1.checked.c %S/safefptrargcallermulti2.checked.c %S/safefptrargcallermulti1.checked.convert_again.c %S/safefptrargcallermulti2.checked.convert_again.c
+// RUN: rm %S/safefptrargcallermulti1.checked.c %S/safefptrargcallermulti2.checked.c
 
 
 /*********************************************************************************/
@@ -123,7 +123,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargcallermulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/safefptrargcallermulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargcallermulti1.checked2.c %S/safefptrargcallermulti2.checked2.c
-// RUN: diff %S/safefptrargcallermulti1.checked2.convert_again.c %S/safefptrargcallermulti1.checked2.c
-// RUN: diff %S/safefptrargcallermulti2.checked2.convert_again.c %S/safefptrargcallermulti2.checked2.c
+// RUN: test ! -f %S/safefptrargcallermulti1.checked2.convert_again.c
+// RUN: test ! -f %S/safefptrargcallermulti2.checked2.convert_again.c
 // RUN: rm %S/safefptrargcallermulti1.checkedALL2.c %S/safefptrargcallermulti2.checkedALL2.c
 // RUN: rm %S/safefptrargcallermulti1.checkedNOALL2.c %S/safefptrargcallermulti2.checkedNOALL2.c
-// RUN: rm %S/safefptrargcallermulti1.checked2.c %S/safefptrargcallermulti2.checked2.c %S/safefptrargcallermulti1.checked2.convert_again.c %S/safefptrargcallermulti2.checked2.convert_again.c
+// RUN: rm %S/safefptrargcallermulti1.checked2.c %S/safefptrargcallermulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/safefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotoboth.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargprotoboth.checked.c -- | diff %S/safefptrargprotoboth.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargprotoboth.checked.c -- | count 0
 // RUN: rm %S/safefptrargprotoboth.checked.c
 
 
@@ -145,7 +145,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocallee.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargprotocallee.checked.c -- | diff %S/safefptrargprotocallee.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargprotocallee.checked.c -- | count 0
 // RUN: rm %S/safefptrargprotocallee.checked.c
 
 
@@ -144,7 +144,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Array_ptr<int> z =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z = calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
 	//CHECK_NOALL: for(i = 0; i < 5; i++) { 

--- a/clang/test/CheckedCRewriter/safefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocaller.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargprotocaller.checked.c -- | diff %S/safefptrargprotocaller.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargprotocaller.checked.c -- | count 0
 // RUN: rm %S/safefptrargprotocaller.checked.c
 
 
@@ -118,7 +118,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/safefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotosafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargprotosafe.checked.c -- | diff %S/safefptrargprotosafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargprotosafe.checked.c -- | count 0
 // RUN: rm %S/safefptrargprotosafe.checked.c
 
 
@@ -117,7 +117,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -131,7 +131,7 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 

--- a/clang/test/CheckedCRewriter/safefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafe.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s
-// RUN: cconv-standalone -alltypes %S/safefptrargsafe.checked.c -- | diff %S/safefptrargsafe.checked.c -
+// RUN: cconv-standalone -alltypes %S/safefptrargsafe.checked.c -- | count 0
 // RUN: rm %S/safefptrargsafe.checked.c
 
 
@@ -128,7 +128,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -142,6 +142,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargsafemulti1.checkedALL.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %S/safefptrargsafemulti2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargsafemulti1.checked.c %S/safefptrargsafemulti2.checked.c
-// RUN: diff %S/safefptrargsafemulti1.checked.convert_again.c %S/safefptrargsafemulti1.checked.c
-// RUN: diff %S/safefptrargsafemulti2.checked.convert_again.c %S/safefptrargsafemulti2.checked.c
+// RUN: test ! -f %S/safefptrargsafemulti1.checked.convert_again.c
+// RUN: test ! -f %S/safefptrargsafemulti2.checked.convert_again.c
 // RUN: rm %S/safefptrargsafemulti1.checkedALL.c %S/safefptrargsafemulti2.checkedALL.c
 // RUN: rm %S/safefptrargsafemulti1.checkedNOALL.c %S/safefptrargsafemulti2.checkedNOALL.c
-// RUN: rm %S/safefptrargsafemulti1.checked.c %S/safefptrargsafemulti2.checked.c %S/safefptrargsafemulti1.checked.convert_again.c %S/safefptrargsafemulti2.checked.convert_again.c
+// RUN: rm %S/safefptrargsafemulti1.checked.c %S/safefptrargsafemulti2.checked.c
 
 
 /*********************************************************************************/
@@ -122,7 +122,7 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }
 
@@ -136,6 +136,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y = sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Array_ptr<int> z : count(5) =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z : count(5) = sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -5,11 +5,11 @@
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %S/safefptrargsafemulti2.checkedALL2.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %S/safefptrargsafemulti1.c %s
 // RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=convert_again %S/safefptrargsafemulti1.checked2.c %S/safefptrargsafemulti2.checked2.c
-// RUN: diff %S/safefptrargsafemulti1.checked2.convert_again.c %S/safefptrargsafemulti1.checked2.c
-// RUN: diff %S/safefptrargsafemulti2.checked2.convert_again.c %S/safefptrargsafemulti2.checked2.c
+// RUN: test ! -f %S/safefptrargsafemulti1.checked2.convert_again.c
+// RUN: test ! -f %S/safefptrargsafemulti2.checked2.convert_again.c
 // RUN: rm %S/safefptrargsafemulti1.checkedALL2.c %S/safefptrargsafemulti2.checkedALL2.c
 // RUN: rm %S/safefptrargsafemulti1.checkedNOALL2.c %S/safefptrargsafemulti2.checkedNOALL2.c
-// RUN: rm %S/safefptrargsafemulti1.checked2.c %S/safefptrargsafemulti2.checked2.c %S/safefptrargsafemulti1.checked2.convert_again.c %S/safefptrargsafemulti2.checked2.convert_again.c
+// RUN: rm %S/safefptrargsafemulti1.checked2.c %S/safefptrargsafemulti2.checked2.c
 
 
 /*********************************************************************************/

--- a/clang/test/CheckedCRewriter/simple_locals.c
+++ b/clang/test/CheckedCRewriter/simple_locals.c
@@ -6,7 +6,7 @@
 // RUN: cconv-standalone -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
 // RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: cconv-standalone -alltypes -output-postfix=checked %s 
-// RUN: cconv-standalone -alltypes %S/simple_locals.checked.c -- | diff -w %S/simple_locals.checked.c -
+// RUN: cconv-standalone -alltypes %S/simple_locals.checked.c -- | count 0
 // RUN: rm %S/simple_locals.checked.c
 // expected-no-diagnostics
 

--- a/clang/test/CheckedCRewriter/struct_init_list.c
+++ b/clang/test/CheckedCRewriter/struct_init_list.c
@@ -2,7 +2,7 @@
 // RUN: cconv-standalone -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -alltypes %s -- | %clang_cc1  -fno-builtin -verify -fcheckedc-extension -x c -
 // RUN: cconv-standalone -output-postfix=checked -alltypes %s 
-// RUN: cconv-standalone -alltypes %S/struct_init_list.checked.c -- | diff -w %S/struct_init_list.checked.c -
+// RUN: cconv-standalone -alltypes %S/struct_init_list.checked.c -- | count 0
 // RUN: rm %S/struct_init_list.checked.c
 // expected-no-diagnostics
 


### PR DESCRIPTION
With this change `3C` is able to convert partially checked pointer types into fully checked pointer types. 
e.g.,
```c
_Ptr<int *> a;
```
can be converted to
```
_Ptr<_Ptr<int> a;
```
provided that `a` is used safely. 

More examples are in the test case `partial_checked.c`. 

---

A large number of test cases are modified as a side effect of this change. When converting the converted output from `3C` a second time to check for idempotence , we had to use `diff` to check that no changes occurred in some cases. `3C` will now not generate a converted output file in some of these cases.  