### PR TITLE
Remove defered params

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -429,11 +429,6 @@ typedef PointerVariableConstraint PVConstraint;
 // Name for function return, for debugging
 #define RETVAR "$ret"
 
-typedef struct {
-  PersistentSourceLoc PL;
-  std::vector<CVarSet> PS;
-} ParamDeferment;
-
 // This class contains a pair of PVConstraints that represent an internal and
 // external view of a variable for use as the parameter and return constraints
 // of FunctionVariableConstraints. The internal constraint represents how the
@@ -477,8 +472,6 @@ private:
   // K parameters accepted by the function.
   std::vector<FVComponentVariable> ParamVars;
 
-  // Storing of parameters in the case of untyped prototypes
-  std::vector<ParamDeferment> DeferredParams;
   // File name in which this declaration is found.
   std::string FileName;
   bool Hasproto;
@@ -512,12 +505,6 @@ public:
   PVConstraint *getInternalReturn() const {
     return ReturnVar.InternalConstraint;
   }
-
-  const std::vector<ParamDeferment> &getDeferredParams() const {
-    return DeferredParams;
-  }
-
-  void addDeferredParams(PersistentSourceLoc PL, std::vector<CVarSet> Ps);
 
   size_t numParams() const { return ParamVars.size(); }
 

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -236,12 +236,6 @@ public:
         // and for each arg to the function ...
         if (FVConstraint *TargetFV = dyn_cast<FVConstraint>(TmpC)) {
           unsigned I = 0;
-          bool CallUntyped = TFD ? TFD->getType()->isFunctionNoProtoType() &&
-                                       E->getNumArgs() != 0 &&
-                                       TargetFV->numParams() == 0
-                                 : false;
-
-          std::vector<CVarSet> Deferred;
           for (const auto &A : E->arguments()) {
             CVarSet ArgumentConstraints;
             if (I < TargetFV->numParams()) {
@@ -258,9 +252,7 @@ public:
             } else
               ArgumentConstraints = CB.getExprConstraintVars(A);
 
-            if (CallUntyped) {
-              Deferred.push_back(ArgumentConstraints);
-            } else if (I < TargetFV->numParams()) {
+            if (I < TargetFV->numParams()) {
               // Constrain the arg CV to the param CV.
               ConstraintVariable *ParameterDC = TargetFV->getExternalParam(I);
 
@@ -293,8 +285,6 @@ public:
             }
             I++;
           }
-          if (CallUntyped)
-            TargetFV->addDeferredParams(PL, Deferred);
         }
       }
     }

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1797,12 +1797,12 @@ void FunctionVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV,
                                                   ProgramInfo &I,
                                                   std::string &ReasonFailed) {
   // `this`: is the declaration the tool saw first.
-  // `FromCV`: is the declaration seen second, it cannot have defered
-  // constraints.
+  // `FromCV`: is the declaration seen second
+
   FVConstraint *From = dyn_cast<FVConstraint>(FromCV);
   assert(From != nullptr);
-  assert(From->getDeferredParams().size() == 0);
-  // Transplant returns.
+
+  // Merge returns.
   ReturnVar.mergeDeclaration(&From->ReturnVar, I, ReasonFailed);
   if (ReasonFailed != "") {
     ReasonFailed += " for return value";
@@ -1831,12 +1831,6 @@ void FunctionVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV,
       }
     }
   }
-}
-
-void FunctionVariableConstraint::addDeferredParams(PersistentSourceLoc PL,
-                                                   std::vector<CVarSet> Ps) {
-  ParamDeferment P = {PL, Ps};
-  DeferredParams.push_back(P);
 }
 
 bool FunctionVariableConstraint::getIsOriginallyChecked() const {

--- a/clang/test/3C/merge_fp1_xfail.c
+++ b/clang/test/3C/merge_fp1_xfail.c
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -output-dir=%t.checked %s %S/merge_fp2.c --
+// RUN: %clang -working-directory=%t.checked -c merge_fp1_xfail.c merge_fp2.c
+// RUN: FileCheck -match-full-lines --input-file %t.checked/merge_fp1_xfail.c %s
+//
+// XFAIL: *
+
+// When this file is first it fails.
+
+// possible assert failure - nothing should merge into undeclared params
+int * primary_merge(int * (*secondary_merge)());
+// CHECK: _Ptr<int> primary_merge(_Ptr<_Ptr<int> (int *)> secondary_merge);

--- a/clang/test/3C/merge_fp2.c
+++ b/clang/test/3C/merge_fp2.c
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -output-dir=%t.checked %s %S/merge_fp1_xfail.c --
+// RUN: %clang -working-directory=%t.checked -c merge_fp1_xfail.c merge_fp2.c
+// RUN: FileCheck -match-full-lines --input-file %t.checked/merge_fp2.c %s
+
+// When this file is first it succeeds, when second it fails.
+
+int * primary_merge(int * (*secondary_merge)(int*));
+// CHECK: _Ptr<int> primary_merge(_Ptr<_Ptr<int> (int *)> secondary_merge);
+
+// need this to produce changes (0 is safe, and clang merged the declarations)
+int * primary_merge(int * (*secondary_merge)()) {
+// CHECK: _Ptr<int> primary_merge(_Ptr<_Ptr<int> (int *)> secondary_merge) {
+
+  return ((*secondary_merge)(0));
+}


### PR DESCRIPTION
Remove now-vestigial code after brainTransplant was removed. Also, include tests of known failure merging function pointers.