### PR TITLE
Avoid trying to insert cast inside macros

### DIFF
--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -199,15 +199,19 @@ private:
   // rewritten.
   std::map<PersistentSourceLoc, CVarOption> TypedefVars;
 
-  // Map with the similar purpose as the Variables map, this stores constraint
-  // variables and set of bounds key for non-declaration expressions.
-  std::map<PersistentSourceLoc, CSetBkeyPair> ExprConstraintVars;
+  // A pair containing an AST node ID and the name of the main file in the
+  // translation unit. Used as a key to index expression in the following maps.
+  typedef std::pair<int64_t, std::string> IDAndTranslationUnit;
+  IDAndTranslationUnit getExprKey(clang::Expr *E, clang::ASTContext *C) const;
 
-  // Implicit casts do not physically exist in the source code, so their source
-  // location can collide with the source location of another expression. Since
-  // we need to look up constraint variables for implicit casts for the cast
-  // placement, the variables are stored in this separate map.
-  std::map<PersistentSourceLoc, CSetBkeyPair> ImplicitCastConstraintVars;
+  // Map with the similar purpose as the Variables map. This stores a set of
+  // constraint variables and bounds key for non-declaration expressions.
+  std::map<IDAndTranslationUnit, CSetBkeyPair> ExprConstraintVars;
+
+  // For each expr stored in the ExprConstraintVars, also store the source
+  // location for the expression. This is used to emit diagnostics. It is
+  // expected that multiple entries will map to the same source location.
+  std::map<IDAndTranslationUnit, PersistentSourceLoc> ExprLocations;
 
   //Performance stats
   PerformanceStats PerfS;

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -256,10 +256,17 @@ public:
               // Constrain the arg CV to the param CV.
               ConstraintVariable *ParameterDC = TargetFV->getExternalParam(I);
 
+              // We cannot insert a cast if the source location of a call
+              // expression is not writable. By using Same_to_Same for calls at
+              // unwritable source locations, we ensure that we will not need to
+              // insert a cast because this unifies the checked type for the
+              // parameter and the argument.
+              ConsAction CA = Rewriter::isRewritable(A->getExprLoc())
+                              ? Wild_to_Safe : Same_to_Same;
               // Do not handle bounds key here because we will be
               // doing context-sensitive assignment next.
-              constrainConsVarGeq(ParameterDC, ArgumentConstraints.first, CS, &PL,
-                                  Wild_to_Safe, false, &Info, false);
+              constrainConsVarGeq(ParameterDC, ArgumentConstraints.first, CS,
+                                  &PL, CA, false, &Info, false);
 
               if (AllTypes && TFD != nullptr && I < TFD->getNumParams()) {
                 auto *PVD = TFD->getParamDecl(I);

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -241,9 +241,6 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
     if (CHKCBindTemporaryExpr *CE = dyn_cast<CHKCBindTemporaryExpr>(E)) {
       return getExprConstraintVars(CE->getSubExpr());
     }
-    if (auto *CE = dyn_cast<ImplicitCastExpr>(E))
-      if (CE->getCastKind() == CK_LValueToRValue)
-        return getExprConstraintVars(CE->getSubExpr());
 
     // Apart from the above expressions constraints for all the other
     // expressions can be cached.

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -241,6 +241,9 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
     if (CHKCBindTemporaryExpr *CE = dyn_cast<CHKCBindTemporaryExpr>(E)) {
       return getExprConstraintVars(CE->getSubExpr());
     }
+    if (auto *CE = dyn_cast<ImplicitCastExpr>(E))
+      if (CE->getCastKind() == CK_LValueToRValue)
+        return getExprConstraintVars(CE->getSubExpr());
 
     // Apart from the above expressions constraints for all the other
     // expressions can be cached.
@@ -557,10 +560,13 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
                                           NewCV->getBoundsKey());
           NewCV->setBoundsKey(CSensBKey);
         }
-        // Important: Do Safe_to_Wild from returnvar in this copy, which then
-        //   might be assigned otherwise (Same_to_Same) to LHS
-        if (NewCV != CV)
-          constrainConsVarGeq(NewCV, CV, CS, &PSL, Safe_to_Wild, false, &Info);
+        if (NewCV != CV) {
+          // If the call is in a macro, use Same_to_Same to force checked type
+          // equality and avoid ever needing to insert a cast inside a macro.
+          ConsAction CA = Rewriter::isRewritable(CE->getExprLoc())
+                          ? Safe_to_Wild : Same_to_Same;
+          constrainConsVarGeq(NewCV, CV, CS, &PSL, CA, false, &Info);
+        }
         TmpCVs.insert(NewCV);
         // If this is realloc, constrain the first arg to flow to the return
         if (!ReallocFlow.empty()) {

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -786,18 +786,18 @@ void ProgramInfo::unifyIfTypedef(const Type* Ty, ASTContext& Context, Declarator
   }
 }
 
+
+ProgramInfo::IDAndTranslationUnit
+ProgramInfo::getExprKey(Expr *E, ASTContext *C) const {
+  // TODO: Main file name can be shared by multiple translation units if on file
+  //       is compiled multiple times with different defines
+  std::string Name = C->getSourceManager().getFileEntryForID(
+    C->getSourceManager().getMainFileID())->getName().str();
+  return std::make_pair(E->getID(*C), Name);
+}
+
 bool ProgramInfo::hasPersistentConstraints(Expr *E, ASTContext *C) const {
-  auto PSL = PersistentSourceLoc::mkPSL(E, *C);
-  bool HasImpCastConstraint = isa<ImplicitCastExpr>(E) &&
-                              ImplicitCastConstraintVars.find(PSL) !=
-                                  ImplicitCastConstraintVars.end() &&
-                              !ImplicitCastConstraintVars.at(PSL).first.empty();
-  bool HasExprConstraint =
-      !isa<ImplicitCastExpr>(E) &&
-      ExprConstraintVars.find(PSL) != ExprConstraintVars.end() &&
-      !ExprConstraintVars.at(PSL).first.empty();
-  // Has constraints only if the PSL is valid.
-  return PSL.valid() && (HasExprConstraint || HasImpCastConstraint);
+  return ExprConstraintVars.find(getExprKey(E, C)) != ExprConstraintVars.end();
 }
 
 const CVarSet &ProgramInfo::getPersistentConstraintsSet(clang::Expr *E,
@@ -823,33 +823,22 @@ const CSetBkeyPair &ProgramInfo::getPersistentConstraints(Expr *E,
                                                      ASTContext *C) const {
   assert(hasPersistentConstraints(E, C) &&
          "Persistent constraints not present.");
-  PersistentSourceLoc PLoc = PersistentSourceLoc::mkPSL(E, *C);
-  if (isa<ImplicitCastExpr>(E))
-    return ImplicitCastConstraintVars.at(PLoc);
-  return ExprConstraintVars.at(PLoc);
+  return ExprConstraintVars.at(getExprKey(E, C));
 }
 
 void ProgramInfo::storePersistentConstraints(Expr *E, const CSetBkeyPair &Vars,
                                              ASTContext *C) {
-  // Store only if the PSL is valid.
-  auto PSL = PersistentSourceLoc::mkPSL(E, *C);
-  // The check Rewrite::isRewritable is needed here to ensure that the
-  // expression is not inside a macro. If the expression is in a macro, then it
-  // is possible for there to be multiple expressions that map to the same PSL.
-  // This could make it look like the constraint variables for an expression
-  // have been computed and cached when the expression has not in fact been
-  // visited before. To avoid this, the expression is not cached and instead is
-  // recomputed each time it's needed.
-  if (PSL.valid()) {
-    if (!canWrite(PSL.getFileName())) {
-      for (ConstraintVariable *CVar : Vars.first)
-        CVar->constrainToWild(CS, "Expression in non-writable file", &PSL);
-    }
-    auto &ExprMap = isa<ImplicitCastExpr>(E) ? ImplicitCastConstraintVars
-                                             : ExprConstraintVars;
-    ExprMap[PSL].first.insert(Vars.first.begin(), Vars.first.end());
-    ExprMap[PSL].second.insert(Vars.second.begin(), Vars.second.end());
-  }
+  assert(!hasPersistentConstraints(E, C) &&
+         "Persistent constraints already present.");
+
+   auto PSL = PersistentSourceLoc::mkPSL(E, *C);
+   if (PSL.valid() && !canWrite(PSL.getFileName()))
+     for (ConstraintVariable *CVar : Vars.first)
+       CVar->constrainToWild(CS, "Expression in non-writable file", &PSL);
+
+  IDAndTranslationUnit Key = getExprKey(E, C);
+  ExprConstraintVars[Key] = Vars;
+  ExprLocations[Key] = PSL;
 }
 
 // The Rewriter won't let us re-write things that are in macros. So, we
@@ -1075,9 +1064,11 @@ bool ProgramInfo::computeInterimConstraintState(
 
   for (const auto &I : Variables)
     insertIntoPtrSourceMap(&(I.first), I.second);
-  for (const auto &I : ExprConstraintVars)
+  for (const auto &I : ExprConstraintVars) {
+    PersistentSourceLoc *PSL = &ExprLocations[I.first];
     for (auto *J : I.second.first)
-      insertIntoPtrSourceMap(&(I.first), J);
+      insertIntoPtrSourceMap(PSL, J);
+  }
 
   auto &WildPtrsReason = CState.RootWildAtomsWithReason;
   for (auto *CurrC : CS.getConstraints()) {

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -840,7 +840,7 @@ void ProgramInfo::storePersistentConstraints(Expr *E, const CSetBkeyPair &Vars,
   // have been computed and cached when the expression has not in fact been
   // visited before. To avoid this, the expression is not cached and instead is
   // recomputed each time it's needed.
-  if (PSL.valid() && Rewriter::isRewritable(E->getBeginLoc())) {
+  if (PSL.valid()) {
     if (!canWrite(PSL.getFileName())) {
       for (ConstraintVariable *CVar : Vars.first)
         CVar->constrainToWild(CS, "Expression in non-writable file", &PSL);

--- a/clang/test/3C/liberal_itypes_ptr.c
+++ b/clang/test/3C/liberal_itypes_ptr.c
@@ -123,18 +123,6 @@ void bounds_call(void *p) {
    // CHECK: bounds_fn(p);
 }
 
-#define macro_cast(x) macro_cast_fn(x)
-
-void macro_cast_fn(int *y) { }
-// CHECK: void macro_cast_fn(_Ptr<int> y) _Checked { }
-
-void macro_cast_caller() {
-  int *z = 1;
-  // CHECK: int *z = 1;
-  macro_cast(z);
-  // CHECK: macro_cast(_Assume_bounds_cast<_Ptr<int>>(z));
-}
-
 char *unused_return_unchecked();
 char *unused_return_checked() {return 0;}
 char *unused_return_itype() {return 1;}

--- a/clang/test/3C/macro_function_call.c
+++ b/clang/test/3C/macro_function_call.c
@@ -1,0 +1,101 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -verify -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -verify -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -verify -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -verify -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -verify  -alltypes %t.checked/macro_function_call.c -- | diff %t.checked/macro_function_call.c -
+
+// Test fix for https://github.com/correctcomputation/checkedc-clang/issues/439
+// We cannot insert casts on function calls inside macros, so constraints must
+// be generated in way that these calls are accepted by CheckedC without
+// additional casts.
+
+// 3C emits a warning if it fails inserting a cast. Ensure the test fails if
+// this happens.
+// expected-no-diagnostics
+
+// Unsafe call in macro. This would require an _Assume_bounds_cast, but we
+// can't insert it.  Constraints are generated so that the cast isn't needed.
+
+#define macro0 \
+  void caller0(int *a) {\
+    fn0(a);\
+  }
+void fn0(int *b) {}
+macro0
+
+//CHECK: #define macro0 \
+//CHECK:   void caller0(int *a) {\
+//CHECK:     fn0(a);\
+//CHECK:   }
+//CHECK: void fn0(int *b) {}
+//CHECK: macro0
+
+
+// Same as above, but the cast is requried on the return.
+
+#define macro1 fn1();
+int *fn1(void) { return 0; }
+void caller1() {
+  int *a = (int *) 1;
+  a = macro1
+}
+
+//CHECK: #define macro1 fn1();
+//CHECK: int *fn1(void) { return 0; }
+//CHECK: void caller1() {
+//CHECK:   int *a = (int *) 1;
+//CHECK:   a = macro1
+//CHECK: }
+
+// Checked function call in macro. Doesn't need cast, so no changes required to
+// avoid cast.
+
+#define macro2 fn2(a);
+void fn2(int *b) {}
+void caller2(int *a) {
+  macro2
+}
+//CHECK: #define macro2 fn2(a);
+//CHECK: void fn2(_Ptr<int> b) _Checked {}
+//CHECK: void caller2(_Ptr<int> a) _Checked {
+//CHECK:   macro2
+//CHECK: }
+
+
+// Like the first test case, but pointer to a pointer.
+
+#define macro3 fn3(a);
+void fn3(int **g) {}
+void caller3() {
+  int **a = (int **) 1;
+  macro3
+}
+//CHECK: #define macro3 fn3(a);
+//CHECK: void fn3(int **g) {}
+//CHECK: void caller3() {
+//CHECK:   int **a = (int **) 1;
+//CHECK:   macro3
+//CHECK: }
+
+// Call to function pointer
+#define macro4 fn(a);
+void fn4a(int *g) {}
+void fn4b(int *g) {}
+void caller4() {
+  int *a = (int *) 1;
+  void (*fn)(int *) =  fn4a;
+  if (0)
+    fn = fn4b;
+  macro4
+}
+//CHECK: #define macro4 fn(a);
+//CHECK: void fn4a(int *g) {}
+//CHECK: void fn4b(int *g) {}
+//CHECK: void caller4() {
+//CHECK:   int *a = (int *) 1;
+//CHECK:   _Ptr<void (int *)> fn = fn4a;
+//CHECK:   if (0)
+//CHECK:     fn = fn4b;
+//CHECK:   macro4
+//CHECK: }


### PR DESCRIPTION
Fixes #439.

The constraint created between a function parameter and a corresponding
argument is updated to be an equality constraint when the function call
is inside a macro. Doing this forces the checked type of the parameter
to the same as that of the argument. Casts are only inserted when
parameter and argument types are not equal, so this changes ensures that
3C will not try (and subsequently fail) to insert casts on expressions
in macros.

After the previous change there were still issues with cast insertion due
to source location collision in the ExprConstraintVars map. To avoid
these problems the map has been updated to use the AST node ID instead
of the source location. AST node IDs are only unique within a
translation unit, so they are paired with the name of the main file for
the translation unit.

AST nodes IDs are consistent between multiple clang tool invocations,but
they can change when run on different computers.
http://clang-developers.42468.n3.nabble.com/Question-about-hashing-AST-nodes-td4063810.html#a4063828
