### PR TITLE
Fixing Issue 415

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -196,7 +196,7 @@ void ClangdServer::_3CCollectAndBuildInitialConstraints(
     _3CDiagInfo.clearAllDiags();
     ConvCB->send3CMessage("Running 3C for first time.");
     _3CInter.buildInitialConstraints();
-    _3CInter.solveConstraints(true);
+    _3CInter.solveConstraints();
     ConvCB->send3CMessage("Finished running 3C.");
     log("3C: Built initial constraints successfully.\n");
     auto &WildPtrsInfo = _3CInter.getWildPtrsInfo();

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -196,6 +196,8 @@ void ClangdServer::_3CCollectAndBuildInitialConstraints(
     _3CDiagInfo.clearAllDiags();
     ConvCB->send3CMessage("Running 3C for first time.");
     _3CInter.buildInitialConstraints();
+    // NOTE: If and when we revive clangd3c, revisit this to make sure
+    // computeInterimConstraintState gets called if clangd3c needs it.
     _3CInter.solveConstraints();
     ConvCB->send3CMessage("Finished running 3C.");
     log("3C: Built initial constraints successfully.\n");


### PR DESCRIPTION
Fix for: https://github.com/correctcomputation/checkedc-clang/issues/415

There is a chance of clang CFG not having appropriate basicblock, we check to see if we have the basicblock else ignore the heuristic.

I also fixed a minor issue with `clangd`, which has a compilation problem as the `solveConstraints` interface changed.