### PR TITLE
Split variable adder and constrain variable passes

### DIFF
--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -120,6 +120,10 @@ public:
 
   void addTypedef(PersistentSourceLoc PSL, bool ShouldCheck);
 
+  // For each pointer type in the declaration of D, add a variable to the
+  // constraint system for that pointer type.
+  void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *AstContext);
+
 private:
   // List of constraint variables for declarations, indexed by their location in
   // the source. This information persists across invocations of the constraint
@@ -198,10 +202,6 @@ private:
 
   // Retrieves a FVConstraint* from a Decl (which could be static, or global)
   FVConstraint *getFuncFVConstraint(FunctionDecl *FD, ASTContext *C);
-
-  // For each pointer type in the declaration of D, add a variable to the
-  // constraint system for that pointer type.
-  void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *AstContext);
 
   void insertIntoPtrSourceMap(const PersistentSourceLoc *PSL,
                               ConstraintVariable *CV);

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -266,7 +266,7 @@ public:
               constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
                                   Wild_to_Safe, false, &Info, false);
 
-              if (AllTypes && TFD != nullptr) {
+              if (AllTypes && TFD != nullptr && I < TFD->getNumParams()) {
                 auto *PVD = TFD->getParamDecl(I);
                 auto &ABI = Info.getABoundsInfo();
                 // Here, we need to handle context-sensitive assignment.

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -640,6 +640,8 @@ void ConstraintBuilderConsumer::HandleTranslationUnit(ASTContext &C) {
     // variable information gathered in the type variable traversal.
     VAV.TraverseDecl(D);
     CSBV.TraverseDecl(D);
+  }
+  for (const auto &D : TUD->decls()) {
     TV.TraverseDecl(D);
     GV.TraverseDecl(D);
   }


### PR DESCRIPTION
By creating and merging all FV's at once, we avoid alterations introduced by the constraints on them. Merging is simpler and solves #427. Hopefully, this allows us to remove code later that dealing with the complexity, like the various brainTransplant methods.

The Typedef map needed to be populated in the variable adder stage, or it wasn't available in time.