### PR TITLE
Preserve attributes on rewriting

### DIFF
--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -94,125 +94,17 @@ public:
            (RewriteReturn || RewriteParams));
   }
 
-  SourceRange getSourceRange(SourceManager &SM) const override {
-    TypeSourceInfo *TSInfo = Decl->getTypeSourceInfo();
-    FunctionTypeLoc FTypeLoc = FunctionTypeLoc();
-
-    SourceLocation AttrBeginLoc = SourceLocation();
-    SourceLocation AttrEndLoc = SourceLocation();
-    if (TSInfo) {
-      auto TSInfoLoc = TSInfo->getTypeLoc();
-      TypeLoc TLoc = getBaseTypeLoc(TSInfoLoc);
-      AttributedTypeLoc ATypeLoc = TLoc.getAs<AttributedTypeLoc>();
-      if (!ATypeLoc.isNull()) {
-        TLoc = ATypeLoc.getNextTypeLoc();
-        AttrBeginLoc = ATypeLoc.getSourceRange().getBegin();;
-        AttrEndLoc = ATypeLoc.getSourceRange().getEnd();
-      }
-      if (Decl->hasAttrs()) {
-        for (auto *A : Decl->getAttrs())  {
-          SourceLocation NewAttrBegin = A->getRange().getBegin();
-          if (AttrBeginLoc.isInvalid() ||
-              SM.isBeforeInTranslationUnit(NewAttrBegin, AttrBeginLoc))
-            AttrBeginLoc = NewAttrBegin;
-
-          SourceLocation NewAttrEnd = A->getRange().getEnd();
-          if (AttrEndLoc.isInvalid() ||
-              SM.isBeforeInTranslationUnit(AttrEndLoc, NewAttrEnd))
-            AttrEndLoc = NewAttrEnd;
-        }
-      }
-      if (AttrEndLoc.isValid()) {
-        auto T = Lexer::findNextToken(AttrEndLoc, SM, Decl->getLangOpts());
-        AttrEndLoc = T->getEndLoc();
-      }
-      FTypeLoc = TLoc.getAs<clang::FunctionTypeLoc>();
-    }
-    if (FTypeLoc.isNull()) {
-      // When we can't get a FunctionTypeLoc, we have no way to rewrite in
-      // specifically parameter or return source ranges. We can still rewrite
-      // if we're replacing both the parameter and the return. For this we just
-      // need to get the source range for the entire function. If we are
-      // replacing only one of the parameter and return, then this case would
-      // rewriting like this would cause us to clobber the one we aren't
-      // rewriting.
-      assert("SourceRange will overwrite function return type or argument." &&
-             RewriteReturn && RewriteParams);
-      return SourceRange(Decl->getBeginLoc(),
-                         getFunctionDeclRParen(Decl, SM));
-    }
-
-    // Function pointer are funky, and require special handling to rewrite the
-    // return type.
-    if (Decl->getReturnType()->isFunctionPointerType()) {
-      if (RewriteParams && RewriteReturn) {
-        auto T =
-            getBaseTypeLoc(FTypeLoc.getReturnLoc()).getAs<FunctionTypeLoc>();
-        if (!T.isNull())
-          return SourceRange(Decl->getBeginLoc(), T.getRParenLoc());
-      }
-      // Fall through to standard handling when only rewriting param decls
-    }
-
-    // If rewriting the return, then the range starts at the begining of the
-    // decl. Otherwise, skip to the left parenthesis of parameters.
-    SourceLocation Begin =
-      RewriteReturn ? Decl->getBeginLoc() : FTypeLoc.getLParenLoc();
-
-    // If rewriting Parameters, stop at the right parenthesis of the parameters.
-    // Otherwise, stop after the return type.
-    SourceLocation End;
-    if (RewriteParams) {
-      // When there are no bounds or itypes on a function, the declaration ends
-      // at the right paren of the declaration parameter list.
-      End = FTypeLoc.getRParenLoc();
-
-      // If there's a bounds expression, this comes after the right paren of the
-      // function declaration parameter list.
-      if (auto *BoundsE = Decl->getBoundsExpr()) {
-        SourceLocation BoundsEnd = BoundsE->getEndLoc();
-        if (BoundsEnd.isValid())
-          End = BoundsEnd;
-      }
-
-      // If there's an itype, this also comes after the right paren. In the case
-      // that there is both a bounds expression and an itype, we need check
-      // which is later in the file and use that as the declaration end.
-      if (auto *InteropE = Decl->getInteropTypeExpr()) {
-        SourceLocation InteropEnd = InteropE->getEndLoc();
-        if (InteropEnd.isValid() &&
-            (!End.isValid() || SM.isBeforeInTranslationUnit(End, InteropEnd)))
-          End = InteropEnd;
-      }
-
-      // SourceLocations are weird and turn up invalid for reasons I don't
-      // understand. Fallback to extracting r paren location from source
-      // character buffer.
-      if (!End.isValid())
-        End = getFunctionDeclRParen(Decl, SM);
-    } else {
-      End = Decl->getReturnTypeSourceRange().getEnd();
-    }
-
-    if (RewriteParams && AttrEndLoc.isValid() &&
-        SM.isBeforeInTranslationUnit(End, AttrEndLoc))
-      End = AttrEndLoc;
-
-    if (RewriteReturn && AttrBeginLoc.isValid() &&
-        SM.isBeforeInTranslationUnit(AttrBeginLoc, Begin))
-      Begin = AttrBeginLoc;
-
-    assert("Invalid FunctionDeclReplacement SourceRange!" && Begin.isValid() &&
-           End.isValid());
-
-    return SourceRange(Begin, End);
-  }
+  SourceRange getSourceRange(SourceManager &SM) const override;
 
 private:
   // This determines if the full declaration or the return will be replaced.
   bool RewriteReturn;
-
   bool RewriteParams;
+
+  SourceLocation getDeclBegin(SourceManager &SM) const;
+  SourceLocation getParamBegin(SourceManager &SM) const;
+  SourceLocation getReturnEnd(SourceManager &SM) const;
+  SourceLocation getDeclEnd(SourceManager &SM) const;
 };
 
 // Compare two DeclReplacement values. The algorithm for comparing them relates

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -104,6 +104,9 @@ bool hasFunctionBody(clang::Decl *D);
 
 std::string getStorageQualifierString(clang::Decl *D);
 
+void forEachAttribute(clang::Decl *D,
+                      llvm::function_ref<void(const clang::Attr *A)> F);
+
 std::string getAttributeString(clang::Decl *D);
 
 // Use this version for user input that has not yet been validated.
@@ -207,4 +210,11 @@ clang::TypeLoc getBaseTypeLoc(clang::TypeLoc T);
 // Ignore all CheckedC temporary and clang implicit expression on E. This
 // combines the behavior of IgnoreExprTmp and IgnoreImplicit.
 clang::Expr *ignoreCheckedCImplicit(clang::Expr *E);
+
+// Get a FunctionTypeLoc object from the declaration/type location. This is a
+// little complicated due to various clang wrapper types that come from
+// parenthesised types and function attributes.
+clang::FunctionTypeLoc getFunctionTypeLoc(clang::TypeLoc TLoc);
+clang::FunctionTypeLoc getFunctionTypeLoc(clang::DeclaratorDecl *Decl);
+
 #endif

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -104,6 +104,8 @@ bool hasFunctionBody(clang::Decl *D);
 
 std::string getStorageQualifierString(clang::Decl *D);
 
+std::string getAttributeString(clang::Decl *D);
+
 // Use this version for user input that has not yet been validated.
 std::error_code tryGetCanonicalFilePath(const std::string &FileName,
                                         std::string &AbsoluteFp);

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -468,7 +468,7 @@ SourceRange FunctionDeclReplacement::getSourceRange(SourceManager &SM) const {
   SourceLocation Begin = RewriteReturn ? getDeclBegin(SM) : getParamBegin(SM);
   SourceLocation End = RewriteParams ? getDeclEnd(SM) : getReturnEnd(SM);
   assert("Invalid FunctionDeclReplacement SourceRange!" && Begin.isValid() &&
-         End.isValid() && SM.isBeforeInTranslationUnit(Begin, End));
+         End.isValid());
   return SourceRange(Begin, End);
 }
 

--- a/clang/test/3C/attr.c
+++ b/clang/test/3C/attr.c
@@ -1,0 +1,76 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/attr.c -- | diff %t.checked/attr.c -
+
+// function attributes
+
+__attribute__((disable_tail_calls))
+int *a() {
+//CHECK: __attribute__((disable_tail_calls)) _Ptr<int> a(void) _Checked {
+  return 0;
+}
+
+__attribute__((disable_tail_calls))
+void b(int *x) {
+//CHECK: __attribute__((disable_tail_calls)) void b(_Ptr<int> x) _Checked {
+  return;
+}
+
+__attribute__((disable_tail_calls))
+int *c(int *x) {
+//CHECK: __attribute__((disable_tail_calls)) _Ptr<int> c(_Ptr<int> x) _Checked {
+  return 0;
+}
+int *e(int *x)
+__attribute__((disable_tail_calls))
+//CHECK: __attribute__((disable_tail_calls)) int *e(_Ptr<int> x) : itype(_Ptr<int>)
+{
+  return 1;
+}
+
+__attribute__((no_stack_protector))
+int *f(int *x)
+__attribute__((disable_tail_calls))
+//CHECK: __attribute__((no_stack_protector)) __attribute__((disable_tail_calls)) _Ptr<int> f(_Ptr<int> x)
+{
+//CHECK: _Checked {
+  while (1){}
+}
+
+// variable attribute on param
+
+void g(__attribute__((noescape)) int *x) {
+//CHECK: void g(__attribute__((noescape)) _Ptr<int> x) _Checked {
+  return;
+}
+
+void h(__attribute__((noescape)) int *x) {
+//CHECK: void h(__attribute__((noescape)) int *x : itype(_Ptr<int>)) {
+  x = 1;
+}
+
+int *i(__attribute__((noescape)) void *x) {
+//CHECK: _Ptr<int> i(__attribute__((noescape)) void *x) {
+  return 0;
+}
+
+// variable attribute on local
+
+void j() {
+  __attribute__((nodebug)) int *a;
+  __attribute__((nodebug)) int *b = 0;
+  __attribute__((nodebug)) int *c = 1;
+
+  __attribute__((nodebug)) int *d, *e = 1, **f, g, *h;
+//CHECK: __attribute__((nodebug)) _Ptr<int> a = ((void *)0);
+//CHECK: __attribute__((nodebug)) _Ptr<int> b = 0;
+//CHECK: __attribute__((nodebug)) int *c = 1;
+//CHECK: __attribute__((nodebug)) _Ptr<int> d = ((void *)0);
+//CHECK: int *e __attribute__((nodebug)) = 1;
+//CHECK: __attribute__((nodebug)) _Ptr<_Ptr<int>> f = ((void *)0);
+//CHECK: int g __attribute__((nodebug));
+//CHECK: __attribute__((nodebug)) _Ptr<int> h = ((void *)0);
+}

--- a/clang/test/3C/attr.c
+++ b/clang/test/3C/attr.c
@@ -74,3 +74,14 @@ void j() {
 //CHECK: int g __attribute__((nodebug));
 //CHECK: __attribute__((nodebug)) _Ptr<int> h = ((void *)0);
 }
+
+#define FOO __attribute__((ms_abi))
+int *foo()  FOO ;
+int *foo() { return 0; }
+//CHECK: __attribute__((ms_abi)) _Ptr<int> foo(void) ;
+//CHECK: __attribute__((ms_abi)) _Ptr<int> foo(void) _Checked { return 0; }
+
+__attribute__((deprecated)) int *bar();
+int *bar() { return 0; }
+//CHECK: __attribute__((deprecated)) _Ptr<int> bar(void);
+//CHECK: __attribute__((deprecated)) _Ptr<int> bar(void) _Checked { return 0; }

--- a/clang/test/3C/valist.c
+++ b/clang/test/3C/valist.c
@@ -27,3 +27,16 @@ const char *lua_pushfstring (lua_State *L, const char *fmt, ...) {
 /*force output*/
 int *p;
 	//CHECK: _Ptr<int> p = ((void *)0);
+
+// This tests va_list correctness using windows builtins
+void foo( const char *fmt, __builtin_ms_va_list argp);
+__attribute__((ms_abi)) int *bar(const char *fmt, ...)  {
+//CHECK: __attribute__((ms_abi)) _Ptr<int> bar(const char *fmt : itype(_Ptr<const char>), ...)  {
+  __builtin_ms_va_list argp;
+  __builtin_ms_va_start(argp, fmt);
+  //CHECK: __builtin_ms_va_start(argp, fmt);
+  foo(fmt, argp);
+  __builtin_ms_va_end(argp);
+  //CHECK: __builtin_ms_va_end(argp);
+  return 0;
+}


### PR DESCRIPTION
3C ignored attributes when rewriting, so they would often be deleted or mess up rewriting in a way that made the uncompilable. 

For example

```c
void foo( const char *fmt, __builtin_ms_va_list argp);
__attribute__((ms_abi)) void bar ( const char *fmt, ...)  {
  __builtin_ms_va_list argp;
  __builtin_ms_va_start(argp, fmt);
  foo(fmt, argp);
  __builtin_ms_va_end(argp);
}
```

previously converted to

```c
void foo( const char *fmt, __builtin_ms_va_list argp);
const char *fmt : itype(_Ptr<const char>), ...) {
  __builtin_ms_va_list argp;
  __builtin_ms_va_start(argp, fmt);
  foo(fmt, argp);
  __builtin_ms_va_end(argp);
}
```

but is now converted correctly. 

---

[pending benchmark run](https://github.com/correctcomputation/actions/actions/runs/615177728)