### PR TITLE
Make accessing va_list parameters unchecked (fix #483)

### DIFF
--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -636,6 +636,18 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
       if (Expr *ESE = dyn_cast<Expr>(Res)) {
         return getExprConstraintVars(ESE);
       }
+    } else if (VAArgExpr *VarArg = dyn_cast<VAArgExpr>(E)) {
+      // Use of VarArg parameters are assumed to be unsafe even though CheckedC
+      // will accept them with checked pointer types. If we want to support
+      // VarArgs with checked pointer types, we can remove the constraint to
+      // WILD here. We would then need to update TypeExprRewriter to rewrite the
+      // type in these expression.
+      auto *P = new PVConstraint(VarArg->getType(), nullptr, "VAArgExpr", Info,
+                                 *Context);
+      PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(E, *Context);
+      std::string Rsn = "Accessing VarArg parameter";
+      P->constrainToWild(Info.getConstraints(), Rsn, &PL);
+      Ret = pairWithEmptyBkey({P});
     } else {
       if (Verbose) {
         llvm::errs() << "WARNING! Initialization expression ignored: ";

--- a/clang/test/3C/valist.c
+++ b/clang/test/3C/valist.c
@@ -24,6 +24,15 @@ const char *lua_pushfstring (lua_State *L, const char *fmt, ...) {
   lua_unlock(L);
   return ret;
 }
+
+void foo(int i, ...) {
+  va_list ap;
+  va_start(ap, i);
+  char * c = (char*) va_arg(ap,char*);
+  //CHECK: char * c = (char*) va_arg(ap,char*);
+  va_end(ap);
+}
+
 /*force output*/
 int *p;
 	//CHECK: _Ptr<int> p = ((void *)0);


### PR DESCRIPTION
Use of VarArg parameters are assumed to be unsafe even though CheckedC will
accept them with checked pointer types. If we want to support VarArgs with
checked pointer types, we can remove the constraint to WILD here. We would then
need to update TypeExprRewriter to rewrite the type in these expression.