### PR TITLE
Add -allow-rewrite-failures option to downgrade rewrite errors to warnings.

### DIFF
--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -75,6 +75,8 @@ struct _3COptions {
 
   bool DumpUnwritableChanges;
   bool AllowUnwritableChanges;
+
+  bool AllowRewriteFailures;
 };
 
 // The main interface exposed by the 3C to interact with the tool.

--- a/clang/include/clang/3C/3CGlobalOptions.h
+++ b/clang/include/clang/3C/3CGlobalOptions.h
@@ -32,6 +32,7 @@ extern bool WarnRootCause;
 extern bool WarnAllRootCause;
 extern bool DumpUnwritableChanges;
 extern bool AllowUnwritableChanges;
+extern bool AllowRewriteFailures;
 
 #ifdef FIVE_C
 extern bool RemoveItypes;

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -58,6 +58,7 @@ std::set<std::string> FilePaths;
 bool VerifyDiagnosticOutput;
 bool DumpUnwritableChanges;
 bool AllowUnwritableChanges;
+bool AllowRewriteFailures;
 
 #ifdef FIVE_C
 bool RemoveItypes;
@@ -235,6 +236,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   VerifyDiagnosticOutput = CCopt.VerifyDiagnosticOutput;
   DumpUnwritableChanges = CCopt.DumpUnwritableChanges;
   AllowUnwritableChanges = CCopt.AllowUnwritableChanges;
+  AllowRewriteFailures = CCopt.AllowRewriteFailures;
 
 #ifdef FIVE_C
   RemoveItypes = CCopt.RemoveItypes;

--- a/clang/test/3C/base_subdir/canwrite_constraints_symlink.c
+++ b/clang/test/3C/base_subdir/canwrite_constraints_symlink.c
@@ -23,7 +23,8 @@
 // RUN: cd %t.base && 3c -addcr -verify canwrite_constraints_symlink.c --
 
 // expected-error@base_subdir_partial_defn.h:1 {{3C internal error: 3C generated changes to this file even though it is not allowed to write to the file}}
-// expected-note@base_subdir_partial_defn.h:1 {{-dump-unwritable-changes}}
+// expected-note@*:* {{-dump-unwritable-changes}}
+// expected-note@*:* {{-allow-unwritable-changes}}
 
 void
 #include "base_subdir_partial_defn.h"

--- a/clang/test/3C/base_subdir/canwrite_constraints_unimplemented.c
+++ b/clang/test/3C/base_subdir/canwrite_constraints_unimplemented.c
@@ -8,7 +8,8 @@
 // RUN: cd %S && 3c -addcr -verify %s --
 
 // expected-error@../base_subdir_partial_defn.h:1 {{3C internal error: 3C generated changes to this file even though it is not allowed to write to the file}}
-// expected-note@../base_subdir_partial_defn.h:1 {{-dump-unwritable-changes}}
+// expected-note@*:* {{-dump-unwritable-changes}}
+// expected-note@*:* {{-allow-unwritable-changes}}
 
 // The "../base_subdir_partial_defn.h" path is testing two former base dir
 // matching bugs from

--- a/clang/test/3C/macro_rewrite_error.c
+++ b/clang/test/3C/macro_rewrite_error.c
@@ -3,6 +3,8 @@
 #define args ();
 typedef int (*a) args // expected-error {{Unable to rewrite converted source range. Intended rewriting: "typedef _Ptr<int (void)> a"}}
 a b;
+// expected-note@*:* {{-allow-rewrite-failures}}
 
 #define MIDDLE x; int *
 int MIDDLE y; // expected-error {{Unable to rewrite converted source range. Intended rewriting: "_Ptr<int> y = ((void *)0)"}}
+// expected-note@*:* {{-allow-rewrite-failures}}

--- a/clang/test/3C/stdout_mode_write_other.c
+++ b/clang/test/3C/stdout_mode_write_other.c
@@ -5,7 +5,8 @@
 // RUN: 3c -base-dir=%S -addcr -verify %s --
 
 // expected-error@base_subdir_partial_defn.h:1 {{3C generated changes to this file, which is under the base dir but is not the main file and thus cannot be written in stdout mode}}
-// expected-note@base_subdir_partial_defn.h:1 {{-dump-unwritable-changes}}
+// expected-note@*:* {{-dump-unwritable-changes}}
+// expected-note@*:* {{-allow-unwritable-changes}}
 
 void
 #include "base_subdir_partial_defn.h"

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -226,6 +226,18 @@ static cl::opt<bool> OptAllowUnwritableChanges(
              "may be removed in the future."),
     cl::init(false), cl::cat(_3CCategory));
 
+static cl::opt<bool> OptAllowRewriteFailures(
+    "allow-rewrite-failures",
+    cl::desc("When 3c fails to make a rewrite to a source file (typically "
+             "because of macros), issue a warning instead of an error. This "
+             "option is intended to be used temporarily until you change your "
+             "code to allow 3c to work or you report the problem to the 3C "
+             "team to get it fixed; the option may be removed in the future. "
+             "Note that some kinds of rewrite failures currently generate "
+             "warnings regardless of this option, due to known bugs that "
+             "affect common use cases."),
+    cl::init(false), cl::cat(_3CCategory));
+
 #ifdef FIVE_C
 static cl::opt<bool> OptRemoveItypes(
     "remove-itypes",
@@ -272,6 +284,7 @@ int main(int argc, const char **argv) {
   CcOptions.VerifyDiagnosticOutput = OptVerifyDiagnosticOutput;
   CcOptions.DumpUnwritableChanges = OptDumpUnwritableChanges;
   CcOptions.AllowUnwritableChanges = OptAllowUnwritableChanges;
+  CcOptions.AllowRewriteFailures = OptAllowRewriteFailures;
 
 #ifdef FIVE_C
   CcOptions.RemoveItypes = OptRemoveItypes;
@@ -335,7 +348,7 @@ int main(int argc, const char **argv) {
 
   // Write all the converted files back.
   if (!_3CInterface.writeAllConvertedFilesToDisk()) {
-    errs() << "Failure occurred while trying to rewrite converted files back."
+    errs() << "Failure occurred while trying to rewrite converted files back. "
               "Exiting.\n";
     return 1;
   }


### PR DESCRIPTION
While we're here:

- Add note about -allow-unwritable-changes to the unwritable change
  error, and change the existing note to have no location for
  consistency with the others.

- Fix a highly visible typo in a `3c` error message.

Our practice so far has been not to add regression tests specifically for the `-allow-*` flags.  I believe I tested all the combinations manually, in addition to running `ninja check-3c`.