### PR TITLE
Fix function rewriting with r-paren between prototype and definition

### DIFF
--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -132,9 +132,9 @@ public:
           End = BoundsEnd;
       }
 
-      // If there's an itype, this also comes would also come after the right
-      // paren. In the case that there is a bounds expression and an itype,
-      // then we need check which is later in the file.
+      // If there's an itype, this also comes after the right paren. In the case
+      // that there is both a bounds expression and an itype, we need check
+      // which is later in the file and use that as the declaration end.
       if (auto *InteropE = Decl->getInteropTypeExpr()) {
         SourceLocation InteropEnd = InteropE->getEndLoc();
         if (InteropEnd.isValid() &&

--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -97,7 +97,7 @@ public:
     }
     if (!TSInfo || TypeLoc.isNull())
       return SourceRange(Decl->getBeginLoc(),
-                         getFunctionDeclarationEnd(Decl, SM));
+                         getFunctionDeclRParen(Decl, SM));
 
     // Function pointer are funky, and require special handling to rewrite the
     // return type.
@@ -129,7 +129,7 @@ public:
       // SourceLocations are weird and turn up invalid for reasons I don't
       // understand. Fallback to the original FunctionDecl end function.
       if (!End.isValid())
-        End = getFunctionDeclarationEnd(Decl, SM);
+        End = getFunctionDeclRParen(Decl, SM);
     } else {
       End = Decl->getReturnTypeSourceRange().getEnd();
     }

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -133,8 +133,8 @@ bool isStructOrUnionType(clang::VarDecl *VD);
 std::string tyToStr(const clang::Type *T);
 
 // Get the end source location of the end of the provided function.
-clang::SourceLocation getFunctionDeclarationEnd(clang::FunctionDecl *FD,
-                                                clang::SourceManager &S);
+clang::SourceLocation getFunctionDeclRParen(clang::FunctionDecl *FD,
+                                            clang::SourceManager &S);
 
 // Remove auxillary casts from the provided expression.
 clang::Expr *removeAuxillaryCasts(clang::Expr *SrcExpr);

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -713,8 +713,8 @@ FunctionDeclBuilder::buildDeclVar(PVConstraint *IntCV, PVConstraint *ExtCV,
     IType = "";
   } else {
     Type = ExtCV->getOriginalTy() + " ";
-    IType =
-      getExistingIType(ExtCV) + ABRewriter.getBoundsString(ExtCV, Decl, false);
+    IType = getExistingIType(ExtCV);
+    IType += ABRewriter.getBoundsString(ExtCV, Decl, !IType.empty());
   }
 }
 

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -56,7 +56,16 @@ FunctionDecl *getDefinition(FunctionDecl *FD) {
   return nullptr;
 }
 
-SourceLocation getFunctionDeclarationEnd(FunctionDecl *FD, SourceManager &S) {
+// Get the source location for the right paren of a function declaration
+// using the source character data buffer. Because this uses the character
+// buffer directly, it sees character data prior to preprocessing. This
+// means characters that are in comments, macros or otherwise not part of the
+// final preprocessed source code are seen and can cause this function to give
+// an incorrect result. This should only be used as a fall back for when the
+// clang library function FunctionTypeLoc::getRParenLoc cannot be called due to
+// a null FunctionTypeLoc or for when the function returns an invalid source
+// location.
+SourceLocation getFunctionDeclRParen(FunctionDecl *FD, SourceManager &S) {
   const FunctionDecl *OFd = nullptr;
 
   if (FD->hasBody(OFd) && OFd == FD) {

--- a/clang/test/3C/functionDeclEnd.c
+++ b/clang/test/3C/functionDeclEnd.c
@@ -1,0 +1,135 @@
+// RUN: 3c -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -addcr -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -alltypes -output-postfix=checked %s
+// RUN: 3c -alltypes %S/functionDeclEnd.checked.c | count 0
+// RUN: rm %S/functionDeclEnd.checked.c
+
+
+// Tests for issue 392. When rewriting function prototypes sometimes code
+// falling between the start of the definition and the end of the prototype
+// could be deleted.
+// NOTE: Tests in this file assume that code in the branch of the preprocessor
+// directive that is not taken will not be rewritten. It might be desirable to
+// eventually rewrite in both branches. See issue 374.
+
+#define FOO
+
+#ifdef FOO
+void test0(int *a)
+// CHECK: void test0(_Ptr<int> a)
+#else
+void test0(int *a)
+#endif
+// CHECK: #else
+// CHECK: void test0(int *a)
+// CHECK: #endif
+{
+// CHECK: _Checked {
+  return;
+}
+
+#ifdef FOO
+int *test1()
+// CHECK: _Ptr<int> test1(void)
+#else
+int *test1()
+#endif
+// CHECK: #else
+// CHECK: int *test1()
+// CHECK: #endif
+{
+// CHECK: _Checked {
+  return 0;
+}
+
+#ifdef FOO
+int *test2()
+// CHECK: int *test2(void) : itype(_Ptr<int>)
+#else
+int *test2()
+#endif
+// CHECK: #else
+// CHECK: int *test2()
+// CHECK: #endif
+{
+// CHECK: {
+  int *a = 1;
+  return a;
+}
+
+
+// These test for rewriting with existing itype and bounds expression are
+// particularly important because they break the simplest fix where
+// getRParenLoc is always used.
+
+#ifdef FOO
+int *test3(int *a, int l) : itype(_Array_ptr<int>) count(l)
+// CHECK: int *test3(_Ptr<int> a, int l) : itype(_Array_ptr<int>) count(l)
+#else
+int *test3(int *a, int l) : itype(_Array_ptr<int>) count(l)
+#endif
+// CHECK: #else
+// CHECK: int *test3(int *a, int l) : itype(_Array_ptr<int>) count(l)
+// CHECK: #endif
+{
+// CHECK: {
+  int *b = 1;
+  return b;
+}
+
+#ifdef FOO
+int *test4(int *a) : itype(_Ptr<int>)
+// CHECK: int *test4(_Ptr<int> a) : itype(_Ptr<int>)
+#else
+int *test4(int *a) : itype(_Ptr<int>)
+#endif
+// CHECK: #else
+// CHECK: int *test4(int *a) : itype(_Ptr<int>)
+// CHECK: #endif
+{
+// CHECK: {
+  int *b = 1;
+  return b;
+}
+
+#ifdef FOO
+_Array_ptr<int> test5(int *a, int l) : count(l)
+// CHECK: _Array_ptr<int> test5(_Ptr<int> a, int l) : count(l)
+#else
+_Array_ptr<int> test5(int *a, int l) : count(l)
+#endif
+// CHECK: #else
+// CHECK: _Array_ptr<int> test5(int *a, int l) : count(l)
+// CHECK: #endif
+{
+// CHECK: _Checked {
+  return 0;
+}
+
+void test6(int *a)
+// A comment ( with parentheses ) that shouldn't be deleted
+// CHECK: void test6(_Ptr<int> a)
+// CHECK: // A comment ( with parentheses ) that shouldn't be deleted
+{
+  *a = 1;
+}
+
+#ifdef FOO
+int *test7(int *a) : count(10)
+//CHECK_NOALL: int *test7(int *a : itype(_Ptr<int>)) : count(10)
+//CHECK_ALL: int *test7(_Array_ptr<int> a) : count(10)
+#else
+int *test7(int *a) : count(10)
+#endif
+;
+//CHECK: #else
+//CHECK: int *test7(int *a) : count(10)
+//CHECK: #endif
+//CHECK: ;
+
+int *test7(int *a) : count(10) {
+//CHECK_ALL: int *test7(_Array_ptr<int> a) : count(10) _Checked {
+//CHECK_NOALL: int *test7(int *a : itype(_Ptr<int>)) : count(10) {
+  return a;
+}

--- a/clang/test/3C/functionDeclEnd.c
+++ b/clang/test/3C/functionDeclEnd.c
@@ -133,3 +133,22 @@ int *test7(int *a) : count(10) {
 //CHECK_NOALL: int *test7(int *a : itype(_Ptr<int>)) : count(10) {
   return a;
 }
+
+// This test cast checks that the itype is overwritten even when it appears
+// after the count. Unfortunately, the count and itype are reversed on
+// rewriting. This isn't great since it's an unnecessary change to the code,
+// but it is still valid.
+#ifdef FOO
+int *test8(int *a, int l) : count(l) itype(_Array_ptr<int>)
+// CHECK: int *test8(_Ptr<int> a, int l) : itype(_Array_ptr<int>) count(l)
+#else
+int *test8(int *a, int l) : count(l) itype(_Array_ptr<int>)
+#endif
+// CHECK: #else
+// CHECK: int *test8(int *a, int l) : count(l) itype(_Array_ptr<int>)
+// CHECK: #endif
+{
+// CHECK: {
+  int *b = 1;
+  return b;
+}


### PR DESCRIPTION

Fixes #392. A right parentheses appearing between a function prototype and the
beginning of its definition caused anything falling between the
parenthesis and the actual end of the prototype to be deleted. This
problem is fixed by using clang provided source locations instead of
locating the closing parenthesis by iterating of the source code
characters.