### PR TITLE
Marking inlinestructs non-wild when AllTypes is enabled

### DIFF
--- a/clang/test/3C/anonstruct.c
+++ b/clang/test/3C/anonstruct.c
@@ -5,8 +5,8 @@
 struct { 
     int *data; 
 } *x; 
-//CHECK: _Ptr<int> data;
-//CHECK: } *x;
+//CHECK_NOALL: _Ptr<int> data;
+//CHECK_ALL: _Ptr<struct> x = ((void *)0);
 
 /*ensure trivial conversion*/
 void foo(int *x) { 

--- a/clang/test/3C/arrinlinestruct.c
+++ b/clang/test/3C/arrinlinestruct.c
@@ -16,5 +16,5 @@ struct alpha *al[4];
 struct {
   int *a;
 } *be[4];  
-//CHECK: _Ptr<int> a;
-//CHECK: } *be[4]; 
+//CHECK_NOALL: _Ptr<int> a;
+//CHECK_ALL: _Ptr<struct> be _Checked[4] = {((void *)0)};

--- a/clang/test/3C/complexinlinestruct.c
+++ b/clang/test/3C/complexinlinestruct.c
@@ -6,7 +6,8 @@
 
  /* one decl; x rewrites to _Ptr<int> */
 struct foo { int *x; } *a;
-//CHECK: struct foo { _Ptr<int> x; } *a;
+//CHECK_NOALL: struct foo { _Ptr<int> x; } *a;
+//CHECK_ALL: _Ptr<struct foo> a = ((void *)0);
 
 struct baz { int *z; };
 struct baz *d;
@@ -15,11 +16,15 @@ struct baz *d;
 
 /* two decls, not one; y stays as int * */
 struct bad { int* y; } *b, *c; 
-//CHECK: struct bad { int* y; } *b, *c;
+//CHECK_NOALL: struct bad { int* y; } *b, *c;
+//CHECK_ALL: _Ptr<struct bad> b = ((void *)0); 
+//CHECK_ALL: _Ptr<struct bad> c = ((void *)0);
 
  /* two decls, y should be converted */
 struct bar { int* y; } *e, *f;
-//CHECK: struct bar { _Ptr<int> y; } *e, *f;
+//CHECK_NOALL: struct bar { _Ptr<int> y; } *e, *f;
+//CHECK_ALL: _Ptr<struct bar> e = ((void *)0);
+//CHECK_ALL: _Ptr<struct bar> f = ((void *)0);
 
 
 void foo(void) {

--- a/clang/test/3C/inlinestruct_difflocs.c
+++ b/clang/test/3C/inlinestruct_difflocs.c
@@ -14,6 +14,6 @@ array[] =
   { "mystery", &valuable }
 }; 
 
-//CHECK_ALL: _Ptr<const char> name;
+//CHECK_ALL: static struct foo array _Checked[1] =
 //CHECK_NOALL: const char* name;
-//CHECK: _Ptr<int> p_valuable;
+//CHECK_NOALL: _Ptr<int> p_valuable;


### PR DESCRIPTION
This PR marks inline structs wild only when alltypes is disabled, in partial compliance with the discussion about trying not to mark rewriting failures as WILD. 
The code after this PR will mark pointers WILD when alltypes is disabled, but allow them to become checked when alltypes is enabled, with a warning to the user with guidelines for how to manually address the failure in rewriting.  
An important note here is that inline structs that occur within function definitions will still be marked wild (regardless of whether alltypes is enabled), because when inline structs inside functions are allowed to be checked, the Rewriter crashes due to the following assertion error: 
```
Assertion failed: (getPiece(StartPiece).size() > NumBytes)
``` 