### PR TITLE
Refactor to include generic types info in VCs

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -268,11 +268,11 @@ private:
   // String representing declared bounds expression.
   std::string BoundsAnnotationStr;
 
-  // Does this variable represent a generic type?
+  // Does this variable represent a generic type? Which one (or -1 for none)?
   // Generic types can be used with fewer restrictions, so this field is used
-  // stop assignments wth generic variables from forcing constraint variables
+  // stop assignments with generic variables from forcing constraint variables
   // to be wild.
-  bool IsGeneric;
+  int GenericIndex;
 
   // Empty array pointers are represented the same as standard pointers. This
   // lets pointers be passed to functions expecting a zero width array. This
@@ -296,11 +296,11 @@ public:
   // Constructor for when we know a CVars and a type string.
   PointerVariableConstraint(CAtoms V, std::string T, std::string Name,
                             FunctionVariableConstraint *F, bool IsArr,
-                            bool IsItype, std::string Is, bool Generic = false)
+                            bool IsItype, std::string Is, int Generic = -1)
       : ConstraintVariable(PointerVariable, "" /*not used*/, Name), BaseType(T),
         Vars(V), FV(F), ArrPresent(IsArr), ItypeStr(Is),
         PartOfFuncPrototype(false), Parent(nullptr), BoundsAnnotationStr(""),
-        IsGeneric(Generic), IsZeroWidthArray(false) {}
+        GenericIndex(Generic), IsZeroWidthArray(false) {}
 
   std::string getTy() const { return BaseType; }
   bool getArrPresent() const { return ArrPresent; }
@@ -321,7 +321,7 @@ public:
   // Get bounds annotation.
   std::string getBoundsStr() const { return BoundsAnnotationStr; }
 
-  bool getIsGeneric() const { return IsGeneric; }
+  bool getIsGeneric() const { return GenericIndex >= 0; }
 
   bool getIsOriginallyChecked() const override {
     return llvm::any_of(Vars, [](Atom *A) { return isa<ConstAtom>(A); });
@@ -348,14 +348,14 @@ public:
   //          that all constructor calls will take the same global objects here.
   // inFunc: If this variable is part of a function prototype, this string is
   //         the name of the function. nullptr otherwise.
-  // IsGeneric: CheckedC supports generic types (_Itype_for_any) which need less
-  //            restrictive constraints. Set to true to indicate that this
+  // GenericIndex: CheckedC supports generic types (_Itype_for_any) which need
+  //            less restrictive constraints. Set >= 0 to indicate that this
   //            variable is generic.
   PointerVariableConstraint(const clang::QualType &QT, clang::DeclaratorDecl *D,
                             std::string N, ProgramInfo &I,
                             const clang::ASTContext &C,
                             std::string *InFunc = nullptr,
-                            bool IsGeneric = false);
+                            int Generic = -1);
 
   const CAtoms &getCvars() const { return Vars; }
 
@@ -436,6 +436,9 @@ private:
   FunctionVariableConstraint *Parent;
   // Flag to indicate whether this is a function pointer or not.
   bool IsFunctionPtr;
+
+  // Count of type parameters from `_Itype_for_any(...)`
+  int TypeParams;
 
   void equateFVConstraintVars(ConstraintVariable *CV, ProgramInfo &Info) const;
 

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -323,6 +323,7 @@ public:
 
   bool getIsGeneric() const { return GenericIndex >= 0; }
   int getGenericIndex() const { return GenericIndex; }
+  void setGenericIndex(int Idx) { GenericIndex = Idx; }
 
   bool getIsOriginallyChecked() const override {
     return llvm::any_of(Vars, [](Atom *A) { return isa<ConstAtom>(A); });

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -322,6 +322,7 @@ public:
   std::string getBoundsStr() const { return BoundsAnnotationStr; }
 
   bool getIsGeneric() const { return GenericIndex >= 0; }
+  int getGenericIndex() const { return GenericIndex; }
 
   bool getIsOriginallyChecked() const override {
     return llvm::any_of(Vars, [](Atom *A) { return isa<ConstAtom>(A); });
@@ -354,8 +355,7 @@ public:
   PointerVariableConstraint(const clang::QualType &QT, clang::DeclaratorDecl *D,
                             std::string N, ProgramInfo &I,
                             const clang::ASTContext &C,
-                            std::string *InFunc = nullptr,
-                            int Generic = -1);
+                            std::string *InFunc = nullptr);
 
   const CAtoms &getCvars() const { return Vars; }
 
@@ -482,6 +482,9 @@ public:
   }
 
   bool hasItype() const override;
+
+  int getGenericIndex() const { return ReturnVar->getGenericIndex(); }
+
   bool solutionEqualTo(Constraints &CS,
                        const ConstraintVariable *CV) const override;
 

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -323,7 +323,6 @@ public:
 
   bool getIsGeneric() const { return GenericIndex >= 0; }
   int getGenericIndex() const { return GenericIndex; }
-  void setGenericIndex(int Idx) { GenericIndex = Idx; }
 
   bool getIsOriginallyChecked() const override {
     return llvm::any_of(Vars, [](Atom *A) { return isa<ConstAtom>(A); });
@@ -350,13 +349,14 @@ public:
   //          that all constructor calls will take the same global objects here.
   // inFunc: If this variable is part of a function prototype, this string is
   //         the name of the function. nullptr otherwise.
-  // GenericIndex: CheckedC supports generic types (_Itype_for_any) which need
-  //            less restrictive constraints. Set >= 0 to indicate that this
-  //            variable is generic.
+  // ForceGenericIndex: CheckedC supports generic types (_Itype_for_any) which
+  //                    need less restrictive constraints. Set >= 0 to indicate
+  //                    that this variable should be considered generic.
   PointerVariableConstraint(const clang::QualType &QT, clang::DeclaratorDecl *D,
                             std::string N, ProgramInfo &I,
                             const clang::ASTContext &C,
-                            std::string *InFunc = nullptr);
+                            std::string *InFunc = nullptr,
+                            int ForceGenericIndex = -1);
 
   const CAtoms &getCvars() const { return Vars; }
 

--- a/clang/include/clang/3C/TypeVariableAnalysis.h
+++ b/clang/include/clang/3C/TypeVariableAnalysis.h
@@ -93,7 +93,6 @@ private:
   ConstraintResolver CR;
   TypeVariableMapT TVMap;
 
-  void insertBinding(CallExpr *CE, const TypeVariableType *TyV, QualType Ty,
-                     CVarSet &CVs);
+  void insertBinding(CallExpr *CE, const int TyIdx, QualType Ty, CVarSet &CVs);
 };
 #endif

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -164,8 +164,6 @@ std::string getSourceText(const clang::SourceRange &SR,
 unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
                                   unsigned long Str1Len, unsigned long Str2Len);
 
-const int getTypeVariableIndex(clang::DeclaratorDecl *Decl);
-
 bool isTypeAnonymous(const clang::Type *T);
 
 // Find the index of parameter PV in the parameter list of function FD.

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -164,7 +164,7 @@ std::string getSourceText(const clang::SourceRange &SR,
 unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
                                   unsigned long Str1Len, unsigned long Str2Len);
 
-const clang::TypeVariableType *getTypeVariableType(clang::DeclaratorDecl *Decl);
+const int getTypeVariableIndex(clang::DeclaratorDecl *Decl);
 
 bool isTypeAnonymous(const clang::Type *T);
 

--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -35,12 +35,12 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
         TypeVars = Info.getTypeParamBindings(CE, Context);
       unsigned PIdx = 0;
       for (const auto &A : CE->arguments()) {
-        if (PIdx < FD->getNumParams()) {
+        if (PIdx < FV->numParams()) {
           // Avoid adding incorrect casts to generic function arguments by
           // removing implicit casts when on arguments with a consistently
           // used generic type.
           Expr *ArgExpr = A;
-          const int TyVarIdx = getTypeVariableIndex(FD->getParamDecl(PIdx));
+          const int TyVarIdx = FV->getParamVar(PIdx)->getGenericIndex();
           if (TypeVars.find(TyVarIdx) != TypeVars.end() &&
               TypeVars[TyVarIdx] != nullptr)
             ArgExpr = ArgExpr->IgnoreImpCasts();

--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -40,10 +40,9 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
           // removing implicit casts when on arguments with a consistently
           // used generic type.
           Expr *ArgExpr = A;
-          const TypeVariableType *TyVar =
-              getTypeVariableType(FD->getParamDecl(PIdx));
-          if (TyVar && TypeVars.find(TyVar->GetIndex()) != TypeVars.end() &&
-              TypeVars[TyVar->GetIndex()] != nullptr)
+          const int TyVarIdx = getTypeVariableIndex(FD->getParamDecl(PIdx));
+          if (TypeVars.find(TyVarIdx) != TypeVars.end() &&
+              TypeVars[TyVarIdx] != nullptr)
             ArgExpr = ArgExpr->IgnoreImpCasts();
 
           CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -216,9 +216,8 @@ public:
             if (TFD != nullptr && I < TFD->getNumParams()) {
               // Remove casts to void* on polymorphic types that are used
               // consistently.
-              const auto *Ty = getTypeVariableType(TFD->getParamDecl(I));
-              if (Ty != nullptr && ConsistentTypeParams.find(Ty->GetIndex()) !=
-                                       ConsistentTypeParams.end())
+              const int TyIdx = getTypeVariableIndex(TFD->getParamDecl(I));
+              if (ConsistentTypeParams.find(TyIdx) != ConsistentTypeParams.end())
                 ArgumentConstraints =
                     CB.getExprConstraintVars(A->IgnoreImpCasts());
               else

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -213,10 +213,10 @@ public:
           std::vector<CVarSet> Deferred;
           for (const auto &A : E->arguments()) {
             CVarSet ArgumentConstraints;
-            if (TFD != nullptr && I < TFD->getNumParams()) {
+            if (I < TargetFV->numParams()) {
               // Remove casts to void* on polymorphic types that are used
               // consistently.
-              const int TyIdx = getTypeVariableIndex(TFD->getParamDecl(I));
+              const int TyIdx = TargetFV->getParamVar(I)->getGenericIndex();
               if (ConsistentTypeParams.find(TyIdx) != ConsistentTypeParams.end())
                 ArgumentConstraints =
                     CB.getExprConstraintVars(A->IgnoreImpCasts());

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -448,7 +448,7 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
               N = "&" + N;
               ExprType = Context->getPointerType(ArgTy);
               PVConstraint *PVC = new PVConstraint(ExprType, nullptr, N, Info,
-                                                   *Context, nullptr, true);
+                                                   *Context, nullptr);
               PVC->constrainOuterTo(CS, A, true);
               ReturnCVs.insert(PVC);
               DidInsert = true;
@@ -506,7 +506,7 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
             // constructor.
             NewCV =
                 new PVConstraint(CE->getType(), nullptr, PCV->getName(), Info,
-                                 *Context, nullptr, PCV->getIsGeneric());
+                                 *Context, nullptr);
             if (PCV->hasBoundsKey())
               NewCV->setBoundsKey(PCV->getBoundsKey());
           } else {

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -449,6 +449,7 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
               ExprType = Context->getPointerType(ArgTy);
               PVConstraint *PVC = new PVConstraint(ExprType, nullptr, N, Info,
                                                    *Context, nullptr);
+              PVC->setGenericIndex(0);
               PVC->constrainOuterTo(CS, A, true);
               ReturnCVs.insert(PVC);
               DidInsert = true;
@@ -504,9 +505,11 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
             // had a checked type in the input program because the constraint
             // variables contain constant atoms that are reused by the copy
             // constructor.
-            NewCV =
+            auto *NewPCV =
                 new PVConstraint(CE->getType(), nullptr, PCV->getName(), Info,
                                  *Context, nullptr);
+            NewPCV->setGenericIndex(PCV->getGenericIndex());
+            NewCV = NewPCV;
             if (PCV->hasBoundsKey())
               NewCV->setBoundsKey(PCV->getBoundsKey());
           } else {

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -448,8 +448,7 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
               N = "&" + N;
               ExprType = Context->getPointerType(ArgTy);
               PVConstraint *PVC = new PVConstraint(ExprType, nullptr, N, Info,
-                                                   *Context, nullptr);
-              PVC->setGenericIndex(0);
+                                                   *Context, nullptr, 0);
               PVC->constrainOuterTo(CS, A, true);
               ReturnCVs.insert(PVC);
               DidInsert = true;
@@ -507,8 +506,7 @@ CVarSet ConstraintResolver::getExprConstraintVars(Expr *E) {
             // constructor.
             auto *NewPCV =
                 new PVConstraint(CE->getType(), nullptr, PCV->getName(), Info,
-                                 *Context, nullptr);
-            NewPCV->setGenericIndex(PCV->getGenericIndex());
+                                 *Context, nullptr, PCV->getGenericIndex());
             NewCV = NewPCV;
             if (PCV->hasBoundsKey())
               NewCV->setBoundsKey(PCV->getBoundsKey());

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1691,6 +1691,8 @@ void PointerVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV,
   Vars = NewVatoms;
   if (!From->ItypeStr.empty())
     ItypeStr = From->ItypeStr;
+  if (From->GenericIndex >= 0)
+    GenericIndex = From->GenericIndex;
   if (FV) {
     assert(From->FV);
     FV->mergeDeclaration(From->FV, Info, ReasonFailed);

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -891,6 +891,7 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
   FileName = "";
   HasEqArgumentConstraints = false;
   IsFunctionPtr = true;
+  TypeParams = 0;
 
   // Metadata about function
   FunctionDecl *FD = nullptr;
@@ -937,7 +938,11 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
           PName = PVD->getName();
         }
       }
-      ParamVars.push_back(new PVConstraint(QT, ParmVD, PName, I, Ctx, &N));
+      auto *ParamVar = new PVConstraint(QT, ParmVD, PName, I, Ctx, &N);
+      int GenericIdx = ParamVar->getGenericIndex();
+      if (GenericIdx >= 0)
+        TypeParams = std::max(TypeParams, GenericIdx + 1);
+      ParamVars.push_back(ParamVar);
     }
 
     Hasproto = true;
@@ -950,7 +955,11 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
   }
 
   // ConstraintVariable for the return
-  ReturnVar = new PVConstraint(RT, D, RETVAR, I, Ctx, &N);
+  auto *ReturnVC = new PVConstraint(RT, D, RETVAR, I, Ctx, &N);
+  int GenericIdx = ReturnVC->getGenericIndex();
+  if (GenericIdx >= 0)
+    TypeParams = std::max(TypeParams, GenericIdx + 1);
+  ReturnVar = ReturnVC;
 }
 
 void FunctionVariableConstraint::constrainToWild(Constraints &CS,

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -497,7 +497,7 @@ void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
   // Special-case for va_list, constrain to wild.
   bool IsGeneric = false;
   if (auto *PVD = dyn_cast<ParmVarDecl>(D))
-    IsGeneric = getTypeVariableType(PVD) != nullptr;
+    IsGeneric = getTypeVariableIndex(PVD) >= 0;
   if (isVarArgType(D->getType().getAsString()) ||
       (hasVoidType(D) && !IsGeneric)) {
     // set the reason for making this variable WILD.

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -496,8 +496,16 @@ bool ProgramInfo::insertNewFVConstraint(FunctionDecl *FD, FVConstraint *FVCon,
 void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
   // Special-case for va_list, constrain to wild.
   bool IsGeneric = false;
-  if (auto *PVD = dyn_cast<ParmVarDecl>(D))
-    IsGeneric = getTypeVariableIndex(PVD) >= 0;
+  PVConstraint *PVC = nullptr;
+
+  CVarOption CVOpt = getVariable(D, Context);
+  if (CVOpt.hasValue()) {
+    ConstraintVariable &CV = CVOpt.getValue();
+    PVC = dyn_cast<PVConstraint>(&CV);
+  }
+
+  if (isa<ParmVarDecl>(D))
+    IsGeneric = PVC && PVC->getIsGeneric();
   if (isVarArgType(D->getType().getAsString()) ||
       (hasVoidType(D) && !IsGeneric)) {
     // set the reason for making this variable WILD.
@@ -505,12 +513,8 @@ void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
     PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(D, *Context);
     if (!D->getType()->isVoidType())
       Rsn = "Variable type is va_list.";
-    CVarOption CVOpt = getVariable(D, Context);
-    if (CVOpt.hasValue()) {
-      ConstraintVariable &CV = CVOpt.getValue();
-      if (PVConstraint *PVC = dyn_cast<PVConstraint>(&CV))
-        PVC->constrainToWild(CS, Rsn, &PL);
-    }
+    if (PVC != nullptr)
+      PVC->constrainToWild(CS, Rsn, &PL);
   }
 }
 

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -121,6 +121,7 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
             FD->getNameAsString() + "_tyarg_" + std::to_string(TVEntry.first);
         PVConstraint *P = new PVConstraint(TVEntry.second.getType(), nullptr,
                                            Name, Info, *Context, nullptr);
+        P->setGenericIndex(TVEntry.first);
 
         // Constrain this variable GEQ the function arguments using the type
         // variable so if any of them are wild, the type argument will also be

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -73,34 +73,40 @@ bool TypeVarVisitor::VisitCastExpr(CastExpr *CE) {
     SubExpr = TempE->getSubExpr();
 
   if (auto *Call = dyn_cast<CallExpr>(SubExpr))
-    if (auto *FD = dyn_cast_or_null<FunctionDecl>(Call->getCalleeDecl())) {
-      const int TyIdx = getTypeVariableIndex(FD);
-      if (TyIdx >= 0) {
-        clang::QualType Ty = CE->getType();
-        std::set<ConstraintVariable *> CVs = CR.getExprConstraintVars(SubExpr);
-        insertBinding(Call, TyIdx, Ty, CVs);
-      }
-    }
+    if (auto *FD = dyn_cast_or_null<FunctionDecl>(Call->getCalleeDecl()))
+      if (auto FDDef = getDefinition(FD))
+        if (auto *FVCon = Info.getFuncConstraint(FDDef, Context)) {
+          const int TyIdx = FVCon->getGenericIndex();
+          if (TyIdx >= 0) {
+            clang::QualType Ty = CE->getType();
+            std::set<ConstraintVariable *> CVs =
+                CR.getExprConstraintVars(SubExpr);
+            insertBinding(Call, TyIdx, Ty, CVs);
+          }
+        }
   return true;
 }
 
 bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
   if (FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl())) {
-    // Visit each function argument, and if it use a type variable, insert it
-    // into the type variable binding map.
-    unsigned int I = 0;
-    for (auto *const A : CE->arguments()) {
-      // This can happen with varargs
-      if (I >= FD->getNumParams())
-        break;
-      const int TyIdx = getTypeVariableIndex(FD->getParamDecl(I));
-      if (TyIdx >= 0) {
-        Expr *Uncast = A->IgnoreImpCasts();
-        std::set<ConstraintVariable *> CVs = CR.getExprConstraintVars(Uncast);
-        insertBinding(CE, TyIdx, Uncast->getType(), CVs);
+    if (auto FDDef = getDefinition(FD))
+      if (auto *FVCon = Info.getFuncConstraint(FDDef, Context)) {
+        // Visit each function argument, and if it use a type variable, insert it
+        // into the type variable binding map.
+        unsigned int I = 0;
+        for (auto *const A : CE->arguments()) {
+          // This can happen with varargs
+          if (I >= FVCon->numParams())
+            break;
+          const int TyIdx = FVCon->getParamVar(I)->getGenericIndex();
+          if (TyIdx >= 0) {
+            Expr *Uncast = A->IgnoreImpCasts();
+            std::set<ConstraintVariable *> CVs = CR.getExprConstraintVars(Uncast);
+            insertBinding(CE, TyIdx, Uncast->getType(), CVs);
+          }
+          ++I;
+        }
       }
-      ++I;
-    }
 
     // For each type variable added above, make a new constraint variable to
     // remember the solved pointer type.

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -120,8 +120,8 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
         std::string Name =
             FD->getNameAsString() + "_tyarg_" + std::to_string(TVEntry.first);
         PVConstraint *P = new PVConstraint(TVEntry.second.getType(), nullptr,
-                                           Name, Info, *Context, nullptr);
-        P->setGenericIndex(TVEntry.first);
+                                           Name, Info, *Context, nullptr,
+                                           TVEntry.first);
 
         // Constrain this variable GEQ the function arguments using the type
         // variable so if any of them are wild, the type argument will also be

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -359,25 +359,6 @@ unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
                   longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len));
 }
 
-// Get the type variable index used in a parameter declaration, or return -1
-// if no type variable is used or the declaration is null.
-const int getTypeVariableIndex(DeclaratorDecl *Decl) {
-  if (Decl == nullptr) return -1;
-  // This makes a lot of assumptions about how the AST will look.
-  if (auto *ITy = Decl->getInteropTypeExpr()) {
-    const auto *Ty = ITy->getType().getTypePtr();
-    if (Ty && Ty->isPointerType()) {
-      auto *PtrTy = Ty->getPointeeType().getTypePtr();
-      if (auto *TypdefTy = dyn_cast_or_null<TypedefType>(PtrTy)) {
-        const TypeVariableType *Tv =
-            dyn_cast<TypeVariableType>(TypdefTy->desugar());
-        return Tv ? Tv->GetIndex() : -1;
-      }
-    }
-  }
-  return -1;
-}
-
 bool isTypeAnonymous(const clang::Type *T) {
   return T->isRecordType() &&
          !(T->getAsRecordDecl()->getIdentifier() ||

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -359,19 +359,20 @@ unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
                   longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len));
 }
 
-// Get the type variable used in a parameter declaration, or return null if no
-// type variable is used.
-const TypeVariableType *getTypeVariableType(DeclaratorDecl *Decl) {
+// Get the type variable index used in a parameter declaration, or return -1
+// if no type variable is used or the declaration is null.
+const int getTypeVariableIndex(DeclaratorDecl *Decl) {
+  if (Decl == nullptr) return -1;
   // This makes a lot of assumptions about how the AST will look.
   if (auto *ITy = Decl->getInteropTypeExpr()) {
     const auto *Ty = ITy->getType().getTypePtr();
     if (Ty && Ty->isPointerType()) {
       auto *PtrTy = Ty->getPointeeType().getTypePtr();
       if (auto *TypdefTy = dyn_cast_or_null<TypedefType>(PtrTy))
-        return dyn_cast<TypeVariableType>(TypdefTy->desugar());
+        return dyn_cast<TypeVariableType>(TypdefTy->desugar())->GetIndex();
     }
   }
-  return nullptr;
+  return -1;
 }
 
 bool isTypeAnonymous(const clang::Type *T) {

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -368,8 +368,11 @@ const int getTypeVariableIndex(DeclaratorDecl *Decl) {
     const auto *Ty = ITy->getType().getTypePtr();
     if (Ty && Ty->isPointerType()) {
       auto *PtrTy = Ty->getPointeeType().getTypePtr();
-      if (auto *TypdefTy = dyn_cast_or_null<TypedefType>(PtrTy))
-        return dyn_cast<TypeVariableType>(TypdefTy->desugar())->GetIndex();
+      if (auto *TypdefTy = dyn_cast_or_null<TypedefType>(PtrTy)) {
+        const TypeVariableType *Tv =
+            dyn_cast<TypeVariableType>(TypdefTy->desugar());
+        return Tv ? Tv->GetIndex() : -1;
+      }
     }
   }
   return -1;


### PR DESCRIPTION
Change the generic flag to an index, and have other functions rely on this index rather than regenerating it from decl itypes. This is in preparation for changing these indexes in TypeVariableAnalysis later, so that we can i.e. change `void *` to `T *`.

All other functionality remains unchanged. Regression tests are unaffected.