### PR TITLE
Don't print the performance statistics unconditionally.

### DIFF
--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -104,10 +104,6 @@ public:
          const std::vector<std::string> &SourceFileList,
          clang::tooling::CompilationDatabase *CompDB);
 
-  virtual ~_3CInterface() {
-    GlobalProgramInfo.getPerfStats().printPerformanceStats(llvm::errs());
-  }
-
   // Constraint Building.
 
   // Create ConstraintVariables to hold constraints

--- a/clang/test/3C/stderr_clean.c
+++ b/clang/test/3C/stderr_clean.c
@@ -1,0 +1,15 @@
+// Test that 3C's stderr is empty by default on a successful run to prevent a
+// recurrence of an issue like
+// https://github.com/correctcomputation/checkedc-clang/issues/478 .
+
+// Apparently `count 0` passes if the input contains a single line without a
+// trailing newline character, as it did in the issue linked above. (This
+// behavior seems surprising. TODO: File a bug against LLVM?) So we compare the
+// stderr to a manually created empty file instead.
+
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S %s -- 2>%t.stderr
+// RUN: touch %t.empty
+// RUN: diff %t.empty %t.stderr
+
+int *p;

--- a/clang/test/3C/stderr_clean.c
+++ b/clang/test/3C/stderr_clean.c
@@ -4,8 +4,8 @@
 
 // Apparently `count 0` passes if the input contains a single line without a
 // trailing newline character, as it did in the issue linked above. (This
-// behavior seems surprising. TODO: File a bug against LLVM?) So we compare the
-// stderr to a manually created empty file instead.
+// behavior may be considered a bug in `count`.) So we compare the stderr to a
+// manually created empty file instead.
 
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S %s -- 2>%t.stderr


### PR DESCRIPTION
They were already also printed to TotalConstraintStats.json when -dump-stats is passed.

Also add a regression test that 3C's stderr is empty by default on a successful run.

Fixes #478.