### PR TITLE
Ensure presumed source file paths are canonical when using a compilation database.

### DIFF
--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -96,6 +96,31 @@ ArgumentsAdjuster addVerifyAdjuster() {
     return AdjustedArgs;
   };
 }
+ArgumentsAdjuster canonicalizeSourceFilePathAdjuster() {
+  return [](const CommandLineArguments &Args, StringRef FileName) {
+    std::string AbsoluteFp;
+    std::error_code EC = tryGetCanonicalFilePath(std::string(FileName), AbsoluteFp);
+    assert(!EC && "We canonicalized the source file path during 3C "
+                  "initialization; doing it again in "
+                  "canonicalizeSourceFilePathAdjuster shouldn't fail.");
+    CommandLineArguments AdjustedArgs;
+    for (auto Arg : Args) {
+      if (Arg == FileName) {
+        // XXX We are assuming that any occurrence of the source file path as an
+        // argument should be replaced with the canonical file path. It might be
+        // safer to only match the argument that represents the input file.
+        // Unfortunately, it's hard to do here short of reimplementing compiler
+        // command line parsing. It would be better if LibTooling let us adjust
+        // the parsed option data structures, like we did with the diagnostic
+        // verification options before PR #488.
+        AdjustedArgs.push_back(AbsoluteFp);
+      } else {
+        AdjustedArgs.push_back(Arg);
+      }
+    }
+    return AdjustedArgs;
+  };
+}
 
 void dumpConstraintOutputJson(const std::string &PostfixStr,
                               ProgramInfo &Info) {
@@ -302,6 +327,14 @@ bool _3CInterface::parseASTs() {
   // for status.
   if (VerifyDiagnosticOutput)
     Tool->appendArgumentsAdjuster(addVerifyAdjuster());
+  // We canonicalize source file paths in the _3CInterface constructor, but the
+  // compilation database may override the path with a relative or otherwise
+  // non-canonical path, which may then affect the presumed filename, which is
+  // used in the PersistentSourceLoc. Since we need PersistentSourceLocs to be
+  // unambiguous, we canonicalize the source file path again here. We may still
+  // get relative presumed filenames from relative -I paths, though
+  // convert_project tries to change the -I options to avoid this.
+  Tool->appendArgumentsAdjuster(canonicalizeSourceFilePathAdjuster());
 
   // load the ASTs
   if (Tool->buildASTs(ASTs))

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -110,9 +110,9 @@ ArgumentsAdjuster canonicalizeSourceFilePathAdjuster() {
         // argument should be replaced with the canonical file path. It might be
         // safer to only match the argument that represents the input file.
         // Unfortunately, it's hard to do here short of reimplementing compiler
-        // command line parsing. It would be better if LibTooling let us adjust
-        // the parsed option data structures, like we did with the diagnostic
-        // verification options before PR #488.
+        // command line parsing. It would be better to adjust the parsed option
+        // data structures instead
+        // (https://github.com/correctcomputation/checkedc-clang/issues/536).
         AdjustedArgs.push_back(AbsoluteFp);
       } else {
         AdjustedArgs.push_back(Arg);

--- a/clang/tools/3c/utils/port_tools/generate_ccommands.py
+++ b/clang/tools/3c/utils/port_tools/generate_ccommands.py
@@ -227,6 +227,10 @@ def run3C(checkedc_bin, extra_3c_args,
     # relative paths with -I when different translation units have different
     # working directories. For details, see
     # https://github.com/correctcomputation/checkedc-clang/issues/515 .
+    #
+    # Even if the above issue were fixed, we may still need this in some cases
+    # to ensure that PersistentSourceLoc filenames are unambiguous: see the
+    # comment in _3CInterface::parseASTs in clang/lib/3C/3C.cpp .
     for dir in absolute_include_dirs:
         args.append('-extra-arg-before=-I' + dir)
     vcodewriter.addClangdArg("-log=verbose")


### PR DESCRIPTION
Fixes #529.

This just needs a regression test.  I'd have to figure out the best way to create a compilation database as part of the regression test _and_ demonstrate a problem even if, in the future, we change 3C to always use the presumed file path rather than overriding it with the `SM.getFileEntryForID(TFSL.getFileID())` in some cases (which is what triggered #529).