### PR TITLE
Calls to polymorphic functions in macros no longer fail an assert

### DIFF
--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -261,6 +261,8 @@ private:
 
 bool canRewrite(Rewriter &R, const SourceRange &SR);
 
+bool isInMacro(clang::Expr &D, ASTContext &Context);
+
 // Rewrites the given source range with fallbacks for when the SourceRange is
 // inside a macro. This should be preferred to direct calls to ReplaceText
 // because this function will automatically expand macros where it needs to and

--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -261,7 +261,7 @@ private:
 
 bool canRewrite(Rewriter &R, const SourceRange &SR);
 
-bool isInMacro(clang::Expr &D, ASTContext &Context);
+bool canRewrite(clang::Expr &D, ASTContext &Context);
 
 // Rewrites the given source range with fallbacks for when the SourceRange is
 // inside a macro. This should be preferred to direct calls to ReplaceText

--- a/clang/include/clang/3C/TypeVariableAnalysis.h
+++ b/clang/include/clang/3C/TypeVariableAnalysis.h
@@ -20,11 +20,13 @@ class TypeVariableEntry {
 public:
   // Note: does not initialize TyVarType!
   TypeVariableEntry() : IsConsistent(false), TypeParamConsVar(nullptr) {}
-  TypeVariableEntry(QualType Ty, std::set<ConstraintVariable *> &CVs)
+  TypeVariableEntry(QualType Ty, std::set<ConstraintVariable *> &CVs
+                    , bool ForceInconsistent = false)
       : TypeParamConsVar(nullptr) {
     // We'll need a name to provide the type arguments during rewriting, so no
     // anonymous types are allowed.
-    IsConsistent = (Ty->isPointerType() || Ty->isArrayType()) &&
+    IsConsistent = !ForceInconsistent &&
+                   (Ty->isPointerType() || Ty->isArrayType()) &&
                    !isTypeAnonymous(Ty->getPointeeOrArrayElementType());
     TyVarType = Ty;
     ArgConsVars = CVs;
@@ -93,6 +95,7 @@ private:
   ConstraintResolver CR;
   TypeVariableMapT TVMap;
 
-  void insertBinding(CallExpr *CE, const int TyIdx, QualType Ty, CVarSet &CVs);
+  void insertBinding(CallExpr *CE, const int TyIdx, QualType Ty,
+                     CVarSet &CVs, bool ForceInconsistent = false);
 };
 #endif

--- a/clang/include/clang/3C/TypeVariableAnalysis.h
+++ b/clang/include/clang/3C/TypeVariableAnalysis.h
@@ -98,4 +98,7 @@ private:
   void insertBinding(CallExpr *CE, const int TyIdx, QualType Ty,
                      CVarSet &CVs, bool ForceInconsistent = false);
 };
+
+bool typeArgsProvided(CallExpr *Call);
+
 #endif

--- a/clang/lib/3C/CheckedRegions.cpp
+++ b/clang/lib/3C/CheckedRegions.cpp
@@ -224,6 +224,9 @@ bool CheckedRegionFinder::VisitCallExpr(CallExpr *C) {
     Map[ID] = isInStatementPosition(C) ? IS_CONTAINED : IS_UNCHECKED;
   } else {
     if (FD) {
+      if (Info.hasTypeParamBindings(C,Context))
+        for (auto Entry : Info.getTypeParamBindings(C, Context))
+          Wild |= (Entry.second == nullptr);
       auto Type = FD->getReturnType();
       Wild |= (!(FD->hasPrototype() || FD->doesThisDeclarationHaveABody())) ||
               containsUncheckedPtr(Type);

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -1071,10 +1071,13 @@ void ProgramInfo::setTypeParamBinding(CallExpr *CE, unsigned int TypeVarIdx,
 
   auto PSL = PersistentSourceLoc::mkPSL(CE, *C);
   auto CallMap = TypeParamBindings[PSL];
-  assert("Attempting to overwrite type param binding in ProgramInfo." &&
-         CallMap.find(TypeVarIdx) == CallMap.end());
-
-  TypeParamBindings[PSL][TypeVarIdx] = CV;
+  if (CallMap.find(TypeVarIdx) == CallMap.end()) {
+    // If this CE/idx is at the same location, it's in a macro,
+    // so mark it as inconsistent.
+    TypeParamBindings[PSL][TypeVarIdx] = nullptr;
+  } else {
+    TypeParamBindings[PSL][TypeVarIdx] = CV;
+  }
 }
 
 bool ProgramInfo::hasTypeParamBindings(CallExpr *CE, ASTContext *C) const {

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -1072,11 +1072,11 @@ void ProgramInfo::setTypeParamBinding(CallExpr *CE, unsigned int TypeVarIdx,
   auto PSL = PersistentSourceLoc::mkPSL(CE, *C);
   auto CallMap = TypeParamBindings[PSL];
   if (CallMap.find(TypeVarIdx) == CallMap.end()) {
+    TypeParamBindings[PSL][TypeVarIdx] = CV;
+  } else {
     // If this CE/idx is at the same location, it's in a macro,
     // so mark it as inconsistent.
     TypeParamBindings[PSL][TypeVarIdx] = nullptr;
-  } else {
-    TypeParamBindings[PSL][TypeVarIdx] = CV;
   }
 }
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -132,6 +132,11 @@ bool canRewrite(Rewriter &R, const CharSourceRange &SR) {
   return SR.isValid() && (R.getRangeSize(SR) != -1);
 }
 
+bool isInMacro(clang::Expr &D, ASTContext &Context) {
+  Rewriter R(Context.getSourceManager(), Context.getLangOpts());
+  return !canRewrite(R,CharSourceRange::getCharRange(D.getSourceRange()));
+}
+
 void rewriteSourceRange(Rewriter &R, const SourceRange &Range,
                         const std::string &NewText, bool ErrFail) {
   rewriteSourceRange(R, CharSourceRange::getTokenRange(Range), NewText,

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -133,12 +133,6 @@ bool canRewrite(Rewriter &R, const CharSourceRange &SR) {
   return SR.isValid() && (R.getRangeSize(SR) != -1);
 }
 
-bool canRewrite(clang::Expr &D, ASTContext &Context) {
-  Rewriter R(Context.getSourceManager(), Context.getLangOpts());
-  CharSourceRange Range = CharSourceRange::getCharRange(D.getSourceRange());
-  return canRewrite(R,Range);
-}
-
 void rewriteSourceRange(Rewriter &R, const SourceRange &Range,
                         const std::string &NewText, bool ErrFail) {
   rewriteSourceRange(R, CharSourceRange::getTokenRange(Range), NewText,

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -105,11 +105,13 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
         if (I >= FVCon->numParams())
           break;
         const int TyIdx = FVCon->getExternalParam(I)->getGenericIndex();
+        // if we can't rewrite it (macro, etc), it isn't safe
+        bool ForcedInconsistent = !canRewrite(*CE,*Context);
         if (TyIdx >= 0) {
           Expr *Uncast = A->IgnoreImpCasts();
           std::set<ConstraintVariable *> CVs = CR.getExprConstraintVars(Uncast);
           insertBinding(CE, TyIdx, Uncast->getType(),
-                        CVs, isInMacro(*CE,*Context));
+                        CVs, ForcedInconsistent);
         }
         ++I;
       }

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/TypeVariableAnalysis.h"
-#include "clang/3C/RewriteUtils.h"
 
 using namespace llvm;
 using namespace clang;
@@ -99,7 +98,7 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
     if (auto *FVCon = Info.getFuncConstraint(FDef, Context)) {
       // if we need to rewrite it but can't (macro, etc), it isn't safe
       bool ForcedInconsistent = !typeArgsProvided(CE)
-                                && !canRewrite(*CE,*Context);
+                                && !Rewriter::isRewritable(CE->getExprLoc());
       // Visit each function argument, and if it use a type variable, insert it
       // into the type variable binding map.
       unsigned int I = 0;

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -179,21 +179,15 @@ void TypeVarVisitor::getConsistentTypeParams(CallExpr *CE,
 // during rewriting.
 void TypeVarVisitor::setProgramInfoTypeVars() {
   for (const auto &TVEntry : TVMap) {
-//    bool AllInconsistent = true;
-//    for (auto TVCallEntry : TVEntry.second)
-//      AllInconsistent &= !TVCallEntry.second.getIsConsistent();
-//    // If they're all inconsistent type variables, ignore the call expression
-//    if (!AllInconsistent) {
-      // Add each type variable into the map in ProgramInfo. Inconsistent
-      // variables are mapped to null.
-      for (auto TVCallEntry : TVEntry.second)
-        if (TVCallEntry.second.getIsConsistent())
-          Info.setTypeParamBinding(TVEntry.first, TVCallEntry.first,
-                                   TVCallEntry.second.getTypeParamConsVar(),
-                                   Context);
-        else
-          Info.setTypeParamBinding(TVEntry.first, TVCallEntry.first, nullptr,
-                                   Context);
-//    }
+    // Add each type variable into the map in ProgramInfo. Inconsistent
+    // variables are mapped to null.
+    for (auto TVCallEntry : TVEntry.second)
+      if (TVCallEntry.second.getIsConsistent())
+        Info.setTypeParamBinding(TVEntry.first, TVCallEntry.first,
+                                 TVCallEntry.second.getTypeParamConsVar(),
+                                 Context);
+      else
+        Info.setTypeParamBinding(TVEntry.first, TVCallEntry.first, nullptr,
+                                 Context);
   }
 }

--- a/clang/test/3C/type_params_macro.c
+++ b/clang/test/3C/type_params_macro.c
@@ -6,6 +6,7 @@
 // Test for invalid type arguments from a macro,
 // recognized also my checked regions
 
+#define baz foo<int>(i);
 #define buz foo(i);
 #define buzzy foo(i); foo(j);
 
@@ -18,6 +19,13 @@ void test_none() {
 // CHECK: void test_none() _Checked {
 // CHECK: _Ptr<int> i = 0;
 // CHECK: foo<int>(i);
+
+void test_one_given() {
+  int *i = 0;
+  baz
+}
+// CHECK: void test_one_given() _Checked {
+// CHECK: _Ptr<int> i = 0;
 
 void test_one() {
   int *i = 0;

--- a/clang/test/3C/type_params_macro.c
+++ b/clang/test/3C/type_params_macro.c
@@ -1,0 +1,40 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unused -
+
+// Test for invalid type arguments from a macro,
+// recognized also my checked regions
+
+#define buz foo(i);
+#define buzzy foo(i); foo(j);
+
+_Itype_for_any(T) void foo(void *x  : itype(_Ptr<T>));
+
+void test_none() {
+  int *i = 0;
+  foo(i);
+}
+// CHECK: void test_none() _Checked {
+// CHECK: _Ptr<int> i = 0;
+// CHECK: foo<int>(i);
+
+void test_one() {
+  int *i = 0;
+  buz
+}
+// CHECK: void test_one() {
+// CHECK:  int *i = 0;
+// CHECK:  buz
+
+void test_two() {
+  int *i = 0;
+  int *j = 0;
+  buzzy
+}
+
+// CHECK: void test_two() {
+// CHECK:  int *i = 0;
+// CHECK:  int *j = 0;
+// CHECK:  buzzy
+


### PR DESCRIPTION
Fixes #315.

Calls to polymorphic functions in macros no longer fail an assert.
These calls also no longer trigger a checked region.

If calls come from a macro they are marked inconsistent, and this is available through ProgramInfo globals.