### PR TITLE
Properly emit typedefs where the name is in the middle of the type.

### DIFF
--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -61,9 +61,8 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
           if (Var.anyChanges(Env)) {
             std::string newTy =
                   getStorageQualifierString(D) +
-                  Var.mkString(Info.getConstraints().getVariables(), false,
-                                   false, false, true) +
-                  " " + TD->getNameAsString();
+                  Var.mkString(Info.getConstraints().getVariables(), true,
+                                   false, false, true);
               RewriteThese.insert(
                   new TypedefDeclReplacement(TD, nullptr, newTy));
             }

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -1045,7 +1045,7 @@ bool ProgramInfo::seenTypedef(PersistentSourceLoc PSL) {
 
 void ProgramInfo::addTypedef(PersistentSourceLoc PSL, bool CanRewriteDef,
                              TypedefDecl* TD, ASTContext &C) {
-  auto Name = "typedef__" + TD->getNameAsString();
+  auto Name = TD->getNameAsString();
   auto* PV = new PointerVariableConstraint(TD->getUnderlyingType(), nullptr,
                                        Name, *this, C);
   auto *const Rsn =


### PR DESCRIPTION
Probably fixes #440 and doesn't appear to break any other regression tests.

I'll wait to turn this into a real PR until #408 is merged since I have other urgent work to do anyway.  The target branch is set for review purposes; I'll change it to `main` after #408 is merged and I update this PR accordingly.