### PR TITLE
Fix bounds inference breakage due to declaration merging change (issue #522)

### DIFF
--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -203,6 +203,8 @@ public:
                         const std::set<BoundsKey> &CSRKeys,
                         ASTContext *C, ConstraintResolver *CR);
 
+  void mergeBoundsKey(BoundsKey To, BoundsKey From);
+
   // Handle the arithmetic expression. This is required to adjust bounds
   // for pointers that has pointer arithmetic performed on them.
   void recordArithmeticOperation(clang::Expr *E, ConstraintResolver *CR);

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -874,6 +874,15 @@ AVarBoundsInfo::handlePointerAssignment(clang::Stmt *St, clang::Expr *L,
 }
 
 void
+AVarBoundsInfo::mergeBoundsKey(BoundsKey To, BoundsKey From) {
+  if (InvalidBounds.find(To) != InvalidBounds.end() ||
+      InvalidBounds.find(From) != InvalidBounds.end()) {
+    InvalidBounds.insert(To);
+    InvalidBounds.insert(From);
+  }
+}
+
+void
 AVarBoundsInfo::recordArithmeticOperation(clang::Expr *E,
                                           ConstraintResolver *CR) {
   CVarSet CSet = CR->getExprConstraintVarsSet(E);

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1796,8 +1796,13 @@ void PointerVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV,
   SrcHasItype = SrcHasItype || From->SrcHasItype;
   if (!From->ItypeStr.empty())
     ItypeStr = From->ItypeStr;
+
+  // Merge Bounds Related information.
+  if (hasBoundsKey() && From->hasBoundsKey())
+    Info.getABoundsInfo().mergeBoundsKey(getBoundsKey(), From->getBoundsKey());
   if (!From->BoundsAnnotationStr.empty())
     BoundsAnnotationStr = From->BoundsAnnotationStr;
+
   if (From->GenericIndex >= 0)
     GenericIndex = From->GenericIndex;
   if (FV) {

--- a/clang/test/3C/arrboundsprototypemerge.c
+++ b/clang/test/3C/arrboundsprototypemerge.c
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -f3c-tool -fcheckedc-extension -x c -o %t1.unused -
+
+/*
+Handle function prototype merging in bounds inference.
+https://github.com/correctcomputation/checkedc-clang/issues/522
+*/
+
+#include <string_checked.h>
+
+void fiddle_with_strings(const char *tc) {
+  strdup(tc);
+  strcmp(tc, tc);
+  strcmp(tc, "some really long string");
+}
+//CHECK: void fiddle_with_strings(_Nt_array_ptr<const char> tc) {
+
+void get_string_from_callback(const char *(*callback)(void)) {
+  const char *p = callback();
+  strdup(p);
+}
+//CHECK: void get_string_from_callback(_Ptr<_Nt_array_ptr<const char> (void)> callback) {
+//CHECK:   _Nt_array_ptr<const char> p = callback();

--- a/clang/test/3C/ptrtoconstarr.c
+++ b/clang/test/3C/ptrtoconstarr.c
@@ -88,9 +88,6 @@ int example(void) {
   //CHECK_NOALL: int local[5] = {0};
   compl t = &local;
   //CHECK_ALL: compl t = &local;
-  // The following CHECK comment was malformed (missing the colon after
-  // CHECK_NOALL) and thus didn't execute. When I tried to enable it, it failed.
-  // So comment it out for now. ~ Matt 2021-03-10
-  //COM: CHECK_NOALL: _Ptr<int *> t = &local;
+  //CHECK_NOALL: compl t = &local;
   return (*t)[2];
 }


### PR DESCRIPTION
The new logic to merge multiple prototypes of functions was not handled correctly in the bounds inference code.

Added code to handle the merging of bounds key.