### PR TITLE
Fixing inline struct rewriting bug on vsftpd

### DIFF
--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -77,6 +77,7 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
   for (const auto &I : Info.getVarMap())
     Keys.insert(I.first);
   MappingVisitor MV(Keys, Context);
+  LastRecordDecl = nullptr;
   for (const auto &D : TUD->decls()) {
     MV.TraverseDecl(D);
     detectInlineStruct(D, Context.getSourceManager());


### PR DESCRIPTION
Nulls out the static field LastRecordDecl, publishing as a PR to get the go-ahead that this fix actually addresses the vsftpd vulnerability. 