### PR TITLE
Constrain expression variables in unwritable files to not change.

### DIFF
--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -700,6 +700,10 @@ void ProgramInfo::storePersistentConstraints(Expr *E, const CVarSet &Vars,
   // visited before. To avoid this, the expression is not cached and instead is
   // recomputed each time it's needed.
   if (PSL.valid() && Rewriter::isRewritable(E->getBeginLoc())) {
+    if (!canWrite(PSL.getFileName())) {
+      for (ConstraintVariable *CVar : Vars)
+        CVar->constrainToWild(CS, "Expression in non-writable file", &PSL);
+    }
     auto &ExprMap = isa<ImplicitCastExpr>(E) ? ImplicitCastConstraintVars
                                              : ExprConstraintVars;
     ExprMap[PSL].insert(Vars.begin(), Vars.end());

--- a/clang/test/3C/canwrite_constraints.h
+++ b/clang/test/3C/canwrite_constraints.h
@@ -14,6 +14,15 @@ inline void foo(int *p) {}
 int *foo_var = ((void *)0);
 // CHECK_HIGHER: _Ptr<int> foo_var = ((void *)0);
 
+// Make sure we don't allow the types of casts in non-writable files to be
+// changed. This problem was seen with the inline definition of `atol(p)` as
+// `strtol(p, (char **) NULL, 10)` in the system headers.
+void strtol_like(int *p : itype(_Ptr<int>));
+void atol_like() {
+  // expected-warning@+1 {{Expression in non-writable file}}
+  strtol_like((int *) 0);
+}
+
 // Make sure we do not add checked regions in non-writable files. This happened
 // incidentally in system headers in some other regression tests, but this is a
 // dedicated test for it.


### PR DESCRIPTION
This should fix the failure in the vsftpd benchmark with #463.