### PR TITLE
Inline struct rewriting support

### DIFF
--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_3C_DECLREWRITER_H
 
 #include "clang/3C/RewriteUtils.h"
+#include "clang/3C/ConstraintBuilder.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -35,6 +36,9 @@ public:
   static void rewriteDecls(ASTContext &Context, ProgramInfo &Info, Rewriter &R);
 
 private:
+  static RecordDecl *LastRecordDecl;
+  static std::map<Decl *, Decl *> VDToRDMap;
+  static std::set<Decl *> InlineVarDecls;
   Rewriter &R;
   ASTContext &A;
   GlobalVariableGroups &GP;
@@ -69,13 +73,13 @@ private:
                         bool ContainsInlineStruct);
   void rewriteSingleDecl(DeclReplacement *N, RSet &ToRewrite);
   void doDeclRewrite(SourceRange &SR, DeclReplacement *N);
-
   void rewriteFunctionDecl(FunctionDeclReplacement *N);
   void rewriteTypedefDecl(TypedefDeclReplacement *TDT, RSet &ToRewrite);
   void getDeclsOnSameLine(DeclReplacement *N, std::vector<Decl *> &Decls);
   bool isSingleDeclaration(DeclReplacement *N);
   bool areDeclarationsOnSameLine(DeclReplacement *N1, DeclReplacement *N2);
   SourceRange getNextCommaOrSemicolon(SourceLocation L);
+  static void detectInlineStruct(Decl *D, SourceManager &SM);
 };
 
 // Visits function declarations and adds entries with their new rewritten

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -64,10 +64,10 @@ private:
 
   template <typename DRType>
   void rewriteFieldOrVarDecl(DRType *N, RSet &ToRewrite);
-  void rewriteMultiDecl(DeclReplacement *N, RSet &ToRewrite);
+  void rewriteMultiDecl(DeclReplacement *N, RSet &ToRewrite,
+                        std::vector<Decl *> SameLineDecls,
+                        bool ContainsInlineStruct);
   void rewriteSingleDecl(DeclReplacement *N, RSet &ToRewrite);
-  void rewriteNamedInlineStruct(DeclReplacement *N, RSet &ToRewrite,
-                                std::vector<Decl *> SameLineDecls);
   void doDeclRewrite(SourceRange &SR, DeclReplacement *N);
 
   void rewriteFunctionDecl(FunctionDeclReplacement *N);

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -66,6 +66,8 @@ private:
   void rewriteFieldOrVarDecl(DRType *N, RSet &ToRewrite);
   void rewriteMultiDecl(DeclReplacement *N, RSet &ToRewrite);
   void rewriteSingleDecl(DeclReplacement *N, RSet &ToRewrite);
+  void rewriteNamedInlineStruct(DeclReplacement *N, RSet &ToRewrite,
+                                std::vector<Decl *> SameLineDecls);
   void doDeclRewrite(SourceRange &SR, DeclReplacement *N);
 
   void rewriteFunctionDecl(FunctionDeclReplacement *N);

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -20,99 +20,109 @@
 using namespace llvm;
 using namespace clang;
 
-// Used to keep track of in-line struct defs
-RecordDecl *LastRecordDecl = nullptr;
+// This class is intended to locate inline struct definitions
+// in order to mark them wild or signal a warning as appropriate
+class InlineStructDetector {
+public:
+  explicit InlineStructDetector() : LastRecordDecl(nullptr) {}
 
-void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
-                       ASTContext *Context, ConstraintResolver CB) {
-  LastRecordDecl = Declaration;
-  if (RecordDecl *Definition = Declaration->getDefinition()) {
-    auto LastRecordLocation = Definition->getBeginLoc();
-    FullSourceLoc FL = Context->getFullLoc(Definition->getBeginLoc());
-    if (FL.isValid()) {
-      SourceManager &SM = Context->getSourceManager();
-      FileID FID = FL.getFileID();
-      const FileEntry *FE = SM.getFileEntryForID(FID);
-
-      //detect whether this RecordDecl is part of an inline struct
-      bool IsInLineStruct = false;
-      Decl *D = Declaration->getNextDeclInContext();
-      if (VarDecl *VD = dyn_cast_or_null<VarDecl>(D)) {
-        auto VarTy = VD->getType();
-        auto BeginLoc = VD->getBeginLoc();
-        auto EndLoc = VD->getEndLoc();
+  void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
+                         ASTContext *Context, ConstraintResolver CB) {
+    LastRecordDecl = Declaration;
+    if (RecordDecl *Definition = Declaration->getDefinition()) {
+      auto LastRecordLocation = Definition->getBeginLoc();
+      FullSourceLoc FL = Context->getFullLoc(Definition->getBeginLoc());
+      if (FL.isValid()) {
         SourceManager &SM = Context->getSourceManager();
-        IsInLineStruct = !isPtrOrArrayType(VarTy) && !VD->hasInit() &&
-                         SM.isPointWithin(LastRecordLocation, BeginLoc, EndLoc);
-      }
+        FileID FID = FL.getFileID();
+        const FileEntry *FE = SM.getFileEntryForID(FID);
 
-      if (FE && FE->isValid()) {
-        // We only want to re-write a record if it contains
-        // any pointer types, to include array types.
-        for (const auto &F : Definition->fields()) {
-          auto FieldTy = F->getType();
-          // If the RecordDecl is a union or in a system header
-          // and this field is a pointer, we need to mark it wild;
-          bool FieldInUnionOrSysHeader =
-              (FL.isInSystemHeader() || Definition->isUnion());
-          // mark field wild if the above is true and the field is a pointer
-          if (isPtrOrArrayType(FieldTy) &&
-              (FieldInUnionOrSysHeader || IsInLineStruct)) {
-            std::string Rsn = "Union or external struct field encountered";
-            CVarOption CV = Info.getVariable(F, Context);
-            CB.constraintCVarToWild(CV, Rsn);
+        //detect whether this RecordDecl is part of an inline struct
+        bool IsInLineStruct = false;
+        Decl *D = Declaration->getNextDeclInContext();
+        if (VarDecl *VD = dyn_cast_or_null<VarDecl>(D)) {
+          auto VarTy = VD->getType();
+          auto BeginLoc = VD->getBeginLoc();
+          auto EndLoc = VD->getEndLoc();
+          SourceManager &SM = Context->getSourceManager();
+          IsInLineStruct =
+              !isPtrOrArrayType(VarTy) && !VD->hasInit() &&
+              SM.isPointWithin(LastRecordLocation, BeginLoc, EndLoc);
+        }
+
+        if (FE && FE->isValid()) {
+          // We only want to re-write a record if it contains
+          // any pointer types, to include array types.
+          for (const auto &F : Definition->fields()) {
+            auto FieldTy = F->getType();
+            // If the RecordDecl is a union or in a system header
+            // and this field is a pointer, we need to mark it wild;
+            bool FieldInUnionOrSysHeader =
+                (FL.isInSystemHeader() || Definition->isUnion());
+            // mark field wild if the above is true and the field is a pointer
+            if (isPtrOrArrayType(FieldTy) &&
+                (FieldInUnionOrSysHeader || IsInLineStruct)) {
+              std::string Rsn = "Union or external struct field encountered";
+              CVarOption CV = Info.getVariable(F, Context);
+              CB.constraintCVarToWild(CV, Rsn);
+            }
           }
         }
       }
     }
   }
-}
 
-void processVarDecl(VarDecl *VD, ProgramInfo &Info,
-                    ASTContext *Context, ConstraintResolver CB) {
-  // If the last seen RecordDecl is non-null and coincides with the current
-  // VarDecl (i.e. via an inline struct), we proceed as follows:
-  // if the struct is named, do nothing
-  // if the struct is anonymous:
-  //      when alltypes is on, do nothing, but signal a warning to
-  //                           the user indicating its presence
-  //      when alltypes is off, mark the VarDecl WILD in order to
-  //                           ensure the converted program compiles. 
-  if(LastRecordDecl != nullptr) {
-    auto lastRecordLocation = LastRecordDecl->getBeginLoc();
-    auto BeginLoc = VD->getBeginLoc();
-    auto EndLoc = VD->getEndLoc();
-    auto VarTy = VD->getType();
-    SourceManager &SM = Context->getSourceManager();
-    bool IsInLineStruct =
-        SM.isPointWithin(lastRecordLocation, BeginLoc, EndLoc)
-        && isPtrOrArrayType(VarTy);
-    bool IsNamedInLineStruct = IsInLineStruct
-                               && LastRecordDecl->getNameAsString() != "";
-    if (IsInLineStruct && !IsNamedInLineStruct) {
-      if (!AllTypes) {
-        CVarOption CV = Info.getVariable(VD, Context);
-        CB.constraintCVarToWild(CV, "Inline struct encountered.");
-      } else {
-        clang::DiagnosticsEngine &DE = Context->getDiagnostics();
-        unsigned InlineStructWarning = DE.getCustomDiagID(
-            DiagnosticsEngine::Warning, "\n Rewriting failed"
-                                        "for %q0 because an inline "
-                                        "or anonymous struct instance "
-                                        "was detected.\n Consider manually "
-                                        "rewriting by inserting the struct "
-                                        "definition inside the _Ptr "
-                                        "annotation.\n "
-                                        "EX. struct {int *a; int *b;} x; "
-                                        "_Ptr<struct {int *a; _Ptr<int> b;}>;");
-        const auto Pointer = reinterpret_cast<intptr_t>(VD);
-        const auto Kind = clang::DiagnosticsEngine::ArgumentKind::ak_nameddecl;
-        auto DiagBuilder = DE.Report(VD->getLocation(), InlineStructWarning);
-        DiagBuilder.AddTaggedVal(Pointer, Kind);
+  void processVarDecl(VarDecl *VD, ProgramInfo &Info, ASTContext *Context,
+                      ConstraintResolver CB) {
+    // If the last seen RecordDecl is non-null and coincides with the current
+    // VarDecl (i.e. via an inline struct), we proceed as follows:
+    // if the struct is named, do nothing
+    // if the struct is anonymous:
+    //      when alltypes is on, do nothing, but signal a warning to
+    //                           the user indicating its presence
+    //      when alltypes is off, mark the VarDecl WILD in order to
+    //                           ensure the converted program compiles.
+    if (LastRecordDecl != nullptr) {
+      auto lastRecordLocation = LastRecordDecl->getBeginLoc();
+      auto BeginLoc = VD->getBeginLoc();
+      auto EndLoc = VD->getEndLoc();
+      auto VarTy = VD->getType();
+      SourceManager &SM = Context->getSourceManager();
+      bool IsInLineStruct =
+          SM.isPointWithin(lastRecordLocation, BeginLoc, EndLoc) &&
+          isPtrOrArrayType(VarTy);
+      bool IsNamedInLineStruct =
+          IsInLineStruct && LastRecordDecl->getNameAsString() != "";
+      if (IsInLineStruct && !IsNamedInLineStruct) {
+        if (!AllTypes) {
+          CVarOption CV = Info.getVariable(VD, Context);
+          CB.constraintCVarToWild(CV, "Inline struct encountered.");
+        } else {
+          clang::DiagnosticsEngine &DE = Context->getDiagnostics();
+          unsigned InlineStructWarning =
+              DE.getCustomDiagID(DiagnosticsEngine::Warning,
+                                 "\n Rewriting failed"
+                                 "for %q0 because an inline "
+                                 "or anonymous struct instance "
+                                 "was detected.\n Consider manually "
+                                 "rewriting by inserting the struct "
+                                 "definition inside the _Ptr "
+                                 "annotation.\n "
+                                 "EX. struct {int *a; int *b;} x; "
+                                 "_Ptr<struct {int *a; _Ptr<int> b;}>;");
+          const auto Pointer = reinterpret_cast<intptr_t>(VD);
+          const auto Kind =
+              clang::DiagnosticsEngine::ArgumentKind::ak_nameddecl;
+          auto DiagBuilder = DE.Report(VD->getLocation(), InlineStructWarning);
+          DiagBuilder.AddTaggedVal(Pointer, Kind);
+        }
       }
     }
   }
-}
+
+private:
+  RecordDecl *LastRecordDecl;
+};
 
 // This class visits functions and adds constraints to the
 // Constraints instance assigned to it.
@@ -122,21 +132,21 @@ class FunctionVisitor : public RecursiveASTVisitor<FunctionVisitor> {
 public:
   explicit FunctionVisitor(ASTContext *C, ProgramInfo &I, FunctionDecl *FD,
                            TypeVarInfo &TVI)
-      : Context(C), Info(I), Function(FD), CB(Info, Context), TVInfo(TVI) {}
+      : Context(C), Info(I), Function(FD), CB(Info, Context), TVInfo(TVI), ISD() {}
 
   // T x = e
   bool VisitDeclStmt(DeclStmt *S) {
     // Introduce variables as needed.
     for (const auto &D : S->decls()) {
       if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
-        processRecordDecl(RD, Info, Context, CB);
+        ISD.processRecordDecl(RD, Info, Context, CB);
       }
       if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
         if (VD->isLocalVarDecl()) {
           FullSourceLoc FL = Context->getFullLoc(VD->getBeginLoc());
           SourceRange SR = VD->getSourceRange();
           if (SR.isValid() && FL.isValid() && isPtrOrArrayType(VD->getType())) {
-            processVarDecl(VD, Info, Context, CB);
+            ISD.processVarDecl(VD, Info, Context, CB);
           }
         }
       }
@@ -440,6 +450,7 @@ private:
   FunctionDecl *Function;
   ConstraintResolver CB;
   TypeVarInfo &TVInfo;
+  InlineStructDetector ISD;
 };
 
 class PtrToStructDef : public RecursiveASTVisitor<PtrToStructDef> {
@@ -494,7 +505,7 @@ class ConstraintGenVisitor : public RecursiveASTVisitor<ConstraintGenVisitor> {
 public:
   explicit ConstraintGenVisitor(ASTContext *Context, ProgramInfo &I,
                                 TypeVarInfo &TVI)
-      : Context(Context), Info(I), CB(Info, Context), TVInfo(TVI) {}
+      : Context(Context), Info(I), CB(Info, Context), TVInfo(TVI), ISD() {}
 
   bool VisitTypedefDecl(TypedefDecl* TD) { 
       CVarSet empty;
@@ -516,7 +527,7 @@ public:
       if (G->hasInit()) {
         CB.constrainLocalAssign(nullptr, G, G->getInit());
       }
-      processVarDecl(G, Info, Context, CB);
+      ISD.processVarDecl(G, Info, Context, CB);
     }
     return true;
   }
@@ -563,7 +574,7 @@ public:
   }
 
   bool VisitRecordDecl(RecordDecl *Declaration) {
-    processRecordDecl(Declaration, Info, Context, CB);
+    ISD.processRecordDecl(Declaration, Info, Context, CB);
     return true;
   }
 
@@ -572,6 +583,7 @@ private:
   ProgramInfo &Info;
   ConstraintResolver CB;
   TypeVarInfo &TVInfo;
+  InlineStructDetector ISD;
 };
 
 // Some information about variables in the program is required by the type

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -21,31 +21,20 @@ using namespace llvm;
 using namespace clang;
 
 // Used to keep track of in-line struct defs
-unsigned int LastRecordLocation = -1;
+RecordDecl *lastRecord2 = nullptr;
+static std::map<Decl *, Decl *> VDToRDMap2;
+static std::set<Decl *> inlines2;
 
 void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
-                       ASTContext *Context, ConstraintResolver CB,
-                       bool IsInFunction) {
+                       ASTContext *Context, ConstraintResolver CB) {
+  lastRecord2 = Declaration;
   if (RecordDecl *Definition = Declaration->getDefinition()) {
-    // store current record's location to cross-ref later in a VarDecl
-    LastRecordLocation = Definition->getBeginLoc().getRawEncoding();
     FullSourceLoc FL = Context->getFullLoc(Definition->getBeginLoc());
     if (FL.isValid()) {
       SourceManager &SM = Context->getSourceManager();
       FileID FID = FL.getFileID();
       const FileEntry *FE = SM.getFileEntryForID(FID);
 
-      //detect whether this RecordDecl is part of an inline struct
-      bool IsInLineStruct = false;
-      Decl *D = Declaration->getNextDeclInContext();
-      if (VarDecl *VD = dyn_cast_or_null<VarDecl>(D)) {
-        auto VarTy = VD->getType();
-        unsigned int BeginLoc = VD->getBeginLoc().getRawEncoding();
-        unsigned int EndLoc = VD->getEndLoc().getRawEncoding();
-        IsInLineStruct = !isPtrOrArrayType(VarTy) && !VD->hasInit() &&
-                         LastRecordLocation >= BeginLoc &&
-                         LastRecordLocation <= EndLoc;
-      }
       if (FE && FE->isValid()) {
         // We only want to re-write a record if it contains
         // any pointer types, to include array types.
@@ -57,13 +46,54 @@ void processRecordDecl(RecordDecl *Declaration, ProgramInfo &Info,
               (FL.isInSystemHeader() || Definition->isUnion());
           // mark field wild if the above is true and the field is a pointer
           if (isPtrOrArrayType(FieldTy) &&
-              (FieldInUnionOrSysHeader || IsInLineStruct)) {
+              (FieldInUnionOrSysHeader /*|| IsInLineStruct*/)) {
             std::string Rsn = "Union or external struct field encountered";
             CVarOption CV = Info.getVariable(F, Context);
             CB.constraintCVarToWild(CV, Rsn);
           }
         }
       }
+    }
+  }
+}
+
+void processVarDecl(VarDecl *VD, ProgramInfo &Info,
+                    ASTContext *Context, ConstraintResolver CB) {
+  if(lastRecord2 != nullptr) {
+    uint lastRecordLocation = lastRecord2->getBeginLoc().getRawEncoding();
+    uint BeginLoc = VD->getBeginLoc().getRawEncoding();
+    uint EndLoc = VD->getEndLoc().getRawEncoding();
+    auto VarTy = VD->getType();
+    bool IsInLineStruct =
+        lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc
+        && isPtrOrArrayType(VarTy);
+    bool IsNamedInLineStruct = IsInLineStruct
+                               && lastRecord2->getNameAsString() != "";
+    if (IsNamedInLineStruct) {
+      VDToRDMap2[VD] = lastRecord2;
+      inlines2.insert(VD);
+    }
+    else if (IsInLineStruct && !AllTypes) {
+      CVarOption CV = Info.getVariable(VD, Context);
+      CB.constraintCVarToWild(CV, "Inline struct encountered.");
+    }
+    else if (IsInLineStruct && AllTypes) {
+      clang::DiagnosticsEngine &DE = Context->getDiagnostics();
+      unsigned InlineStructWarning = DE.getCustomDiagID(
+          DiagnosticsEngine::Warning, "\n Rewriting failed"
+                                      "for %q0 because an inline "
+                                      "or anonymous struct instance "
+                                      "was detected.\n Consider manually "
+                                      "rewriting by inserting the struct "
+                                      "definition inside the _Ptr "
+                                      "annotation.\n "
+                                      "EX. struct {int *a; int *b;} x; "
+                                      "_Ptr<struct {int *a; _Ptr<int> b;}>;");
+      const auto Pointer = reinterpret_cast<intptr_t>(VD);
+      const auto Kind =
+          clang::DiagnosticsEngine::ArgumentKind::ak_nameddecl;
+      auto DiagBuilder = DE.Report(VD->getLocation(), InlineStructWarning);
+      DiagBuilder.AddTaggedVal(Pointer, Kind);
     }
   }
 }
@@ -83,17 +113,14 @@ public:
     // Introduce variables as needed.
     for (const auto &D : S->decls()) {
       if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
-        processRecordDecl(RD, Info, Context, CB, true);
+        processRecordDecl(RD, Info, Context, CB);
       }
       if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
         if (VD->isLocalVarDecl()) {
           FullSourceLoc FL = Context->getFullLoc(VD->getBeginLoc());
           SourceRange SR = VD->getSourceRange();
           if (SR.isValid() && FL.isValid() && isPtrOrArrayType(VD->getType())) {
-            if (LastRecordLocation == VD->getBeginLoc().getRawEncoding()) {
-              CVarOption CV = Info.getVariable(VD, Context);
-              CB.constraintCVarToWild(CV, "Inline struct encountered.");
-            }
+            processVarDecl(VD, Info, Context, CB);
           }
         }
       }
@@ -473,17 +500,8 @@ public:
       if (G->hasInit()) {
         CB.constrainLocalAssign(nullptr, G, G->getInit());
       }
-      // If the location of the previous RecordDecl and the current VarDecl
-      // coincide with one another, we constrain the VarDecl to be wild
-      // in order to allow the fields of the RecordDecl to be converted
-      unsigned int BeginLoc = G->getBeginLoc().getRawEncoding();
-      unsigned int EndLoc = G->getEndLoc().getRawEncoding();
-      if (LastRecordLocation >= BeginLoc && LastRecordLocation <= EndLoc) {
-        CVarOption CV = Info.getVariable(G, Context);
-        CB.constraintCVarToWild(CV, "Inline struct encountered.");
-      }
+      processVarDecl(G, Info, Context, CB);
     }
-
     return true;
   }
 
@@ -529,7 +547,7 @@ public:
   }
 
   bool VisitRecordDecl(RecordDecl *Declaration) {
-    processRecordDecl(Declaration, Info, Context, CB, false);
+    processRecordDecl(Declaration, Info, Context, CB);
     return true;
   }
 

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/DeclRewriter.h"
+#include "clang/3C/ConstraintBuilder.h"
 #include "clang/3C/3CGlobalOptions.h"
 #include "clang/3C/MappingVisitor.h"
 #include "clang/3C/RewriteUtils.h"
@@ -25,6 +26,10 @@
 
 using namespace llvm;
 using namespace clang;
+
+RecordDecl *lastRecord;
+static std::map<Decl *, Decl *> VDToRDMap;
+static std::set<Decl *> inlines;
 
 // This function is the public entry point for declaration rewriting.
 void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
@@ -77,8 +82,47 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
   for (const auto &I : Info.getVarMap())
     Keys.insert(I.first);
   MappingVisitor MV(Keys, Context);
-  for (const auto &D : TUD->decls())
+  for (const auto &D : TUD->decls()) {
     MV.TraverseDecl(D);
+    if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
+      if (RD->getNameAsString() != "")
+        lastRecord = RD;
+    }
+    if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
+      if(lastRecord == nullptr) continue;
+      uint lastRecordLocation = lastRecord->getBeginLoc().getRawEncoding();
+      auto VarTy = VD->getType();
+      uint BeginLoc = VD->getBeginLoc().getRawEncoding();
+      uint EndLoc = VD->getEndLoc().getRawEncoding();
+      bool IsInLineStruct = lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc;
+      if (IsInLineStruct) {
+        VDToRDMap[VD] = lastRecord;
+        inlines.insert(VD);
+      }
+    }
+    if(FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+      if (FD->hasBody() && FD->isThisDeclarationADefinition()) {
+        for (auto &D : FD->decls()) {
+          if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
+            if (RD->getNameAsString() != "")
+              lastRecord = RD;
+          }
+          if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
+            if (lastRecord == nullptr) continue;
+            uint lastRecordLocation = lastRecord->getBeginLoc().getRawEncoding();
+            auto VarTy = VD->getType();
+            uint BeginLoc = VD->getBeginLoc().getRawEncoding();
+            uint EndLoc = VD->getEndLoc().getRawEncoding();
+            bool IsInLineStruct = lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc;
+            if (IsInLineStruct) {
+              VDToRDMap[VD] = lastRecord;
+              inlines.insert(VD);
+            }
+          }
+        }
+      }
+    }
+  }
   SourceToDeclMapType PSLMap;
   VariableDecltoStmtMap VDLToStmtMap;
   std::tie(PSLMap, VDLToStmtMap) = MV.getResults();
@@ -208,6 +252,13 @@ void DeclRewriter::rewriteFieldOrVarDecl(DRType *N, RSet &ToRewrite) {
                     std::is_same<DRType, VarDeclReplacement>::value,
                 "Method expects variable or field declaration replacement.");
 
+  if (inlines.find(N->getDecl()) != inlines.end() && VisitedMultiDeclMembers.find(N) == VisitedMultiDeclMembers.end()) {
+    std::vector<Decl *> combo;
+    getDeclsOnSameLine(N, combo);
+    if (std::find(combo.begin(), combo.end(), VDToRDMap[N->getDecl()]) == combo.end())
+      combo.insert(combo.begin(), VDToRDMap[N->getDecl()]);
+    rewriteNamedInlineStruct(N, ToRewrite, combo);
+  }
   if (isSingleDeclaration(N)) {
     rewriteSingleDecl(N, ToRewrite);
   } else if (VisitedMultiDeclMembers.find(N) == VisitedMultiDeclMembers.end()) {
@@ -327,6 +378,122 @@ void DeclRewriter::rewriteMultiDecl(DeclReplacement *N, RSet &ToRewrite) {
     // are separate statements separated by a semicolon and a newline.
     SourceRange End = getNextCommaOrSemicolon(DL->getEndLoc());
     R.ReplaceText(End, ";\n");
+    // Offset by one to skip past what we've just added so it isn't overwritten.
+    PrevEnd = End.getEnd().getLocWithOffset(1);
+  }
+
+  // Step 3: Be sure and skip all of the declarations that we just dealt with by
+  //         adding them to the skip set.
+  for (const auto &TN : RewritesForThisDecl)
+    VisitedMultiDeclMembers.insert(TN);
+}
+
+void DeclRewriter::rewriteNamedInlineStruct(DeclReplacement *N, RSet &ToRewrite, std::vector<Decl *> SameLineDecls) {
+  //assert("Declaration is not a multi declaration." && !isSingleDeclaration(N));
+  // Rewriting is more difficult when there are multiple variables declared in a
+  // single statement. When this happens, we need to find all the declaration
+  // replacement for this statement and apply them at the same time. We also
+  // need to avoid rewriting any of these declarations twice by updating the
+  // Skip set to include the processed declarations.
+
+  // Step 1: get declaration replacement in the same statement
+//  bool IsSingleDecl = false;
+//  if (isSingleDeclaration(N))
+//     IsSingleDecl = true;
+  RSet RewritesForThisDecl(DComp(R.getSourceMgr()));
+  auto I = ToRewrite.find(N);
+  while (I != ToRewrite.end()) {
+    if (areDeclarationsOnSameLine(N, *I)) {
+      assert("Unexpected DeclReplacement kind." &&
+             (*I)->getKind() == N->getKind());
+      RewritesForThisDecl.insert(*I);
+    }
+    ++I;
+  }
+
+  // Step 2: For each decl in the original, build up a new string. If the
+  //         original decl was re-written, write that out instead. Existing
+  //         initializers are preserved, any declarations that an initializer to
+  //         be valid checked-c are given one.
+//  std::vector<Decl *> SameLineDecls;
+//  getDeclsOnSameLine(N, SameLineDecls);
+
+  bool IsFirst = true;
+  SourceLocation PrevEnd;
+  for (const auto &DL : SameLineDecls) {
+    std::string ReplaceText = ";\n";
+    // Find the declaration replacement object for the current declaration
+    DeclReplacement *SameLineReplacement;
+    bool Found = false;
+    for (const auto &NLT : RewritesForThisDecl)
+      if (NLT->getDecl() == DL) {
+        SameLineReplacement = NLT;
+        Found = true;
+        break;
+      }
+
+    if (IsFirst) {
+      // Rewriting the first declaration is easy. Nothing should change if its
+      // type does not to be rewritten. When rewriting is required, it is
+      // essentially the same as the single declaration case.
+      ReplaceText = "};\n";
+    } else {
+      // The subsequent decls are more complicated because we need to insert a
+      // type string even if the variables type hasn't changed.
+      if (Found) {
+        // If the type has changed, the DeclReplacement object has a replacement
+        // string stored in it that should be used.
+        SourceRange SR(PrevEnd, DL->getEndLoc());
+        doDeclRewrite(SR, SameLineReplacement);
+      } else {
+        // When the type hasn't changed, we still need to insert the original
+        // type for the variable.
+
+        // This is a bit of trickery needed to get a string representation of
+        // the declaration without the initializer. We don't want to rewrite to
+        // initializer because this causes problems when rewriting casts and
+        // generic function calls later on. (issue 267)
+        auto *VD = dyn_cast<VarDecl>(DL);
+        Expr *Init = nullptr;
+        if (VD && VD->hasInit()) {
+          Init = VD->getInit();
+          VD->setInit(nullptr);
+        }
+
+        // Dump the declaration (without the initializer) to a string. Printing
+        // the AST node gives the full declaration including the base type which
+        // is not present in the multi-decl source code.
+        std::string DeclStr = "";
+        raw_string_ostream DeclStream(DeclStr);
+        DL->print(DeclStream);
+        assert("Original decl string empty." && !DeclStream.str().empty());
+
+        // Do the replacement. PrevEnd is setup to be the source location of the
+        // comma after the previous declaration in the multi-decl. getEndLoc is
+        // either the end of the declaration or just before the initializer if
+        // one is present.
+        SourceRange SR(PrevEnd, DL->getEndLoc());
+        R.ReplaceText(SR, DeclStream.str());
+
+        // Undo prior trickery. This need to happen so that the PSL for the decl
+        // is not changed since the PSL is used as a map key in a few places.
+        if (VD && Init)
+          VD->setInit(Init);
+      }
+    }
+
+    // Variables in a mutli-decl are delimited by commas. The rewritten decls
+    // are separate statements separated by a semicolon and a newline.
+    SourceRange End;
+    if (IsFirst) {
+      IsFirst = false;
+      End = DL->getEndLoc();
+    }
+    else
+      End = getNextCommaOrSemicolon(DL->getEndLoc());
+    R.ReplaceText(End, ReplaceText);
+//    if (!IsSingleDecl)
+//      break;
     // Offset by one to skip past what we've just added so it isn't overwritten.
     PrevEnd = End.getEnd().getLocWithOffset(1);
   }

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -448,9 +448,12 @@ void DeclRewriter::rewriteFunctionDecl(FunctionDeclReplacement *N) {
 // A function to detect the presence of inline struct declarations
 // by tracking VarDecls and RecordDecls and populating data structures
 // later used in rewriting
-RecordDecl *DeclRewriter::LastRecordDecl = nullptr;
-std::map<Decl *, Decl *> DeclRewriter::VDToRDMap;
-std::set<Decl *> DeclRewriter::InlineVarDecls;
+
+// These variables are duplicated in the header file and here because
+// static vars need to be initialized in the cpp file where the class is defined
+/*static*/ RecordDecl *DeclRewriter::LastRecordDecl = nullptr;
+/*static*/ std::map<Decl *, Decl *> DeclRewriter::VDToRDMap;
+/*static*/ std::set<Decl *> DeclRewriter::InlineVarDecls;
 void DeclRewriter::detectInlineStruct(Decl *D, SourceManager &SM) {
   if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
     LastRecordDecl = RD;

--- a/clang/test/3C/alloc_type_param.c
+++ b/clang/test/3C/alloc_type_param.c
@@ -55,11 +55,10 @@ void buz() {
   struct {int a;} *b = malloc(10);
 	//CHECK: struct {int a;} *b = malloc(10);
 
-  /* Inline structs work just fine as long as they've been named.
-   Note that c isn't made checked due to limitation in how inline structs are converted.
-   If this test fails because it's made checked, that's great. */
+  /* Named inline structs can be separated and made checked */
   struct test {int a;} *c = malloc(sizeof(struct test));
-	//CHECK: struct test {int a;} *c = malloc<struct test>(sizeof(struct test));
+	//CHECK: struct test {int a;}; 
+  //CHECK: _Ptr<struct test> c = malloc<struct test>(sizeof(struct test));
 
   /* typedefs are also OK. */
   typedef struct {int a;} other;

--- a/clang/test/3C/inline_anon_structs.c
+++ b/clang/test/3C/inline_anon_structs.c
@@ -5,7 +5,7 @@
 // RUN: 3c -alltypes %S/inline_anon_structs.checked.c -- | count 0
 // RUN: rm %S/inline_anon_structs.checked.c
 
-
+#include <stdlib.h>
 /*This code ensures conversion happens as expected when 
 an inlinestruct and its associated VarDecl have different locations*/
 int valuable;
@@ -28,7 +28,8 @@ array[] =
 
  /* one decl; x rewrites to _Ptr<int> */
 struct foo1 { int *x; } *a;
-	//CHECK: struct foo1 { _Ptr<int> x; } *a;
+	//CHECK: struct foo1 { _Ptr<int> x; }; 
+	//CHECK: _Ptr<struct foo1> a = ((void *)0);
 
 struct baz { int *z; };
 	//CHECK: struct baz { _Ptr<int> z; };
@@ -36,11 +37,15 @@ struct baz *d;
 	//CHECK: _Ptr<struct baz> d = ((void *)0);
 
 struct bad { int* y; } *b, *c; 
-	//CHECK: struct bad { int* y; } *b, *c; 
+	//CHECK: struct bad { int* y; }; 
+	//CHECK: _Ptr<struct bad> b = ((void *)0);
+	//CHECK: _Ptr<struct bad> c = ((void *)0); 
 
  /* two decls, y should be converted */
 struct bar { int* y; } *e, *f;
-	//CHECK: struct bar { _Ptr<int> y; } *e, *f; 
+	//CHECK: struct bar { _Ptr<int> y; };
+	//CHECK: _Ptr<struct bar> e = ((void *)0);
+	//CHECK: _Ptr<struct bar> f = ((void *)0);
 
 
 void foo(void) {
@@ -86,7 +91,8 @@ struct {
 void foo2(int *x) {
 	//CHECK: void foo2(_Ptr<int> x) {
   struct bar { int *x; } *y = 0;
-	//CHECK: struct bar { _Ptr<int> x; } *y = 0; 
+	//CHECK: struct bar { _Ptr<int> x; }; 
+	//CHECK: _Ptr<struct bar> y = 0; 
 
   /*A non-pointer struct without an init will be marked wild*/
   struct something { int *x; } z; 

--- a/clang/test/3C/inline_anon_structs.c
+++ b/clang/test/3C/inline_anon_structs.c
@@ -58,11 +58,13 @@ void foo(void) {
 struct { 
 	/*the fields of the anonymous struct are free to be marked checked*/
     int *data; 
-	//CHECK_NOALL: int *data; 
-	//CHECK_ALL: _Array_ptr<int> data : count(4); 
+	//CHECK_NOALL: int *data;
 
-/* but the actual pointer can't be */
-} *x; 
+/* but the actual pointer can't be when alltypes is disabled */ 
+/* when alltypes is enabled, this whole structure is rewritten 
+   improperly, but that's OK, because we signal a warning to the user*/
+} *x;  
+//CHECK_ALL: _Ptr<struct> x = ((void *)0);
 
 /*ensure trivial conversion*/
 void foo1(int *w) { 
@@ -84,7 +86,7 @@ struct alpha *al[4];
 /*be should be made wild, whereas a should be converted*/
 struct {
   int *a;
-	//CHECK: _Ptr<int> a;
+	//CHECK_NOALL: _Ptr<int> a;
 } *be[4]; 
 
 /*this code checks inline structs withiin functions*/

--- a/clang/test/3C/inline_anon_structs.c
+++ b/clang/test/3C/inline_anon_structs.c
@@ -5,7 +5,9 @@
 // RUN: 3c -alltypes %S/inline_anon_structs.checked.c -- | count 0
 // RUN: rm %S/inline_anon_structs.checked.c
 
-#include <stdlib.h>
+#include <stddef.h>
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
 /*This code ensures conversion happens as expected when 
 an inlinestruct and its associated VarDecl have different locations*/
 int valuable;


### PR DESCRIPTION
This PR does several things: 
1. only marks inline (anonymous) structs wild when alltypes is disabled. 
2. instead issues a warning when alltypes is enabled 
3. splits named inline structs to two separate decls (works for both globally declared VarDecls and those declared within functions) 

Lessons learned: inline structs with global scope are treated as single decls (namely, the VarDecl), however inline structs within functions are treated as multi-decls (including both the RecordDecl *and* the VarDecl). This was a source of major blockage for me when debugging, so I'm putting this information here for now, but will document it officially tomorrow. (In fact, I think this might have something to do with why statement expressions #195 are also rewritten poorly, though its hard to tell).  

Explanations: Most of the meat of this PR comes with a new function in DeclRewriter called rewriteNamedInlineStructs. It borrows most of its internal logic from rewriteMultiDecl but with some changes. I think, in theory, it is possible to integrate the logic of this new function into rewriteMultiDecl (albeit with a bunch of if statements, etc) and considered it, but since rewriteMultiDecl seems pretty important, I decided to keep it unchanged.

Issues: the code is completely functional :), but rather ugly. Namely, in order to keep track of all the inline structs, I have to employ a bunch of preprocessing that already takes place in ConstraintBuilder. In status on the 4th of January, we mentioned using PSLs in ConstraintBuilder and unpacking them in DeclRewriter, which I will investigate for feasibility (since it might be that the packing/unpacking process actually ends up looking uglier than the current solution).  

Closes #363  
