### PR TITLE
Fix for issue 283 (Failing gracefully)

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -141,7 +141,8 @@ public:
 
   // Update this CV with information from duplicate declaration CVs
   virtual void brainTransplant(ConstraintVariable *, ProgramInfo &) = 0;
-  virtual void mergeDeclaration(ConstraintVariable *, ProgramInfo &) = 0;
+  virtual void mergeDeclaration(ConstraintVariable *, ProgramInfo &,
+                                std::string &ReasonFailed) = 0;
 
   std::string getOriginalTy() const { return OriginalType; }
   // Get the original type string that can be directly
@@ -347,7 +348,8 @@ public:
   const CAtoms &getCvars() const { return vars; }
 
   void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
-  void mergeDeclaration(ConstraintVariable *From, ProgramInfo &I) override;
+  void mergeDeclaration(ConstraintVariable *From, ProgramInfo &I,
+                        std::string &ReasonFailed) override;
 
   static bool classof(const ConstraintVariable *S) {
     return S->getKind() == PointerVariable;
@@ -460,7 +462,8 @@ public:
   }
 
   void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
-  void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I) override;
+  void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I,
+                        std::string &ReasonFailed) override;
 
   ConstraintVariable *getParamVar(unsigned i) const {
     assert(i < ParamVars.size());

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -159,14 +159,18 @@ private:
   // Returns true if successful else false.
   bool insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
                                      const std::string &FuncName,
-                                     FVConstraint *ToIns);
+                                     FVConstraint *ToIns,
+                                     FunctionDecl *FD,
+                                     ASTContext *C);
 
   // Inserts the given FVConstraint* set into the provided static map.
   // Returns true if successful else false.
   bool insertIntoStaticFunctionMap(StaticFunctionMapType &Map,
                                    const std::string &FuncName,
                                    const std::string &FileName,
-                                   FVConstraint *ToIns);
+                                   FVConstraint *ToIns,
+                                   FunctionDecl *FD,
+                                   ASTContext *C);
 
 
   // Special-case handling for decl introductions. For the moment this covers:


### PR DESCRIPTION
A fix for #283 
Closes #283 

Some considerations: 
* I still have yet to add tests. (I have them written out, but clearly, I expect them to fail. While I could add XFAIL to them, seeing any sort of FAIL, even if it's expected, always makes me panic, so I'm trying to find a way to get it to still PASS. At any rate, my code is far from perfect, so I thought I could meddle with testing stuff while the code review was taking place so I don't delay this any longer.) 
* Most of this code is practically verbatim from our (me, Mike, Matt) conversation in the issue, but I decided to pass around a string instead of a boolean so I could knock out the error message and the fail flag together. It's understandably a little uglier, so if we want to change that, I can do so. 
* I played around with the error message signalling quite a bit (it's pretty fun), and we could make the error messages really cool (i.e. show both of the conflicting FunctionDecls across files with tags on the offending variable) if there were some way to access the underlying FunctionDecl from a ConstraintVariable. I debated adding a Decl field to PVConstraint and FVConstraint, but I thought it might be too invasive a change for something that might not matter as much to warrant it. (But once again, if we decide we want to, I can make this change).  
* **Important Question**: With this change we have 5 regression test failures (because these tests `#include <stdio.h>` but also redeclare `malloc` using the checked version (with the itypes). Before, clang would complain about an incompatible redeclaration but as a warning, but now I've changed it to an error). What should our way forward from this one be? To make an exception for standard functions in our code, or instead change the tests so this redeclaration doesn't occur?
