### PR TITLE
Slight improvements and comments for file path canonicalization (for possible addition to #488)

### DIFF
--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -104,18 +104,12 @@ bool hasFunctionBody(clang::Decl *D);
 
 std::string getStorageQualifierString(clang::Decl *D);
 
-// Use this version for user input that has not yet been validated.
 std::error_code tryGetCanonicalFilePath(const std::string &FileName,
                                         std::string &AbsoluteFp);
 
-// This version asserts success. It may be used for convenience for files we are
-// already accessing and thus believe should exist, modulo race conditions and
-// the like.
-void getCanonicalFilePath(const std::string &FileName, std::string &AbsoluteFp);
-
 // This compares entire path components: it's smart enough to know that "foo.c"
 // does not start with "foo". It's not smart about anything else, so you should
-// probably put both paths through getCanonicalFilePath first.
+// probably put both paths through tryGetCanonicalFilePath first.
 bool filePathStartsWith(const std::string &Path, const std::string &Prefix);
 
 bool isNULLExpression(clang::Expr *E, clang::ASTContext &C);
@@ -169,8 +163,8 @@ bool isCastSafe(clang::QualType DstType, clang::QualType SrcType);
 // Check if the provided file path belongs to the input project
 // and can be rewritten.
 //
-// For accurate results, the path must have gone through getCanonicalFilePath.
-// Note that the file name of a PersistentSourceLoc is always canonical.
+// For accurate results, the path must be canonical. The file name of a
+// PersistentSourceLoc can normally be assumed to be canonical.
 bool canWrite(const std::string &FilePath);
 
 // Check if the provided variable has void as one of its type.

--- a/clang/lib/3C/PersistentSourceLoc.cpp
+++ b/clang/lib/3C/PersistentSourceLoc.cpp
@@ -67,8 +67,14 @@ PersistentSourceLoc PersistentSourceLoc::mkPSL(clang::SourceRange SR,
   if (TFSL.isValid()) {
     const FileEntry *Fe = SM.getFileEntryForID(TFSL.getFileID());
     std::string FeAbsS = Fn;
-    if (Fe != nullptr)
+    if (Fe != nullptr) {
+      // Unlike in `emit` in RewriteUtils.cpp, we don't re-canonicalize the file
+      // path because of the potential performance cost (mkPSL is called on many
+      // AST nodes in each translation unit) and because we don't have a good
+      // way to handle errors. If there is a problem, `emit` will detect it
+      // before we actually write a file.
       FeAbsS = Fe->tryGetRealPathName().str();
+    }
     Fn = std::string(sys::path::remove_leading_dotslash(FeAbsS));
   }
   PersistentSourceLoc PSL(Fn, FESL.getExpansionLineNumber(),

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -247,6 +247,9 @@ static void emit(Rewriter &R, ASTContext &C) {
             "to failure to re-canonicalize the file path provided by Clang");
         DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
         {
+          // Put this in a block because Clang only allows one DiagnosticBuilder
+          // to exist at a time and the call to PrintExtraUnwritableChangeInfo
+          // below may create more DiagnosticBuilders.
           unsigned NoteId =
               DE.getCustomDiagID(DiagnosticsEngine::Note,
                                  "file path from Clang was %0; error was: %1");
@@ -264,6 +267,7 @@ static void emit(Rewriter &R, ASTContext &C) {
             "because the file path provided by Clang was not canonical");
         DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
         {
+          // Ditto re the block.
           unsigned NoteId = DE.getCustomDiagID(
               DiagnosticsEngine::Note, "file path from Clang was %0; "
                                        "re-canonicalized file path is %1");

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -199,11 +199,11 @@ static void emit(Rewriter &R, ASTContext &C) {
     if (const FileEntry *FE = SM.getFileEntryForID(Buffer->first)) {
       assert(FE->isValid());
 
+      DiagnosticsEngine &DE = C.getDiagnostics();
       DiagnosticsEngine::Level UnwritableChangeDiagnosticLevel =
           AllowUnwritableChanges ? DiagnosticsEngine::Warning
                                  : DiagnosticsEngine::Error;
       auto PrintExtraUnwritableChangeInfo = [&]() {
-        DiagnosticsEngine &DE = C.getDiagnostics();
         // With -dump-unwritable-changes and not -allow-unwritable-changes, we
         // want the -allow-unwritable-changes note before the dump.
         if (!DumpUnwritableChanges) {
@@ -229,11 +229,52 @@ static void emit(Rewriter &R, ASTContext &C) {
       };
 
       // Check whether we are allowed to write this file.
+      //
+      // In our testing as of 2021-03-15, the file path returned by
+      // FE->tryGetRealPathName() was canonical, but be safe against unusual
+      // situations or possible future changes to Clang before we actually write
+      // a file. We can't use FE->getName() because it seems it may be relative
+      // to the `directory` field of the compilation database, which (now that
+      // we no longer use `ClangTool::run`) is not guaranteed to match 3C's
+      // working directory.
       std::string ToConv = FE->tryGetRealPathName().str();
       std::string FeAbsS = "";
-      getCanonicalFilePath(ToConv, FeAbsS);
+      std::error_code EC = tryGetCanonicalFilePath(ToConv, FeAbsS);
+      if (EC) {
+        unsigned ErrorId = DE.getCustomDiagID(
+            UnwritableChangeDiagnosticLevel,
+            "3C internal error: not writing the new version of this file due "
+            "to failure to re-canonicalize the file path provided by Clang");
+        DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
+        {
+          unsigned NoteId =
+              DE.getCustomDiagID(DiagnosticsEngine::Note,
+                                 "file path from Clang was %0; error was: %1");
+          auto ErrorBuilder = DE.Report(NoteId);
+          ErrorBuilder.AddString(ToConv);
+          ErrorBuilder.AddString(EC.message());
+        }
+        PrintExtraUnwritableChangeInfo();
+        continue;
+      }
+      if (FeAbsS != ToConv) {
+        unsigned ErrorId = DE.getCustomDiagID(
+            UnwritableChangeDiagnosticLevel,
+            "3C internal error: not writing the new version of this file "
+            "because the file path provided by Clang was not canonical");
+        DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
+        {
+          unsigned NoteId = DE.getCustomDiagID(
+              DiagnosticsEngine::Note, "file path from Clang was %0; "
+                                       "re-canonicalized file path is %1");
+          auto ErrorBuilder = DE.Report(NoteId);
+          ErrorBuilder.AddString(ToConv);
+          ErrorBuilder.AddString(FeAbsS);
+        }
+        PrintExtraUnwritableChangeInfo();
+        continue;
+      }
       if (!canWrite(FeAbsS)) {
-        DiagnosticsEngine &DE = C.getDiagnostics();
         unsigned ID =
             DE.getCustomDiagID(UnwritableChangeDiagnosticLevel,
                                "3C internal error: 3C generated changes to "
@@ -252,7 +293,6 @@ static void emit(Rewriter &R, ASTContext &C) {
           Buffer->second.write(outs());
           StdoutModeSawMainFile = true;
         } else {
-          DiagnosticsEngine &DE = C.getDiagnostics();
           unsigned ID = DE.getCustomDiagID(
               UnwritableChangeDiagnosticLevel,
               "3C generated changes to this file, which is under the base dir "
@@ -266,7 +306,6 @@ static void emit(Rewriter &R, ASTContext &C) {
 
       // Produce a path/file name for the rewritten source file.
       std::string NFile;
-      std::error_code EC;
       // We now know that we are using either OutputPostfix or OutputDir mode
       // because stdout mode is handled above. OutputPostfix defaults to "-"
       // when it's not provided, so any other value means that we should use
@@ -290,14 +329,13 @@ static void emit(Rewriter &R, ASTContext &C) {
         // fatal error in the _3CInterface constructor.
         assert(filePathStartsWith(FeAbsS, BaseDir));
         // replace_path_prefix is not smart about separators, but this should be
-        // OK because getCanonicalFilePath should ensure that neither BaseDir
+        // OK because tryGetCanonicalFilePath should ensure that neither BaseDir
         // nor OutputDir has a trailing separator.
         SmallString<255> Tmp(FeAbsS);
         llvm::sys::path::replace_path_prefix(Tmp, BaseDir, OutputDir);
         NFile = std::string(Tmp.str());
         EC = llvm::sys::fs::create_directories(sys::path::parent_path(NFile));
         if (EC) {
-          DiagnosticsEngine &DE = C.getDiagnostics();
           unsigned ID = DE.getCustomDiagID(
               DiagnosticsEngine::Error,
               "failed to create parent directory of output file \"%0\"");
@@ -314,7 +352,6 @@ static void emit(Rewriter &R, ASTContext &C) {
           errs() << "writing out " << NFile << "\n";
         Buffer->second.write(Out);
       } else {
-        DiagnosticsEngine &DE = C.getDiagnostics();
         unsigned ID = DE.getCustomDiagID(DiagnosticsEngine::Error,
                                          "failed to write output file \"%0\"");
         auto DiagBuilder = DE.Report(SM.translateFileLineCol(FE, 1, 1), ID);

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -173,12 +173,6 @@ std::error_code tryGetCanonicalFilePath(const std::string &FileName,
   return EC;
 }
 
-void getCanonicalFilePath(const std::string &FileName,
-                          std::string &AbsoluteFp) {
-  std::error_code EC = tryGetCanonicalFilePath(FileName, AbsoluteFp);
-  assert(!EC && "tryGetCanonicalFilePath failed");
-}
-
 bool filePathStartsWith(const std::string &Path, const std::string &Prefix) {
   // If the path exactly equals the prefix, don't ruin it by appending a
   // separator to the prefix. (This may never happen in 3C, but let's get it


### PR DESCRIPTION
Pulled out of https://github.com/correctcomputation/checkedc-clang/pull/488#discussion_r599546827 to ease review.

I'd prefer to have at least the two big comments near the `tryGetRealPathName` calls added to #488 to document the changes made there.  If you don't want to deal with the diagnostic code changes and the related cleanup at this time, that's completely fine with me; let me know and I'll remove them from this PR.