### PR TITLE
3C regression tests: Replace remaining size_t typedefs with stddef.h.

### DIFF
--- a/clang/test/3C/allocator.c
+++ b/clang/test/3C/allocator.c
@@ -9,7 +9,7 @@
 // RUN: 3c -base-dir=%t.checked %t.checked/allocator.c -- | diff %t.checked/allocator.c -
 // expected-no-diagnostics
 //
-typedef __SIZE_TYPE__ size_t;
+#include <stddef.h>
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
 

--- a/clang/test/3C/liberal_itypes_ptr.c
+++ b/clang/test/3C/liberal_itypes_ptr.c
@@ -41,7 +41,7 @@ void biz() {
   // CHECK: b = buz();
 }
 
-typedef unsigned long size_t;
+#include <stddef.h>
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
 


### PR DESCRIPTION
The one in liberal_itypes_ptr.c conflicted with the system headers on
Windows X64. We haven't seen a problem with the one in allocator.c yet,
but let's remove it too for consistency.

Fixes #451.