### PR TITLE
Enable test compound_literal.c

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -803,8 +803,12 @@ std::string PointerVariableConstraint::mkString(const EnvironmentMap &E,
     Ss << " " << getName();
 
   // Final array dropping
-  if (!CheckedArrs.empty())
-    addArrayAnnotations(CheckedArrs, EndStrs);
+  if (!CheckedArrs.empty()) {
+    std::deque<std::string> ArrStrs;
+    addArrayAnnotations(CheckedArrs, ArrStrs);
+    for (std::string Str : ArrStrs)
+      Ss << Str;
+  }
 
   //TODO remove comparison to RETVAR
   if (getName() == RETVAR && !ForItype)

--- a/clang/test/3C/compound_literal.c
+++ b/clang/test/3C/compound_literal.c
@@ -1,10 +1,8 @@
-// XFAIL: *
-// Fails dues to issue microsoft#870 but fixed by pull request microsoft#899
 // RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -output-postfix=checked -alltypes %s
-// RUN: 3c -alltypes %S/compound_literal.checked.c -- | diff -w %S/compound_literal.checked.c -
+// RUN: 3c -alltypes %S/compound_literal.checked.c -- | count 0
 // RUN: rm %S/compound_literal.checked.c
 
 struct a {
@@ -37,7 +35,7 @@ void structs() {
 
   int d;
   int *faz = (int*)0;
-	//CHECK: _Ptr<int> faz =  (_Ptr<int> )0;
+	//CHECK: _Ptr<int> faz =  (_Ptr<int>)0;
   faz = (&(struct b){&d, (int*) 1})->a;
 	//CHECK: faz = (&(struct b){&d, (int*) 1})->a;
   int *fuz = (int*)0;
@@ -46,7 +44,7 @@ void structs() {
 
   int *f = (int*) 0;
 	//CHECK_NOALL: int *f = (int*) 0;
-	//CHECK_ALL:   _Array_ptr<int> f =  (_Array_ptr<int> ) 0;
+	//CHECK_ALL:   _Array_ptr<int> f =  (_Array_ptr<int>) 0;
   ((&(struct c){f})->a)++;
 }
 
@@ -108,7 +106,7 @@ void nested(int* x) {
 void silly(int *x) {
 	//CHECK: void silly(_Ptr<int> x) {
   int *a = (int*){x};
-	//CHECK: _Ptr<int> a =  (_Ptr<int> ){x};
+	//CHECK: _Ptr<int> a =  (_Ptr<int>){x};
 
   int *b = (int*){(int*) 1};
 	//CHECK: int *b = (int*){(int*) 1};


### PR DESCRIPTION
This test started failing due to issue microsoft#870 which was later fixed by PR microsoft#899. That pull request is now merged into our fork, so this test should be passing again. Another bug slipped into this test in PR #242 that caused constant array sizes to be dropped in compound literal expressions. This has also been fixed.