### PR TITLE
Use DiagnosticBuilder `<<` operator to avoid the need for code blocks

### DIFF
--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -599,16 +599,14 @@ ProgramInfo::insertNewFVConstraint(FunctionDecl *FD, FVConstraint *NewC,
   if (ReasonFailed == "") return (*Map)[FuncName];
 
   // Error reporting
-  { // block to force DiagBuilder destructor and emit message
-    clang::DiagnosticsEngine &DE = C->getDiagnostics();
-    unsigned FailID = DE.getCustomDiagID(DiagnosticsEngine::Fatal,
-                                         "merging failed for %q0 due to %1");
-    const auto Pointer = reinterpret_cast<intptr_t>(FD);
-    const auto Kind = clang::DiagnosticsEngine::ArgumentKind::ak_nameddecl;
-    auto DiagBuilder = DE.Report(FD->getLocation(), FailID);
-    DiagBuilder.AddTaggedVal(Pointer, Kind);
-    DiagBuilder.AddString(ReasonFailed);
-  }
+  clang::DiagnosticsEngine &DE = C->getDiagnostics();
+  unsigned FailID = DE.getCustomDiagID(DiagnosticsEngine::Fatal,
+                                       "merging failed for %q0 due to %1");
+  const auto Pointer = reinterpret_cast<intptr_t>(FD);
+  const auto Kind = clang::DiagnosticsEngine::ArgumentKind::ak_nameddecl;
+  auto DiagBuilder = DE.Report(FD->getLocation(), FailID);
+  DiagBuilder.AddTaggedVal(Pointer, Kind);
+  DiagBuilder.AddString(ReasonFailed);
   // A failed merge will provide poor data, but the diagnostic error report
   // will cause the program to terminate after the variable adder step.
   return (*Map)[FuncName];

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -246,17 +246,10 @@ static void emit(Rewriter &R, ASTContext &C) {
             "3C internal error: not writing the new version of this file due "
             "to failure to re-canonicalize the file path provided by Clang");
         DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
-        {
-          // Put this in a block because Clang only allows one DiagnosticBuilder
-          // to exist at a time and the call to PrintExtraUnwritableChangeInfo
-          // below may create more DiagnosticBuilders.
-          unsigned NoteId =
-              DE.getCustomDiagID(DiagnosticsEngine::Note,
-                                 "file path from Clang was %0; error was: %1");
-          auto ErrorBuilder = DE.Report(NoteId);
-          ErrorBuilder.AddString(ToConv);
-          ErrorBuilder.AddString(EC.message());
-        }
+        unsigned NoteId =
+            DE.getCustomDiagID(DiagnosticsEngine::Note,
+                               "file path from Clang was %0; error was: %1");
+        DE.Report(NoteId) << ToConv << EC.message();
         PrintExtraUnwritableChangeInfo();
         continue;
       }
@@ -266,15 +259,10 @@ static void emit(Rewriter &R, ASTContext &C) {
             "3C internal error: not writing the new version of this file "
             "because the file path provided by Clang was not canonical");
         DE.Report(SM.translateFileLineCol(FE, 1, 1), ErrorId);
-        {
-          // Ditto re the block.
-          unsigned NoteId = DE.getCustomDiagID(
-              DiagnosticsEngine::Note, "file path from Clang was %0; "
-                                       "re-canonicalized file path is %1");
-          auto ErrorBuilder = DE.Report(NoteId);
-          ErrorBuilder.AddString(ToConv);
-          ErrorBuilder.AddString(FeAbsS);
-        }
+        unsigned NoteId = DE.getCustomDiagID(
+            DiagnosticsEngine::Note, "file path from Clang was %0; "
+                                     "re-canonicalized file path is %1");
+        DE.Report(NoteId) << ToConv << FeAbsS;
         PrintExtraUnwritableChangeInfo();
         continue;
       }


### PR DESCRIPTION
`DiagosticBuilder` overloads the streaming operator for convenience, we should use it.

It's also likely that emit() would prepare the diagnostic engine for another diagnostic, but I didn't test that.
