### PR TITLE
Fix placement of _Assume_bounds_cast on c-style cast

### DIFF
--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -181,7 +181,8 @@ void CastPlacementVisitor::surroundByCast(ConstraintVariable *Dst,
 
   // If E is already a cast expression, we will try to rewrite the cast instead
   // of adding a new expression.
-  if (auto *CE = dyn_cast<CStyleCastExpr>(E->IgnoreParens())) {
+  if (isa<CStyleCastExpr>(E->IgnoreParens()) && CastKind == CAST_TO_WILD) {
+    auto *CE = cast<CStyleCastExpr>(E->IgnoreParens());
     SourceRange CastTypeRange(CE->getLParenLoc(), CE->getRParenLoc());
     assert("Cast expected to start with '('" && !CastStrs.first.empty() &&
            CastStrs.first[0] == '(');


### PR DESCRIPTION
The `if` statement that tries to replace an existing cast with a new cast
assumed that the new cast was a c-style cast and not a CheckedC
bounds cast. If the branch was taken when inserting a bounds cast,
the leading '_' was cut off, resulting in invalid code. This commit
adds a condition that ensures this does not happen.

I added an assert for this invariant in one of the PRs I merged earlier
today, but somehow didn't see the obvious way that it can be violated.   