### PR TITLE
convert_project: Turn off -dump-intermediate by default.

### DIFF
--- a/clang/tools/3c/utils/port_tools/generate_ccommands.py
+++ b/clang/tools/3c/utils/port_tools/generate_ccommands.py
@@ -19,7 +19,7 @@ VSCODE_SETTINGS_JSON = os.path.realpath("settings.json")
 
 # to separate multiple commands in a line
 CMD_SEP = " &&"
-DEFAULT_ARGS = ["-dump-stats", "-dump-intermediate"]
+DEFAULT_ARGS = ["-dump-stats"]
 if os.name == "nt":
     DEFAULT_ARGS.append("-extra-arg-before=--driver-mode=cl")
     CMD_SEP = " ;"


### PR DESCRIPTION
We've found it more distracting than helpful.

Example workflow runs:

- [Before](https://github.com/correctcomputation/actions/runs/2119440717?check_suite_focus=true): The conversion log is full of `-dump-intermediate` output and is truncated.
- [After](https://github.com/correctcomputation/actions/runs/2123670207?check_suite_focus=true): The symbolized stack trace of the assertion failure is visible at the end of the conversion log.