### PR TITLE
Remove special handling of functions defined in system headers.

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -921,17 +921,8 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
     // we'll check if the declaration that has the body is different
     // from the current declaration.
     const FunctionDecl *OFd = nullptr;
-    if (FD->hasBody(OFd) && OFd == FD) {
-      // Some function (e.g, atoi) are given definitions inside the system
-      // headers. Here we ensure that such functions are treated the same as
-      // function without bodies.
-      bool InSysHeader = false;
-      if (FD->getDefinition()) {
-        SourceLocation DefnLoc = FD->getDefinition()->getLocation();
-        InSysHeader = Ctx.getSourceManager().isInSystemHeader(DefnLoc);
-      }
-      Hasbody = !InSysHeader;
-    }
+    if (FD->hasBody(OFd) && OFd == FD)
+      Hasbody = true;
     IsStatic = !(FD->isGlobal());
     ASTContext *TmpCtx = const_cast<ASTContext *>(&Ctx);
     auto PSL = PersistentSourceLoc::mkPSL(D, *TmpCtx);


### PR DESCRIPTION
The liberal itypes change (#356) added code to flag them as not having a
body even though they did. This may have been a useful mitigation for
certain problems with unwritable files at the time, but it risks causing
confusion and violating 3C invariants in the future. From now on, we
want to handle all unwritable files (including system headers) via the
new canWrite constraints approach.

It appears that removing this code will immediately fix one problem with
cast insertion that is currently blocking the benchmark tests (#423), so
we'll go ahead and make this change even though we don't fully
understand the cast insertion problem or how to appropriately
regression-test it.