### PR TITLE
Handle function declaration appearing after definition (fix #399)

### DIFF
--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -169,15 +169,13 @@ private:
   TypeParamBindingsT TypeParamBindings;
 
   // Insert the given FVConstraint* set into the provided Map.
-  // Returns true if successful else false.
-  bool insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
+  void insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
                                      const std::string &FuncName,
-                                     FVConstraint *ToIns, FunctionDecl *FD,
+                                     FVConstraint *NewC, FunctionDecl *FD,
                                      ASTContext *C);
 
   // Inserts the given FVConstraint* set into the provided static map.
-  // Returns true if successful else false.
-  bool insertIntoStaticFunctionMap(StaticFunctionMapType &Map,
+  void insertIntoStaticFunctionMap(StaticFunctionMapType &Map,
                                    const std::string &FuncName,
                                    const std::string &FileName,
                                    FVConstraint *ToIns, FunctionDecl *FD,
@@ -188,15 +186,14 @@ private:
   //  * va_list-typed variables
   void specialCaseVarIntros(ValueDecl *D, ASTContext *Context);
 
-  // Inserts the given FVConstraint* set into the global map, depending
-  // on whether static or not.
+  // Inserts the given FVConstraint set into the extern or static function map.
   // Note: This can trigger a brainTransplant from an existing FVConstraint into
   // the argument FVConstraint. The brainTransplant copies the atoms of the
   // existing FVConstraint into the argument. This effectively throws out any
   // constraints that may been applied to the argument FVConstraint, so do not
   // call this function any time other than immediately after constructing an
   // FVConstraint.
-  bool insertNewFVConstraint(FunctionDecl *FD, FVConstraint *FVCon,
+  void insertNewFVConstraint(FunctionDecl *FD, FVConstraint *FVCon,
                              ASTContext *C);
 
   // Retrieves a FVConstraint* from a Decl (which could be static, or global)

--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -189,7 +189,13 @@ private:
   void specialCaseVarIntros(ValueDecl *D, ASTContext *Context);
 
   // Inserts the given FVConstraint* set into the global map, depending
-  // on whether static or not; returns true on success
+  // on whether static or not.
+  // Note: This can trigger a brainTransplant from an existing FVConstraint into
+  // the argument FVConstraint. The brainTransplant copies the atoms of the
+  // existing FVConstraint into the argument. This effectively throws out any
+  // constraints that may been applied to the argument FVConstraint, so do not
+  // call this function any time other than immediately after constructing an
+  // FVConstraint.
   bool insertNewFVConstraint(FunctionDecl *FD, FVConstraint *FVCon,
                              ASTContext *C);
 

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -549,13 +549,18 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
     if (Variables.find(PLoc) != Variables.end()) {
       // Try to find a previous definition based on function name
       if (!getFuncConstraint(FD, AstContext)) {
+        // No function with the same name exists. It's concerning that
+        // something already exists at this source location, but we add the
+        // function to the function map anyways. The function map indexes by
+        // function name, so there's no collision.
         insertNewFVConstraint(FD, F, AstContext);
         constrainWildIfMacro(F, FD->getLocation());
       } else {
-        // FIXME: Visiting same function in same source location twice.
-        //        This shouldn't happen, but it does for some std lib functions
-        //        on our benchmarks programs (vsftpd, lua, etc.). Bailing for
-        //        now, but a real fix will catch and prevent this earlier.
+        // A function with the same name exists in the same source location.
+        // This happens when a function is defined in a header file which is
+        // included in multiple translation units. getFuncConstraint returned
+        // non-null, so we know that the definition has been processed already,
+        // and there is no more work to do.
       }
       return;
     }

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -450,8 +450,12 @@ bool ProgramInfo::insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
           DiagnosticsEngine::Fatal, "duplicate definition for function %0");
       DE.Report(FD->getLocation(), DuplicateDefinitionsID).AddString(FuncName);
       exit(1);
+    } else {
+      // The old constraint has a body, but we've encountered another prototype
+      // for the function.
+      assert(OldC->hasBody() && !NewC->hasBody());
+      NewC->brainTransplant(OldC, *this);
     }
-    // else oldc->hasBody() so we can ignore the newC prototype
   }
   return RetVal;
 }

--- a/clang/test/3C/defn_then_decl.c
+++ b/clang/test/3C/defn_then_decl.c
@@ -5,10 +5,10 @@
 // RUN: 3c -alltypes %S/defn_then_decl.checked.c -- | count 0
 // RUN: rm %S/defn_then_decl.checked.c
 
-// Tests for when a function's declaration appears after the same function's
-// definition. A particular issue that existed in caused constraints added
-// onto the subsequent declaration (for example, because the declaration was in
-// a macro) were not applied to the original definition. 
+// Tests behavior when a function declaration appears after the definition for
+// that function. A specific issue that existed caused constraints applied to
+// the declaration (for example, when the declaration is in a macro) to not
+// be correctly applied to the original definition.
 
 void test0(int *p) {}
 #define MYDECL void test0(int *p);
@@ -26,8 +26,8 @@ void test2(int *p) {}
 void test2(int *p);
 //CHECK: void test2(_Ptr<int> p);
 
-void test3(int *p) { p = 1;}
-//CHECK: void test3(int *p : itype(_Ptr<int>)) { p = 1;}
+void test3(int *p) { p = 1; }
+//CHECK: void test3(int *p : itype(_Ptr<int>)) { p = 1; }
 void test3(int *p);
 //CHECK: void test3(int *p : itype(_Ptr<int>));
 

--- a/clang/test/3C/defn_then_decl.c
+++ b/clang/test/3C/defn_then_decl.c
@@ -1,0 +1,37 @@
+// RUN: 3c -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -alltypes -output-postfix=checked %s
+// RUN: 3c -alltypes %S/defn_then_decl.checked.c -- | count 0
+// RUN: rm %S/defn_then_decl.checked.c
+
+// Tests for when a function's declaration appears after the same function's
+// definition. A particular issue that existed in caused constraints added
+// onto the subsequent declaration (for example, because the declaration was in
+// a macro) were not applied to the original definition. 
+
+void test0(int *p) {}
+#define MYDECL void test0(int *p);
+MYDECL
+
+void test1(int *p) {}
+//CHECK: void test1(_Ptr<int> p) _Checked {}
+void test1(int *p);
+//CHECK: void test1(_Ptr<int> p);
+
+void test2(int *p);
+//CHECK: void test2(_Ptr<int> p);
+void test2(int *p) {}
+//CHECK: void test2(_Ptr<int> p) _Checked {}
+void test2(int *p);
+//CHECK: void test2(_Ptr<int> p);
+
+void test3(int *p) { p = 1;}
+//CHECK: void test3(int *p : itype(_Ptr<int>)) { p = 1;}
+void test3(int *p);
+//CHECK: void test3(int *p : itype(_Ptr<int>));
+
+void test4(int *p) {}
+//CHECK: void test4(_Ptr<int> p) _Checked {}
+void test4();
+//CHECK: void test4(_Ptr<int> p);


### PR DESCRIPTION
Ensure that constrains generated due to a function's declaration are
applied to the variables generated at the definition even when
declaration appears after the definition. This is done by copying
the atoms from the definition constraint variable into the declaration
constraint variable using `brainTransplant` before any constraints are
added on the declaration. 