### PR TITLE
Add a flag to downgrade the "unwritable change" error to a warning.

### DIFF
--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -72,6 +72,7 @@ struct _3COptions {
   bool VerifyDiagnosticOutput;
 
   bool DumpUnwritableChanges;
+  bool AllowUnwritableChanges;
 };
 
 // The main interface exposed by the 3C to interact with the tool.

--- a/clang/include/clang/3C/3CGlobalOptions.h
+++ b/clang/include/clang/3C/3CGlobalOptions.h
@@ -29,6 +29,7 @@ extern bool AddCheckedRegions;
 extern bool WarnRootCause;
 extern bool WarnAllRootCause;
 extern bool DumpUnwritableChanges;
+extern bool AllowUnwritableChanges;
 
 #ifdef FIVE_C
 extern bool RemoveItypes;

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -56,6 +56,7 @@ bool WarnAllRootCause;
 std::set<std::string> FilePaths;
 bool VerifyDiagnosticOutput;
 bool DumpUnwritableChanges;
+bool AllowUnwritableChanges;
 
 #ifdef FIVE_C
 bool RemoveItypes;
@@ -216,6 +217,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   WarnAllRootCause = CCopt.WarnAllRootCause;
   VerifyDiagnosticOutput = CCopt.VerifyDiagnosticOutput;
   DumpUnwritableChanges = CCopt.DumpUnwritableChanges;
+  AllowUnwritableChanges = CCopt.AllowUnwritableChanges;
 
 #ifdef FIVE_C
   RemoveItypes = CCopt.RemoveItypes;

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -142,6 +142,9 @@ static void emit(Rewriter &R, ASTContext &C, std::string &OutputPostfix) {
     if (const FileEntry *FE = SM.getFileEntryForID(Buffer->first)) {
       assert(FE->isValid());
 
+      DiagnosticsEngine::Level UnwritableChangeDiagnosticLevel =
+          AllowUnwritableChanges ? DiagnosticsEngine::Warning
+                                 : DiagnosticsEngine::Error;
       auto MaybeDumpUnwritableChange = [&]() {
         if (DumpUnwritableChanges) {
           errs() << "=== Beginning of new version of " << FE->getName() << " ===\n";
@@ -164,7 +167,7 @@ static void emit(Rewriter &R, ASTContext &C, std::string &OutputPostfix) {
       if (!canWrite(FeAbsS)) {
         DiagnosticsEngine &DE = C.getDiagnostics();
         unsigned ID = DE.getCustomDiagID(
-            DiagnosticsEngine::Error,
+            UnwritableChangeDiagnosticLevel,
             "3C internal error: 3C generated changes to this file even though it "
             "is not allowed to write to the file "
             "(https://github.com/correctcomputation/checkedc-clang/issues/387)");
@@ -185,7 +188,7 @@ static void emit(Rewriter &R, ASTContext &C, std::string &OutputPostfix) {
         } else {
           DiagnosticsEngine &DE = C.getDiagnostics();
           unsigned ID = DE.getCustomDiagID(
-              DiagnosticsEngine::Error,
+              UnwritableChangeDiagnosticLevel,
               "3C generated changes to this file, which is under the base dir "
               "but is not the main file and thus cannot be written in stdout "
               "mode");

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -144,6 +144,17 @@ static cl::opt<bool> OptDumpUnwritableChanges(
              "of the file to stderr for troubleshooting."),
     cl::init(false), cl::cat(_3CCategory));
 
+static cl::opt<bool> OptAllowUnwritableChanges(
+    "allow-unwritable-changes",
+    cl::desc("When 3C generates changes to a file it cannot write (due to "
+             "stdout mode or implementation limitations), issue a warning "
+             "instead of an error. This option is intended to be used "
+             "temporarily until you fix the root cause of the problem (by "
+             "correcting your usage of stdout mode or reporting the "
+             "implementation limitation to the 3C team to get it fixed) and "
+             "may be removed in the future."),
+    cl::init(false), cl::cat(_3CCategory));
+
 #ifdef FIVE_C
 static cl::opt<bool> OptRemoveItypes(
     "remove-itypes",
@@ -186,6 +197,7 @@ int main(int argc, const char **argv) {
   CcOptions.WarnAllRootCause = OptWarnAllRootCause;
   CcOptions.VerifyDiagnosticOutput = OptVerifyDiagnosticOutput;
   CcOptions.DumpUnwritableChanges = OptDumpUnwritableChanges;
+  CcOptions.AllowUnwritableChanges = OptAllowUnwritableChanges;
 
 #ifdef FIVE_C
   CcOptions.RemoveItypes = OptRemoveItypes;


### PR DESCRIPTION
I hope this change is simple enough and decoupled enough from our other work that it doesn't need a regression test. I tested it once manually.