### PR TITLE
bodiless.c: Don't write a temporary file in the source directory.

### DIFF
--- a/clang/test/3C/bodiless.c
+++ b/clang/test/3C/bodiless.c
@@ -1,7 +1,7 @@
-// RUN: 3c -base-dir=%S %s > %S/temp_bodiless.c --
-// RUN: %clang -c %S/temp_bodiless.c
-// RUN: FileCheck -match-full-lines --input-file %S/temp_bodiless.c %s
-// RUN: rm %S/temp_bodiless.c
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S %s -- >%t
+// RUN: %clang -c %t
+// RUN: FileCheck -match-full-lines --input-file %t %s
 
 /***********************************************/
 /* Tests that functions without bodies         */


### PR DESCRIPTION
Hopefully fixes #378 for real this time.

I tested via a temporary `chmod u-w clang/test/3C` on my laptop that no other tests try to create files in the directory.  I assume that result will hold true on Windows too.