### PR TITLE
Detect 5C files rather than requiring -DFIVE_C=ON to be passed.

### DIFF
--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -4,6 +4,9 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
+# We expect users to build either 5C (with all 5C-specific files present) or 3C
+# (with none present), so we can check existence of an arbitrary 5C-specific
+# file to tell whether this is 3C or 5C.
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/DeclRewriter_5C.cpp)
   set(FIVE_C ON)
 endif()

--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -1,56 +1,60 @@
-set( LLVM_LINK_COMPONENTS
-        ${LLVM_TARGETS_TO_BUILD}
-        Option
-        Support
-        )
-        if (FIVE_C)
-          add_compile_definitions(FIVE_C)
-          set(five_c_source
-            DeclRewriter_5C.cpp
-          )
-        endif()
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Option
+  Support
+  )
 
-        if (MSVC)
-          set_source_files_properties(ArrayBoundsInferenceConsumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-          set_source_files_properties(ConstraintBuilder.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-          set_source_files_properties(DeclRewriter.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-          set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-        endif()
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/DeclRewriter_5C.cpp)
+  set(FIVE_C ON)
+endif()
 
-        add_clang_library(clang3C
-          ABounds.cpp
-          AVarBoundsInfo.cpp
-          AVarGraph.cpp
-          ArrayBoundsInferenceConsumer.cpp
-          CastPlacement.cpp
-          3C.cpp
-          3CInteractiveData.cpp
-          CheckedRegions.cpp
-          ConstraintBuilder.cpp
-          ConstraintResolver.cpp
-          Constraints.cpp
-          ConstraintsGraph.cpp
-          ConstraintVariables.cpp
-          DeclRewriter.cpp
-          IntermediateToolHook.cpp
-          MappingVisitor.cpp
-          PersistentSourceLoc.cpp
-          ProgramInfo.cpp
-          ProgramVar.cpp
-          RewriteUtils.cpp
-          StructInit.cpp
-          TypeVariableAnalysis.cpp
-          Utils.cpp
-          ${five_c_source}
-          LINK_LIBS
-          clangAST
-          clangAnalysis
-          clangBasic
-          clangDriver
-          clangFrontend
-          clangRewriteFrontend
-          clangStaticAnalyzerFrontend
-          clangTooling
-          clangTransformer
-        )
-	target_include_directories(obj.clang3C PUBLIC)
+if (FIVE_C)
+  add_compile_definitions(FIVE_C)
+  set(five_c_source
+    DeclRewriter_5C.cpp
+  )
+endif()
+
+if (MSVC)
+  set_source_files_properties(ArrayBoundsInferenceConsumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+  set_source_files_properties(ConstraintBuilder.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+  set_source_files_properties(DeclRewriter.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+  set_source_files_properties(RewriteUtils.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
+add_clang_library(clang3C
+  ABounds.cpp
+  AVarBoundsInfo.cpp
+  AVarGraph.cpp
+  ArrayBoundsInferenceConsumer.cpp
+  CastPlacement.cpp
+  3C.cpp
+  3CInteractiveData.cpp
+  CheckedRegions.cpp
+  ConstraintBuilder.cpp
+  ConstraintResolver.cpp
+  Constraints.cpp
+  ConstraintsGraph.cpp
+  ConstraintVariables.cpp
+  DeclRewriter.cpp
+  IntermediateToolHook.cpp
+  MappingVisitor.cpp
+  PersistentSourceLoc.cpp
+  ProgramInfo.cpp
+  ProgramVar.cpp
+  RewriteUtils.cpp
+  StructInit.cpp
+  TypeVariableAnalysis.cpp
+  Utils.cpp
+  ${five_c_source}
+  LINK_LIBS
+  clangAST
+  clangAnalysis
+  clangBasic
+  clangDriver
+  clangFrontend
+  clangRewriteFrontend
+  clangStaticAnalyzerFrontend
+  clangTooling
+  clangTransformer
+)

--- a/clang/tools/3c/CMakeLists.txt
+++ b/clang/tools/3c/CMakeLists.txt
@@ -1,11 +1,19 @@
-set( LLVM_LINK_COMPONENTS
+set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Option
   Support
   )
+
+# Copy the FIVE_C variable from clang/lib/3C. This relies on
+# clang/lib/3C/CMakeLists.txt running before clang/tools/3c/CMakeLists.txt,
+# which it does: clang/CMakeLists.txt does add_subdirectory(lib) before
+# add_subdirectory(tools).
+get_directory_property(FIVE_C DIRECTORY ../../lib/3C DEFINITION FIVE_C)
+
 if (FIVE_C)
   add_compile_definitions(FIVE_C)
 endif()
+
 add_clang_executable(3c
   3CStandalone.cpp
   )
@@ -21,7 +29,6 @@ target_link_libraries(3c
   clangStaticAnalyzerFrontend
   clangTooling
   )
-target_include_directories(3c PUBLIC)
 
 # Based on clang/tools/driver/CMakeLists.txt.
 add_dependencies(3c clang-resource-headers)


### PR DESCRIPTION
Some other cleanup to CMake files while I'm here:

- Formatting
- target_include_directories with no include directories is a no-op.

At first I thought we'd be on g5c (which I anticipate will make the `FIVE_C` CMake variable go away altogether) soon enough that this wouldn't be worth doing, but once I got more familiar with writing CMake code and given that this came up during the preparation of the latest PR to Microsoft and g5c still seems far off, I thought the fix was worth making now.

This change should be made in 3C first (because we're allowing 5C-specific code in non-5C-specific files to be in 3C for now) and then merged to 5C, but obviously we want to make sure it works in 5C before merging it to 3C.  So I tested `ninja check-3c` on [a test merge of 3C to 5C](https://github.com/correctcomputation/checkedc-clang-5c/tree/test-merge-from-3c-20210302), and it passed except for a problem with a 5C-specific regression test, which is not the fault of this change and which I will take up separately as part of the real merge of 3C to 5C following this change.