### PR TITLE
update-includes.py: Find the default header location relative to update-includes.py itself.

### DIFF
--- a/clang/tools/3c/utils/update-includes.py
+++ b/clang/tools/3c/utils/update-includes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 This program takes a list of .c or .h files, e.g. in a convert.sh file,
 and converts any included c library headers which have _checked versions
@@ -17,9 +18,14 @@ import argparse
 
 # This default value will be overwritten if an alternate path is provided
 # in an argument.
+#
+# Relative path from "llvm" dir (LLVM_SRC if specified)
 CHECKEDC_INCLUDE_REL_PATH = "projects/checkedc-wrapper/checkedc/include"
+
 checkedcHeaderDir = os.path.abspath(
-    os.path.join("../../../../..",
+    os.path.join(os.path.dirname(__file__),
+                 # Relative path from clang/tools/3c/utils to llvm
+                 "../../../../llvm",
                  CHECKEDC_INCLUDE_REL_PATH))
 
 


### PR DESCRIPTION
I'm not sure under what conditions the existing default (apparently based on the working directory) was supposed to work.  This should work all the time if the Checked C system headers have been installed according to our upcoming instructions.  I have tested it with `checkedc-tiny-bignum-c`.

Bonus: Make update-includes.py directly executable.