### PR TITLE
Remove conditional stopping creating of constraint variables

### DIFF
--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -589,14 +589,9 @@ public:
       assert("Declaration is a definition, but getDefinition() is null?" &&
              Definition);
       FullSourceLoc FL = Context->getFullLoc(Definition->getBeginLoc());
-      if (FL.isValid()) {
-        SourceManager &SM = Context->getSourceManager();
-        FileID FID = FL.getFileID();
-        const FileEntry *FE = SM.getFileEntryForID(FID);
-        if (FE && FE->isValid())
-          for (auto *const D : Definition->fields())
-            addVariable(D);
-      }
+      if (FL.isValid())
+        for (auto *const D : Definition->fields())
+          addVariable(D);
     }
     return true;
   }

--- a/clang/test/3C/struct_macro.c
+++ b/clang/test/3C/struct_macro.c
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/struct_macro.c -- | diff %t.checked/struct_macro.c -
+
+
+// 3C was failing to create constraint variables for fields of structure
+// defined by macros.
+// https://github.com/correctcomputation/checkedc-clang/issues/297
+
+
+// Fields is not in macro, so can be checked
+
+#define b struct c
+b {int * a;};
+//CHECK: b {_Ptr<int> a;};
+void e(struct c x) {
+  int *y = x.a;
+  //CHECK: _Ptr<int> y = x.a;
+}
+
+// Fields is in macro, so it can't be checked.
+// A constraint variable still must be created.
+#define foo struct bar { int * x };
+foo
+
+void baz(struct bar buz) {
+  int *x = buz.x;
+  //CHECK: int *x = buz.x;
+}


### PR DESCRIPTION
This fixes #297 which is blocking libarchive. It's a simple fix, but I'm a little hesitant  to remove the `if (FE && FE->isValid())` conditional without understanding why it was there in the first place.