### PR TITLE
Disable clangd3c build target, which is unmaintained and broken.

### DIFF
--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -30,6 +30,12 @@ target_link_libraries(clangd
   ${CLANGD_XPC_LIBS}
   )
 
+# clangd3c is unmaintained and has failed to build (under its old name, icconv)
+# at least since 3892e314426e8d90b4d3d411e1aaaf636dac47ea (which was merged to
+# CCI's mainline in 0f8d6dc6f31b77af1c7fc593ed16680cf3b6c40e on 2020-10-22),
+# though we continue to include it in some bulk code edits.  We may revive it in
+# the future.
+if(FALSE)
 add_clang_tool(clangd3c
         ClangdMain.cpp
         $<TARGET_OBJECTS:obj.clangDaemonTweaks>
@@ -52,3 +58,4 @@ target_link_libraries(clangd3c
   )
 
 target_compile_definitions(clangd3c PUBLIC INTERACTIVE3C=1)
+endif()

--- a/clang/tools/3c/utils/port_tools/generate_ccommands.py
+++ b/clang/tools/3c/utils/port_tools/generate_ccommands.py
@@ -182,6 +182,12 @@ def run3C(checkedc_bin, compile_commands_json, checkedc_include_dir, skip_paths,
 
     vcodewriter = VSCodeJsonWriter()
     # get path to clangd3c
+    #
+    # The clangd3c build target has been broken for a while and is now disabled
+    # (see clang-tools-extra/clangd/tool/CMakeLists.txt).  Since this code has
+    # been here for a while and no one has been bothered by the fact that it
+    # didn't work, we won't bother removing it now; hopefully clangd3c will
+    # eventually be back.
     vcodewriter.setClangdPath(os.path.join(os.path.dirname(prog_name), "clangd3c"))
     args = []
     args.append(prog_name)


### PR DESCRIPTION
For testing, in order to get a configuration with any of the clangd targets present, you have to pass `'-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra' -DCLANG_ENABLE_CLANGD=ON` on the cmake command line.  You may have to delete everything in the `build` directory before this will work.

I confirmed with `ninja -n` that before this change, `clangd` and `clangd3c` both exist, while after it, `clangd` exists and `clangd3c` does not.

Note that before this change, `clangd3c` fails to build.  While #299 introduced some additional breakages due to collisions between field and type names (something I'd ideally have been more careful about), I confirmed that the old `icconv` target was broken at least as far back as 3892e314426e8d90b4d3d411e1aaaf636dac47ea, apparently due to some occurrences of `cl::opt` in `clang-tools-extra/clangd/tool/ClangdMain.cpp` that should be `llvm::cl::opt`.  I don't know how many more breakages currently exist, and I don't think we care about fixing any of them now.