### PR TITLE
Fix detection of `malloc(a * sizeof(b))` with implicit casts.

### DIFF
--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -119,6 +119,7 @@ PVConstraint *ConstraintResolver::addAtom(PVConstraint *PVC, ConstAtom *PtrTyp,
 }
 
 static bool getSizeOfArg(Expr *Arg, QualType &ArgTy) {
+  Arg = Arg->IgnoreParenImpCasts();
   if (auto *SizeOf = dyn_cast<UnaryExprOrTypeTraitExpr>(Arg))
     if (SizeOf->getKind() == UETT_SizeOf) {
       ArgTy = SizeOf->getTypeOfArgument();

--- a/clang/test/3C/definedType.c
+++ b/clang/test/3C/definedType.c
@@ -1,11 +1,3 @@
-// This test currently fails on Windows X86, but the 3C team is waiting to try
-// to fix it until Microsoft addresses a problem that currently makes the tests
-// difficult to run on Windows X86:
-//
-// https://github.com/microsoft/checkedc-clang/pull/956#issuecomment-752317866
-//
-// UNSUPPORTED: system-windows
-
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s

--- a/clang/test/3C/malloc_implicit_cast.c
+++ b/clang/test/3C/malloc_implicit_cast.c
@@ -1,0 +1,31 @@
+// Regression test for failure to detect the `sizeof` in `malloc(x * sizeof(y))`
+// if there is an implicit cast around the `sizeof` because `x` is of an integer
+// type bigger than `size_t`
+// (https://github.com/correctcomputation/checkedc-clang/issues/345).
+
+// Of course, in order to trigger the bug (if it exists), we need an integer
+// type bigger than `size_t`. We make a best effort to find one (in our main
+// Linux x86_64 environment with the GCC system headers, `size_t` should be 64
+// bits and `unsigned __int128` should be available); if we don't find one, the
+// test may falsely pass.
+
+// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines %s
+
+#include <stddef.h>
+_Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+#include <stdint.h>
+#ifdef __SIZEOF_INT128__
+typedef unsigned __int128 uintrealmax_t;
+#else
+typedef uintmax_t uintrealmax_t;
+#endif
+
+void foo() {
+  uintrealmax_t n = 5;
+  // If the bug triggers, we'll get an "Unsafe call to allocator function" root
+  // cause here (not tested) and `p` will remain wild.
+  int *p = malloc(n * sizeof(int));
+  // CHECK: _Array_ptr<int> p : count(n) = malloc<int>(n * sizeof(int));
+  p[0] = 42;
+}


### PR DESCRIPTION
This was the cause of the `definedType.c` failure on Windows X86, so we
can now re-enable that test. We also have a dedicated test for the bug
that should work in our main Linux environment.

Fixes #345.