### PR TITLE
Fix condition for adding itypes in function pointers

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -84,7 +84,7 @@ public:
   // the name of the variable, false for just the type.
   // The 'forIType' parameter is true when the generated string is expected
   // to be used inside an itype.
-  virtual std::string mkString(const EnvironmentMap &E, bool EmitName = true,
+  virtual std::string mkString(Constraints &CS, bool EmitName = true,
                                bool ForItype = false, bool EmitPointee = false,
                                bool UnmaskTypedef = false) const = 0;
 
@@ -399,7 +399,7 @@ public:
 
   std::string gatherQualStrings(void) const;
 
-  std::string mkString(const EnvironmentMap &E, bool EmitName = true,
+  std::string mkString(Constraints &CS, bool EmitName = true,
                        bool ForItype = false, bool EmitPointee = false,
                        bool UnmaskTypedef = false) const override;
 
@@ -470,9 +470,15 @@ public:
 
   void mergeDeclaration(FVComponentVariable *From, ProgramInfo &I,
                         std::string &ReasonFailed);
-  std::string mkItypeStr(const EnvironmentMap &E) const;
-  std::string mkTypeStr(const EnvironmentMap &E, bool EmitName) const;
-  std::string mkString(const EnvironmentMap &E) const;
+  std::string mkItypeStr(Constraints &CS) const;
+  std::string mkTypeStr(Constraints &CS, bool EmitName) const;
+  std::string mkString(Constraints &CS) const;
+
+  bool hasItypeSolution(Constraints &CS) const;
+  bool hasCheckedSolution(Constraints &CS) const;
+
+  PVConstraint *getInternal() const { return InternalConstraint; }
+  PVConstraint *getExternal() const { return ExternalConstraint; }
 };
 
 // Constraints on a function type. Also contains a 'name' parameter for
@@ -524,6 +530,10 @@ public:
     return ReturnVar.InternalConstraint;
   }
 
+  const FVComponentVariable *getCombineReturn() const {
+    return &ReturnVar;
+  }
+
   size_t numParams() const { return ParamVars.size(); }
 
   bool hasProtoType() const { return Hasproto; }
@@ -548,6 +558,11 @@ public:
     return ParamVars.at(I).InternalConstraint;
   }
 
+  const FVComponentVariable *getCombineParam(unsigned I) const {
+    assert(I < ParamVars.size());
+    return &ParamVars.at(I);
+  }
+
   bool srcHasItype() const override;
   bool srcHasBounds() const override;
 
@@ -558,7 +573,7 @@ public:
   bool solutionEqualTo(Constraints &CS, const ConstraintVariable *CV,
                        bool ComparePtyp = true) const override;
 
-  std::string mkString(const EnvironmentMap &E, bool EmitName = true,
+  std::string mkString(Constraints &CS, bool EmitName = true,
                        bool ForItype = false, bool EmitPointee = false,
                        bool UnmaskTypedef = false) const override;
   void print(llvm::raw_ostream &O) const override;

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -112,7 +112,7 @@ protected:
   // Get existing itype string from constraint variables.
   std::string getExistingIType(ConstraintVariable *DeclC);
 
-  virtual void buildDeclVar(PVConstraint *IntCV, PVConstraint *ExtCV,
+  virtual void buildDeclVar(const FVComponentVariable *CV,
                             DeclaratorDecl *Decl, std::string &Type,
                             std::string &IType, bool &RewriteParm,
                             bool &RewriteRet);

--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -133,7 +133,6 @@ CastPlacementVisitor::CastNeeded CastPlacementVisitor::needCasting(
 std::pair<std::string, std::string>
 CastPlacementVisitor::getCastString(ConstraintVariable *Dst,
                                     CastNeeded CastKind) {
-  const auto &E = Info.getConstraints().getVariables();
   switch (CastKind) {
   case CAST_TO_WILD:
     return std::make_pair("((" + Dst->getRewritableOriginalTy() + ")", ")");
@@ -161,7 +160,8 @@ CastPlacementVisitor::getCastString(ConstraintVariable *Dst,
       }
     }
     return std::make_pair(
-        "_Assume_bounds_cast<" + Dst->mkString(E, false) + ">(", Suffix);
+      "_Assume_bounds_cast<" + Dst->mkString(Info.getConstraints(), false) +
+      ">(", Suffix);
   }
   default:
     llvm_unreachable("No casting needed");

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -378,7 +378,8 @@ private:
     for (auto *CV : CVSingleton)
       // Replace the original type with this new one if the type has changed.
       if (CV->anyChanges(Vars))
-        rewriteSourceRange(Writer, Range, CV->mkString(Vars, false));
+        rewriteSourceRange(Writer, Range,
+                           CV->mkString(Info.getConstraints(), false));
   }
 };
 
@@ -406,7 +407,7 @@ public:
           if (Entry.second != nullptr) {
             AllInconsistent = false;
             std::string TyStr = Entry.second->mkString(
-                Info.getConstraints().getVariables(), false, false, true);
+                Info.getConstraints(), false, false, true);
             if (TyStr.back() == ' ')
               TyStr.pop_back();
             TypeParamString += TyStr + ",";

--- a/clang/test/3C/liberal_itypes_fp.c
+++ b/clang/test/3C/liberal_itypes_fp.c
@@ -106,3 +106,11 @@ void fptr_itype_test(void) {
     baz(fptr2);
     //CHECK: baz(fptr2);
 }
+
+void fn_ptrptr(int **a) { *a = 1; }
+void fptr_ptrptr_test() {
+  void (*fn)(int **) = &fn_ptrptr;
+}
+//CHECK: void fn_ptrptr(int **a : itype(_Ptr<_Ptr<int>>)) { *a = 1; }
+//CHECK: void fptr_ptrptr_test() _Checked {
+//CHECK:   _Ptr<void (int ** : itype(_Ptr<_Ptr<int>>))> fn = &fn_ptrptr;


### PR DESCRIPTION
The code for deciding if a function should get an itype was duplicated
for functions declarations and function pointer types. The function
pointer version of the code had a bug in it that caused issue #498.
The duplicated code has been extracted into single function that is
reused for functions and function pointers.

A lot of the lines changed in this PR are caused by an `EnvironmentMap&`
parameter being changed to `Constraints&`. This lets the function pointer
code call `solutionEqualTo` which is needed for correct itype insertion. 