### PR TITLE
Rename the clang/lib/3C target to clang3C, following convention.

### DIFF
--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -209,7 +209,7 @@ add_clang_library(3cClangDaemon
   refactor/Tweak.cpp
 
   LINK_LIBS
-  3C
+  clang3C
   clangAST
   clangASTMatchers
   clangBasic

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(clangd3c
   clangBasic
   clangTidy
   3cClangDaemon
-  3C
+  clang3C
   clangFormat
   clangFrontend
   clangSema

--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -9,7 +9,7 @@ set( LLVM_LINK_COMPONENTS
             DeclRewriter_5C.cpp
           )
         endif()
-        add_clang_library(3C
+        add_clang_library(clang3C
           ABounds.cpp
           AVarBoundsInfo.cpp
           AVarGraph.cpp
@@ -46,4 +46,4 @@ set( LLVM_LINK_COMPONENTS
           clangToolingRefactoring
         )
         add_subdirectory(unittests)
-	target_include_directories(obj.3C PUBLIC)
+	target_include_directories(obj.clang3C PUBLIC)

--- a/clang/tools/3c/CMakeLists.txt
+++ b/clang/tools/3c/CMakeLists.txt
@@ -12,7 +12,7 @@ add_clang_executable(3c
 
 target_link_libraries(3c
   PRIVATE
-  3C
+  clang3C
   clangAST
   clangBasic
   clangDriver


### PR DESCRIPTION
This neatly resolves the confusing near-collision between the executable
target (renamed from cconv-standalone to 3c in #299) and the library
target (renamed from CConv to 3C).

`ninja check-clang-3c` passes (after deleting everything in the `build` directory: sigh).