### PR TITLE
Rename two identifiers missed in #299.

### DIFF
--- a/clang-tools-extra/clangd/3CCommands.cpp
+++ b/clang-tools-extra/clangd/3CCommands.cpp
@@ -25,7 +25,7 @@ static bool GetPtrIDFromDiagMessage(const Diagnostic &DiagMsg,
   return false;
 }
 
-void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
+void As3CCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
   unsigned long PtrId;
   if (GetPtrIDFromDiagMessage(D, PtrId)) {
     Command AllPtrsCmd;
@@ -52,7 +52,7 @@ bool Is3CCommand(const ExecuteCommandParams &Params) {
            (Params.command.rfind(Command::_3C_APPLY_FOR_ALL, 0) == 0);
 }
 
-bool ExecuteCCCommand(const ExecuteCommandParams &Params,
+bool Execute3CCommand(const ExecuteCommandParams &Params,
                     std::string &ReplyMessage,
                     _3CInterface &CcInterface) {
   ReplyMessage = "Checked C Pointer Modified.";

--- a/clang-tools-extra/clangd/3CCommands.h
+++ b/clang-tools-extra/clangd/3CCommands.h
@@ -18,13 +18,13 @@
 namespace clang {
 namespace clangd {
   // Convert the provided Diagnostic into Commands
-  void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands);
+  void As3CCommands(const Diagnostic &D, std::vector<Command> &OutCommands);
   // Check if the execute command request from the client is a 3C command.
   bool Is3CCommand(const ExecuteCommandParams &Params);
 
   // Interpret the provided execute command request as 3C command
   // and execute them.
-  bool ExecuteCCCommand(const ExecuteCommandParams &Params,
+  bool Execute3CCommand(const ExecuteCommandParams &Params,
                         std::string &ReplyMessage,
                         _3CInterface &CcInterface);
 }

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -814,12 +814,12 @@ void ClangdLSPServer::onCodeAction(const CodeActionParams &Params,
                                    Callback<llvm::json::Value> Reply) {
 #ifdef INTERACTIVE3C
   URIForFile File = Params.textDocument.uri;
-  std::vector<Command> CCommands;
+  std::vector<Command> Commands;
   // Convert the diagnostics into 3C commands.
   for (const Diagnostic &D : Params.context.diagnostics) {
-    AsCCCommands(D, CCommands);
+    As3CCommands(D, Commands);
   }
-  Reply(llvm::json::Array(CCommands));
+  Reply(llvm::json::Array(Commands));
 #else
 
   URIForFile File = Params.textDocument.uri;

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -219,7 +219,7 @@ void ClangdServer::execute3CCommand(ExecuteCommandParams Params,
       log("3C: File of the pointer {0}\n", PtrFileName);
       clear3CDiagsForAllFiles(WildPtrsInfo, ConvCB);
       ConvCB->send3CMessage("3C modifying constraints.");
-      ExecuteCCCommand(Params, RplMsg, _3CInter);
+      Execute3CCommand(Params, RplMsg, _3CInter);
       this->_3CDiagInfo.ClearAllDiags();
       ConvCB->send3CMessage("3C Updating new issues "
                             "after editing constraints.");


### PR DESCRIPTION
Specifically, AsCCCommands and ExecuteCCCommand.  These are used only in
clangd3c, which we're about to disable, but the intent of #299 was to
process the whole source tree.  These do not appear in the currently
existing 5C-specific code.

This change intentionally does not address:

- Local variables (except one as requested by Mike).  They aren't
  important and their naming varies too much to make it easy to find all
  of them.

- Name collisions between fields or local variables and their types.  In
  my tests so far, a field collision causes a compile error, while a
  local variable collision doesn't.  I saw the clangd3c build fail due
  to field collisions (we know there are none in 3c because it builds),
  and this led me to discover some local variable collisions in both
  clangd3c and 3c.  But we don't care about clangd3c build failures
  right now, and there isn't an easy way to find _all_ local variable
  collisions, so I don't see a strong motivation to fix the few in 3c
  that I happen to know about.

To make sure I didn't miss anything else, I conducted a more thorough
search than before for "cc" or "c.c" in the diff from LLVM master.  Some
common false positives could be excluded, but I thought that would be
more work than just reviewing them.

```
RANGE=$(git merge-base llvm/master origin/master)..origin/master
PAT='cc|c[^<(/.a-z]c'
git diff --name-only $RANGE >names
grep -Ei "$PAT" --color=always names | less -R
while read f; do git diff --line-prefix="$f:" $RANGE -- $f; done <names >diffs-with-filenames
GREP_COLORS=cx=37:mt= grep --color=always -B3 -A3 -Ei ":[-+].*($PAT)" diffs-with-filenames | less -R
```

(Then use the case-insensitive "less" search command on $PAT.)

Since the change only affects `clangd3c`, I don't think testing is necessary.