### PR TITLE
DeclRewriter::detectInlineStruct: Skip structs with invalid source locations.

### DIFF
--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -418,7 +418,12 @@ void DeclRewriter::rewriteFunctionDecl(FunctionDeclReplacement *N) {
 /*static*/ std::map<Decl *, Decl *> DeclRewriter::VDToRDMap;
 /*static*/ std::set<Decl *> DeclRewriter::InlineVarDecls;
 void DeclRewriter::detectInlineStruct(Decl *D, SourceManager &SM) {
-  if (RecordDecl *RD = dyn_cast<RecordDecl>(D)) {
+  RecordDecl *RD = dyn_cast<RecordDecl>(D);
+  if (RD != nullptr &&
+      // With -fms-extensions (default on Windows), Clang injects an implicit
+      // `struct _GUID` with an invalid location, which would cause an assertion
+      // failure in SM.isPointWithin below.
+      RD->getBeginLoc().isValid()) {
     LastRecordDecl = RD;
   }
   if (VarDecl *VD = dyn_cast<VarDecl>(D)) {

--- a/clang/test/3C/ms_extensions.c
+++ b/clang/test/3C/ms_extensions.c
@@ -1,0 +1,8 @@
+// Regression test for implicit injection of `struct _GUID` on Windows with an
+// invalid source location crashing DeclRewriter::detectInlineStruct.
+// (https://github.com/correctcomputation/checkedc-clang/issues/448)
+
+// RUN: 3c -base-dir=%S %s -- -fms-extensions | FileCheck -match-full-lines %s
+
+int *x;
+// CHECK: _Ptr<int> x = ((void *)0);


### PR DESCRIPTION
Avoids a crash when an implicit `struct _GUID` is injected with an
invalid source location on Windows (fixes #448).