### PR TITLE
Inline struct rewriting discussion (not for merging)

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -80,6 +80,7 @@ protected:
         ValidBoundsKey(false), IsForDecl(false) {}
 
 public:
+  std::string RewritingBaseType;
   // Create a "for-rewriting" representation of this ConstraintVariable.
   // The 'emitName' parameter is true when the generated string should include
   // the name of the variable, false for just the type.

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -157,6 +157,8 @@ bool isTypeHasVoid(clang::QualType QT);
 // Check if the provided declaration is in system header.
 bool isInSysHeader(clang::Decl *D);
 
+std::string replaceAll(std::string s, std::string search, std::string replace);
+
 std::string getSourceText(const clang::SourceRange &SR,
                           const clang::ASTContext &C);
 

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -25,6 +25,7 @@ unsigned int lastRecordLocation = -1;
 void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
                        ASTContext *Context, ConstraintResolver CB,
                        bool IsInFunction) {
+  std::string yeet = getSourceText(Declaration->getSourceRange(), *Context);
   if (RecordDecl *Definition = Declaration->getDefinition()) {
     // store current record's location to cross-ref later in a VarDecl
     lastRecordLocation = Definition->getBeginLoc().getRawEncoding();
@@ -56,7 +57,7 @@ void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
               (FL.isInSystemHeader() || Definition->isUnion());
           // mark field wild if the above is true and the field is a pointer
           if (isPtrOrArrayType(FieldTy) &&
-              (FieldInUnionOrSysHeader || IsInLineStruct)) {
+              (FieldInUnionOrSysHeader)) {
             std::string Rsn = "Union or external struct field encountered";
             CVarOption CV = Info.getVariable(F, Context);
             CB.constraintCVarToWild(CV, Rsn);
@@ -91,7 +92,7 @@ public:
           if (SR.isValid() && FL.isValid() && isPtrOrArrayType(VD->getType())) {
             if (lastRecordLocation == VD->getBeginLoc().getRawEncoding()) {
               CVarOption CV = Info.getVariable(VD, Context);
-              CB.constraintCVarToWild(CV, "Inline struct encountered.");
+              //CB.constraintCVarToWild(CV, "Inline struct encountered.");
             }
           }
         }
@@ -419,7 +420,7 @@ public:
       unsigned int EndLoc = G->getEndLoc().getRawEncoding();
       if (lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc) {
         CVarOption CV = Info.getVariable(G, Context);
-        CB.constraintCVarToWild(CV, "Inline struct encountered.");
+//        CB.constraintCVarToWild(CV, "Inline struct encountered.");
       }
     }
 

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -710,7 +710,8 @@ std::string PointerVariableConstraint::mkString(const EnvironmentMap &E,
     if (FV) {
       Ss << FV->mkString(E);
     } else {
-      Ss << BaseType;
+      if (RewritingBaseType == "") Ss << BaseType;
+      else Ss << RewritingBaseType;
     }
   }
 

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -335,6 +335,19 @@ bool isInSysHeader(clang::Decl *D) {
   return false;
 }
 
+std::string replaceAll(std::string s, std::string search, std::string replace ) {
+  for( size_t pos = 0; ; pos += replace.length() ) {
+    // Locate the substring to replace
+    pos = s.find( search, pos );
+    if( pos == std::string::npos ) break;
+    if (isalnum(s.at(pos+search.length()))) continue;
+    // Replace by erasing and inserting
+    s.erase( pos, search.length() );
+    s.insert( pos, replace );
+  }
+  return s;
+}
+
 std::string getSourceText(const clang::SourceRange &SR,
                           const clang::ASTContext &C) {
   assert(SR.isValid() && "Invalid Source Range requested.");

--- a/clang/test/3C/example.c
+++ b/clang/test/3C/example.c
@@ -1,0 +1,28 @@
+struct {int *a; int *ab;} *x[4], n;
+struct foo {int *a; int *b;} *y, d; 
+struct bar {int *a; int *b;}; 
+struct bar *z; 
+
+void foo() {
+    //struct {int *d;} *f;
+} 
+
+/*converts to:
+
+
+_Ptr<struct {_Ptr<int> a; _Ptr<int> ab;}> x _Checked[4] = {((void *)0)};
+struct (anonymous struct at /Users/shilpa-roy/checkedc/checkedc-clang/shilpa_issues_examples/example.c:1:1) n;
+
+_Ptr<struct foo {_Ptr<int> a; _Ptr<int> b;}> y = ((void *)0);
+struct foo d;
+ 
+struct bar {_Ptr<int> a; _Ptr<int> b;}; 
+_Ptr<struct bar> z = ((void *)0); 
+
+void foo() {
+    //struct {int *d;} *f;
+} 
+
+
+
+*/


### PR DESCRIPTION
A very rough initial implementation of rewriting inline structs. 
This is by no means finalized, but I think I should get some general feedback on the design and big-picture idea earlier rather than later before investing too much into this. At a high level, the solution is to track inline structs within the rewriting process in `DeclRewriter.cpp`, hold references to the definitions of the inline structs, modify those definitions with the checked versions of the `FieldDecls`, and then pass this updated definition into `mkString`. 
I've commented the code with pitfalls and todo's to give a brief idea of the type of things I've tried and what I'm currently struggling with, but probably the best indication of where this work is currently at is the test file I've linked called `example.c` alongside the other regression tests. Here are the main takeaways from that file: 

1. Global inline structs look fantastic. They rewrite how we want them to, and chaining a bunch of them on the same line works well. It could be a little more robust, so ideas on that are always welcome.
2. Global inline structs where at least one variable is a non-pointer i.e. `struct {...} *a, b;` results in `a` being modified how we want, since it is a pointer, but because `b`'s internal `BaseType` is still "anonymous struct at ....", its rewriting suffers, so if we decide to go with this solution (or a much better, more refined version of this solution when I actually make a PR), we'd have to do some finagling with these guys. 
3. Inline struct definitions in functions also "work" in that they produce the right strings (i.e. with the right converted FieldDecls and struct definitions). However, you'll notice that I've commented it out because 3C crashes currently because of an assertion error in the rewriter (`Assertion failed: (getPiece(StartPiece).size() > NumBytes), function erase`). I have yet to debug it (that's next on my list), but if someone who is familiar with the rewriter knows what this means offhand, that would be great. 

The code in its current state is the process of a lot of trial and error on my end, so I'm very open to other ideas that people have as they review this PR, so if you have a comment along the lines of "what if instead we did... for ...?", I can try it out quickly and get back to you about how well it works. 