### PR TITLE
Make 3c depend on the system headers (original and Checked C).

### DIFF
--- a/clang/tools/3c/CMakeLists.txt
+++ b/clang/tools/3c/CMakeLists.txt
@@ -23,5 +23,13 @@ target_link_libraries(3c
   )
 target_include_directories(3c PUBLIC)
 
+# Based on clang/tools/driver/CMakeLists.txt
+add_dependencies(3c clang-resource-headers)
+
+if (CHECKEDC_IN_TREE)
+  add_dependencies(3c checkedc-headers)
+endif()
+# End of part based on clang/tools/driver/CMakeLists.txt
+
 install(TARGETS 3c
   RUNTIME DESTINATION bin)


### PR DESCRIPTION
[Discussed here](https://correct-computation.slack.com/archives/G01GKGKHMFD/p1610556664015500?thread_ts=1610553768.008000&cid=G01GKGKHMFD).  `ninja check-clang-3c` passes (I couldn't foresee any way this change could break it).