### PR TITLE
CheckedRegions understand return types, fixes #263

### DIFF
--- a/clang/test/3C/checkedregions.c
+++ b/clang/test/3C/checkedregions.c
@@ -80,3 +80,10 @@ void baz(void) {
     bad();
   }
 }
+
+int* g() { 
+	//CHECK: int* g(void) {
+	return 1;
+}
+
+

--- a/clang/test/3C/fn_sets.c
+++ b/clang/test/3C/fn_sets.c
@@ -51,19 +51,19 @@ void foo1(int *z) {
 /* Testing Something with a larger set of functions */
 
 int *a() {
-	//CHECK: int *a(void) _Checked {
+	//CHECK: int *a(void)  {
   return 0;
 }
 int *b() {
-	//CHECK: int *b(void) _Checked {
+	//CHECK: int *b(void)  {
   return 0;
 }
 int *c() {
-	//CHECK: int *c(void) _Checked {
+	//CHECK: int *c(void)  {
   return 0;
 }
 int *d() {
-	//CHECK: int *d(void) _Checked {
+	//CHECK: int *d(void)  {
   return 0;
 }
 int *e() {
@@ -72,7 +72,7 @@ int *e() {
 	//CHECK: return (int*) 1;
 }
 int *i() {
-	//CHECK: _Ptr<int> i(void) _Checked {
+	//CHECK: _Ptr<int> i(void) _Checked  {
   return 0;
 }
 


### PR DESCRIPTION
Main question I have is on my `const_cast` at checkedregions.c:173. Is there a way to avoid this, without needing to change the entire project to make `ProgramInfo::getVariable` const?