### PR TITLE
Add initializer when nested structure has checked field (fix #495)

### DIFF
--- a/clang/include/clang/3C/StructInit.h
+++ b/clang/include/clang/3C/StructInit.h
@@ -37,7 +37,7 @@ public:
   bool VisitDeclStmt(DeclStmt *S);
 
 private:
-  bool variableNeedsInitializer(VarDecl *VD);
+  bool variableNeedsInitializer(DeclaratorDecl *DD);
   void insertVarDecl(VarDecl *VD, DeclStmt *S);
 
   ASTContext *Context;

--- a/clang/include/clang/3C/StructInit.h
+++ b/clang/include/clang/3C/StructInit.h
@@ -37,7 +37,7 @@ public:
   bool VisitDeclStmt(DeclStmt *S);
 
 private:
-  bool variableNeedsInitializer(DeclaratorDecl *DD);
+  bool hasCheckedMembers(DeclaratorDecl *DD);
   void insertVarDecl(VarDecl *VD, DeclStmt *S);
 
   ASTContext *Context;

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -139,7 +139,7 @@ bool isPtrOrArrayType(const clang::QualType &QT);
 bool isVarArgType(const std::string &TypeName);
 
 // Check if the variable is of a structure or union type.
-bool isStructOrUnionType(clang::VarDecl *VD);
+bool isStructOrUnionType(clang::DeclaratorDecl *VD);
 
 // Helper method to print a Type in a way that can be represented in the source.
 // If Name is given, it is included as the variable name (which otherwise isn't

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -221,9 +221,9 @@ bool isPtrOrArrayType(const clang::QualType &QT) {
   return QT->isPointerType() || QT->isArrayType();
 }
 
-bool isStructOrUnionType(clang::VarDecl *VD) {
-  return VD->getType().getTypePtr()->isStructureType() ||
-         VD->getType().getTypePtr()->isUnionType();
+bool isStructOrUnionType(clang::DeclaratorDecl *DD) {
+  return DD->getType().getTypePtr()->isStructureType() ||
+         DD->getType().getTypePtr()->isUnionType();
 }
 
 std::string qtyToStr(clang::QualType QT, const std::string &Name) {

--- a/clang/test/3C/add_struct_init.c
+++ b/clang/test/3C/add_struct_init.c
@@ -13,6 +13,7 @@ struct fiz { int *a; };
 struct buz { struct bar a; };
 struct baz { struct buz a; };
 struct fuz { struct baz a; struct fiz b; };
+struct biz { struct fiz b; };
 
 void test() {
   struct foo a;
@@ -21,12 +22,14 @@ void test() {
   struct buz d;
   struct baz e;
   struct fuz f;
+  struct biz g;
   //CHECK: struct foo a;
   //CHECK: struct bar b = {};
   //CHECK: struct fiz c;
   //CHECK: struct buz d = {};
   //CHECK: struct baz e = {};
   //CHECK: struct fuz f = {};
+  //CHECK: struct biz g;
 
   c.a = 1;
 }

--- a/clang/test/3C/add_struct_init.c
+++ b/clang/test/3C/add_struct_init.c
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/add_struct_init.c -- | diff %t.checked/add_struct_init.c -
+
+
+struct foo {};
+struct bar { int *a; };
+//CHECK: struct bar { _Ptr<int> a; };
+struct fiz { int *a; };
+struct buz { struct bar a; };
+struct baz { struct buz a; };
+struct fuz { struct baz a; struct fiz b; };
+
+void test() {
+  struct foo a;
+  struct bar b;
+  struct fiz c;
+  struct buz d;
+  struct baz e;
+  struct fuz f;
+  //CHECK: struct foo a;
+  //CHECK: struct bar b = {};
+  //CHECK: struct fiz c;
+  //CHECK: struct buz d = {};
+  //CHECK: struct baz e = {};
+  //CHECK: struct fuz f = {};
+
+  c.a = 1;
+}


### PR DESCRIPTION
Updates `StructVariableInitializer::variableNeedsInitializer` to check if any field of a structure need an initializer. This detects if any nested structure has a checked pointer as a field. 