### PR TITLE
Fix rewriting for K&R style function

### DIFF
--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -124,6 +124,8 @@ protected:
                       bool &RewriteRet);
 
   bool hasDeclWithTypedef(const FunctionDecl *FD);
+
+  bool inParamMultiDecl(const ParmVarDecl *PVD);
 };
 
 class FieldFinder : public RecursiveASTVisitor<FieldFinder> {

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -205,4 +205,11 @@ clang::TypeLoc getBaseTypeLoc(clang::TypeLoc T);
 // Ignore all CheckedC temporary and clang implicit expression on E. This
 // combines the behavior of IgnoreExprTmp and IgnoreImplicit.
 clang::Expr *ignoreCheckedCImplicit(clang::Expr *E);
+
+// Get a FunctionTypeLoc object from the declaration/type location. This is a
+// little complicated due to various clang wrapper types that come from
+// parenthesised types and function attributes.
+clang::FunctionTypeLoc getFunctionTypeLoc(clang::TypeLoc TLoc);
+clang::FunctionTypeLoc getFunctionTypeLoc(clang::DeclaratorDecl *Decl);
+
 #endif

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -153,6 +153,10 @@ std::string qtyToStr(clang::QualType QT, const std::string &Name = "");
 clang::SourceLocation getFunctionDeclRParen(clang::FunctionDecl *FD,
                                             clang::SourceManager &S);
 
+clang::SourceLocation locationPrecedingChar(clang::SourceLocation SL,
+                                            clang::SourceManager &S,
+                                            char C);
+
 // Remove auxillary casts from the provided expression.
 clang::Expr *removeAuxillaryCasts(clang::Expr *SrcExpr);
 
@@ -211,5 +215,7 @@ clang::Expr *ignoreCheckedCImplicit(clang::Expr *E);
 // parenthesised types and function attributes.
 clang::FunctionTypeLoc getFunctionTypeLoc(clang::TypeLoc TLoc);
 clang::FunctionTypeLoc getFunctionTypeLoc(clang::DeclaratorDecl *Decl);
+
+bool isKAndRFunctionDecl(clang::FunctionDecl *FD);
 
 #endif

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -701,7 +701,7 @@ void FunctionDeclBuilder::buildDeclVar(PVConstraint *IntCV, PVConstraint *ExtCV,
   ParmVarDecl *PVD = dyn_cast<ParmVarDecl>(Decl);
   if (PVD) {
     SourceRange Range = PVD->getSourceRange();
-    if (Range.isValid()) {
+    if (Range.isValid() && !inParamMultiDecl(PVD) ) {
       Type = getSourceText(Range, *Context);
       if (!Type.empty()) {
         // Great, we got the original source including any itype and bounds.
@@ -759,6 +759,22 @@ bool FunctionDeclBuilder::hasDeclWithTypedef(const FunctionDecl *FD) {
         FDIter->dump();
       }
     }
+  }
+  return false;
+}
+
+// K&R style function declarations can declare multiple parameter variables in
+// a single declaration statement. The source ranges for these parameters
+// overlap, so we cannot copy the declaration from source code to output code
+bool FunctionDeclBuilder::inParamMultiDecl(const ParmVarDecl *PVD) {
+  const DeclContext *DCtx = PVD->getDeclContext();
+  if (DCtx) {
+    SourceRange SR = PVD->getSourceRange();
+    SourceManager &SM = Context->getSourceManager();
+    for (auto *D : DCtx->decls())
+      if (D != PVD && D->getBeginLoc().isValid() &&
+          SM.isPointWithin(D->getBeginLoc(), SR.getBegin(), SR.getEnd()))
+        return true;
   }
   return false;
 }

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -447,8 +447,9 @@ private:
 SourceRange FunctionDeclReplacement::getSourceRange(SourceManager &SM) const {
   SourceLocation Begin = RewriteReturn ? getDeclBegin(SM) : getParamBegin(SM);
   SourceLocation End = RewriteParams ? getDeclEnd(SM) : getReturnEnd(SM);
-  assert("Invalid FunctionDeclReplacement SourceRange!" && Begin.isValid() &&
-         End.isValid() && SM.isBeforeInTranslationUnit(Begin, End));
+  // Begin can be equal to End if the SourceRange only contains one token.
+  assert("Invalid FunctionDeclReplacement SourceRange!" &&
+         (Begin == End || SM.isBeforeInTranslationUnit(Begin, End)));
   return SourceRange(Begin, End);
 }
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -473,34 +473,40 @@ SourceLocation FunctionDeclReplacement::getReturnEnd(SourceManager &SM) const {
 }
 
 SourceLocation FunctionDeclReplacement::getDeclEnd(SourceManager &SM) const {
-  FunctionTypeLoc FTypeLoc = getFunctionTypeLoc(Decl);
-
   SourceLocation End;
-  if (FTypeLoc.isNull()) {
-    // Without a FunctionTypeLocation, we have to approximate the end of the
-    // declaration as the location of the first r-paren before the start of the
-    // function body. This is messed up by comments and ifdef blocks containing
-    // r-paren, but works correctly most of the time.
-    End = getFunctionDeclRParen(Decl, SM);
-  } else if (Decl->getReturnType()->isFunctionPointerType()) {
-    // If a function returns a function pointer type, the paramter list for the
-    // returned function type comes after the top-level functions parameter
-    // list. Of course, this FunctionTypeLoc can also be null, so we have
-    // another fall back to the r-paren approximation.
-    FunctionTypeLoc T = getFunctionTypeLoc(FTypeLoc.getReturnLoc());
-    if (!T.isNull())
-      End = T.getRParenLoc();
-    else
-      End = getFunctionDeclRParen(Decl, SM);
-  } else {
-    End = FTypeLoc.getRParenLoc();
-  }
+   if (isKAndRFunctionDecl(Decl)) {
+     // For K&R style function declaration, use the beginning of the function
+     // body as the end of the declaration. K&R declarations must have a body.
+     End = locationPrecedingChar(Decl->getBody()->getBeginLoc(), SM, ';');
+   } else {
+     FunctionTypeLoc FTypeLoc = getFunctionTypeLoc(Decl);
+     if (FTypeLoc.isNull()) {
+       // Without a FunctionTypeLocation, we have to approximate the end of the
+       // declaration as the location of the first r-paren before the start of the
+       // function body. This is messed up by comments and ifdef blocks containing
+       // r-paren, but works correctly most of the time.
+       End = getFunctionDeclRParen(Decl, SM);
+     } else if (Decl->getReturnType()->isFunctionPointerType()) {
+       // If a function returns a function pointer type, the paramter list for the
+       // returned function type comes after the top-level functions parameter
+       // list. Of course, this FunctionTypeLoc can also be null, so we have
+       // another fall back to the r-paren approximation.
+       FunctionTypeLoc T = getFunctionTypeLoc(FTypeLoc.getReturnLoc());
+       if (!T.isNull())
+         End = T.getRParenLoc();
+       else
+         End = getFunctionDeclRParen(Decl, SM);
+     } else {
+       End = FTypeLoc.getRParenLoc();
+     }
+   }
 
   // If there's a bounds expression, this comes after the right paren of the
   // function declaration parameter list.
   if (auto *BoundsE = Decl->getBoundsExpr()) {
     SourceLocation BoundsEnd = BoundsE->getEndLoc();
-    if (BoundsEnd.isValid())
+    if (BoundsEnd.isValid() &&
+        (!End.isValid() || SM.isBeforeInTranslationUnit(End, BoundsEnd)))
       End = BoundsEnd;
   }
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -444,6 +444,85 @@ private:
   }
 };
 
+SourceRange FunctionDeclReplacement::getSourceRange(SourceManager &SM) const {
+  SourceLocation Begin = RewriteReturn ? getDeclBegin(SM) : getParamBegin(SM);
+  SourceLocation End = RewriteParams ? getDeclEnd(SM) : getReturnEnd(SM);
+  assert("Invalid FunctionDeclReplacement SourceRange!" && Begin.isValid() &&
+         End.isValid() && SM.isBeforeInTranslationUnit(Begin, End));
+  return SourceRange(Begin, End);
+}
+
+SourceLocation FunctionDeclReplacement::getDeclBegin(SourceManager &SM) const {
+  SourceLocation Begin = Decl->getBeginLoc();
+  return Begin;
+}
+
+SourceLocation FunctionDeclReplacement::getParamBegin(SourceManager &SM) const {
+  FunctionTypeLoc FTypeLoc = getFunctionTypeLoc(Decl);
+  // If we can't get a FunctionTypeLoc instance, then we'll guess that the
+  // l-paren is the token following the function name. This can clobber some
+  // comments and formatting.
+  if (FTypeLoc.isNull())
+    return Lexer::getLocForEndOfToken(Decl->getLocation(), 0, SM,
+                                      Decl->getLangOpts());
+  return FTypeLoc.getLParenLoc();
+}
+
+SourceLocation FunctionDeclReplacement::getReturnEnd(SourceManager &SM) const {
+  return Decl->getReturnTypeSourceRange().getEnd();
+}
+
+SourceLocation FunctionDeclReplacement::getDeclEnd(SourceManager &SM) const {
+  FunctionTypeLoc FTypeLoc = getFunctionTypeLoc(Decl);
+
+  SourceLocation End;
+  if (FTypeLoc.isNull()) {
+    // Without a FunctionTypeLocation, we have to approximate the end of the
+    // declaration as the location of the first r-paren before the start of the
+    // function body. This is messed up by comments and ifdef blocks containing
+    // r-paren, but works correctly most of the time.
+    End = getFunctionDeclRParen(Decl, SM);
+  } else if (Decl->getReturnType()->isFunctionPointerType()) {
+    // If a function returns a function pointer type, the paramter list for the
+    // returned function type comes after the top-level functions parameter
+    // list. Of course, this FunctionTypeLoc can also be null, so we have
+    // another fall back to the r-paren approximation.
+    FunctionTypeLoc T = getFunctionTypeLoc(FTypeLoc.getReturnLoc());
+    if (!T.isNull())
+      End = T.getRParenLoc();
+    else
+      End = getFunctionDeclRParen(Decl, SM);
+  } else {
+    End = FTypeLoc.getRParenLoc();
+  }
+
+  // If there's a bounds expression, this comes after the right paren of the
+  // function declaration parameter list.
+  if (auto *BoundsE = Decl->getBoundsExpr()) {
+    SourceLocation BoundsEnd = BoundsE->getEndLoc();
+    if (BoundsEnd.isValid())
+      End = BoundsEnd;
+  }
+
+  // If there's an itype, this also comes after the right paren. In the case
+  // that there is both a bounds expression and an itype, we need check
+  // which is later in the file and use that as the declaration end.
+  if (auto *InteropE = Decl->getInteropTypeExpr()) {
+    SourceLocation InteropEnd = InteropE->getEndLoc();
+    if (InteropEnd.isValid() &&
+        (!End.isValid() || SM.isBeforeInTranslationUnit(End, InteropEnd)))
+      End = InteropEnd;
+  }
+
+  // SourceLocations are weird and turn up invalid for reasons I don't
+  // understand. Fallback to extracting r paren location from source
+  // character buffer.
+  if (!End.isValid())
+    End = getFunctionDeclRParen(Decl, SM);
+
+  return End;
+}
+
 std::string ArrayBoundsRewriter::getBoundsString(const PVConstraint *PV,
                                                  Decl *D, bool Isitype) {
   auto &ABInfo = Info.getABoundsInfo();

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -57,33 +57,36 @@ FunctionDecl *getDefinition(FunctionDecl *FD) {
   return nullptr;
 }
 
-// Get the source location for the right paren of a function declaration
-// using the source character data buffer. Because this uses the character
-// buffer directly, it sees character data prior to preprocessing. This
-// means characters that are in comments, macros or otherwise not part of the
-// final preprocessed source code are seen and can cause this function to give
-// an incorrect result. This should only be used as a fall back for when the
-// clang library function FunctionTypeLoc::getRParenLoc cannot be called due to
-// a null FunctionTypeLoc or for when the function returns an invalid source
-// location.
+
+//This should only be used as a fall back for when the clang library function
+// FunctionTypeLoc::getRParenLoc cannot be called due to a null FunctionTypeLoc
+// or for when the function returns an invalid source location.
 SourceLocation getFunctionDeclRParen(FunctionDecl *FD, SourceManager &S) {
   const FunctionDecl *OFd = nullptr;
-
   if (FD->hasBody(OFd) && OFd == FD) {
     // Replace everything up to the beginning of the body.
     const Stmt *Body = FD->getBody(OFd);
-
-    int Offset = 0;
-    const char *Buf = S.getCharacterData(Body->getSourceRange().getBegin());
-
-    while (*Buf != ')') {
-      Buf--;
-      Offset--;
-    }
-
-    return Body->getSourceRange().getBegin().getLocWithOffset(Offset);
+    return locationPrecedingChar(Body->getBeginLoc(), S, ')');
   }
   return FD->getSourceRange().getEnd();
+}
+
+// Find the source location of the first character C preceding the given source
+// location.  Because this uses the character buffer directly, it sees character
+// data prior to preprocessing. This means characters that are in comments,
+// macros or otherwise not part of the final preprocessed source code are seen
+// and can cause this function to give an incorrect result. This should only be
+// used as a fall back for when clang library function for obtaining source
+// locations are not available or return invalid results.
+SourceLocation
+locationPrecedingChar(SourceLocation SL, SourceManager &S, char C) {
+  int Offset = 0;
+  const char *Buf = S.getCharacterData(SL);
+  while (*Buf != C) {
+    Buf--;
+    Offset--;
+  }
+  return SL.getLocWithOffset(Offset);
 }
 
 clang::CheckedPointerKind getCheckedPointerKind(InteropTypeExpr *ItypeExpr) {
@@ -484,4 +487,8 @@ FunctionTypeLoc getFunctionTypeLoc(DeclaratorDecl *Decl) {
   if (auto *TSInfo = Decl->getTypeSourceInfo())
     return getFunctionTypeLoc(TSInfo->getTypeLoc());
   return FunctionTypeLoc();
+}
+
+bool isKAndRFunctionDecl(FunctionDecl *FD) {
+  return !FD->hasPrototype() && FD->getNumParams();
 }

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -471,3 +471,17 @@ Expr *ignoreCheckedCImplicit(Expr *E) {
   }
   return New;
 }
+
+FunctionTypeLoc getFunctionTypeLoc(TypeLoc TLoc) {
+  TLoc = getBaseTypeLoc(TLoc);
+  auto ATLoc = TLoc.getAs<AttributedTypeLoc>();
+  if (!ATLoc.isNull())
+    TLoc = ATLoc.getNextTypeLoc();
+  return TLoc.getAs<FunctionTypeLoc>();
+}
+
+FunctionTypeLoc getFunctionTypeLoc(DeclaratorDecl *Decl) {
+  if (auto *TSInfo = Decl->getTypeSourceInfo())
+    return getFunctionTypeLoc(TSInfo->getTypeLoc());
+  return FunctionTypeLoc();
+}

--- a/clang/test/3C/k_and_r.c
+++ b/clang/test/3C/k_and_r.c
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/k_and_r.c -- | diff %t.checked/k_and_r.c -
+
+void test0(a)
+  int *a;
+{}
+//CHECK: void test0(_Ptr<int> a)
+//CHECK: _Checked {}
+
+void test1(a)
+  int *a;
+{ a = 1; }
+//CHECK: void test1(int *a : itype(_Ptr<int>))
+//CHECK: { a = 1; }
+
+void test2(a, b)
+  int *a;
+  char *b;
+{}
+//CHECK: void test2(_Ptr<int> a, _Ptr<char> b)
+//CHECK: _Checked {}
+
+int *test3(a)
+  int *a;
+{return a;}
+//CHECK: _Ptr<int> test3(_Ptr<int> a)
+//CHECK: _Checked {return a;}
+
+void test4(a)
+  int *a;
+{
+  for (int i = 0; i < 10; i++) {
+    a[i] = i;
+  }
+}
+//CHECK_NOALL: void test4(int *a : itype(_Ptr<int>))
+//CHECK_ALL: void test4(_Array_ptr<int> a : count(10))
+//CHECK_ALL: _Checked {
+
+// bc test case
+
+struct yy_buffer_state {};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+#ifdef YY_USE_PROTOS
+void yy_init_buffer( YY_BUFFER_STATE b, FILE *file )
+#else
+void yy_init_buffer( b, file )
+YY_BUFFER_STATE b;
+int *file;
+//CHECK: void yy_init_buffer(YY_BUFFER_STATE b, _Ptr<int> file)
+#endif
+{}
+
+// Zlib test case
+
+typedef int deflate_state;
+typedef int ct_data;
+void compress_block(s, ltree, dtree)
+    deflate_state *s;
+    const ct_data *ltree;
+    const ct_data *dtree;
+//CHECK: void compress_block(_Ptr<deflate_state> s, _Ptr<const ct_data> ltree, _Ptr<const ct_data> dtree)
+ { }

--- a/clang/test/3C/k_and_r.c
+++ b/clang/test/3C/k_and_r.c
@@ -41,6 +41,15 @@ void test4(a)
 //CHECK_ALL: void test4(_Array_ptr<int> a : count(10))
 //CHECK_ALL: _Checked {
 
+void test5(a, b, c, d, e, f, g, h)
+  int *a;
+  char *b, c;
+  char d, *e;
+  int f, *g, h;
+{}
+//CHECK: void test5(_Ptr<int> a, _Ptr<char> b, char c, char d, _Ptr<char> e, int f, _Ptr<int> g, int h)
+//CHECK: _Checked {}
+
 // bc test case
 
 struct yy_buffer_state {};


### PR DESCRIPTION
For example
```c
void f(x)
int *x;
{ }
```
can now rewrite to 
```c
void f(_Ptr<x>)
{ }
```

fixes issue #93 