### PR TITLE
Add new array bounds even when pointer type does not change

### DIFF
--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -715,6 +715,17 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
     return;
   }
 
+  // If the type of the pointer hasn't changed, then neither of the above
+  // branches will be taken, but it's still possible for the bounds of an array
+  // pointer to change.
+  if (ABRewriter.hasNewBoundsString(CV->getExternal(), Decl)) {
+    RewriteParm = true;
+    RewriteRet |= isa_and_nonnull<FunctionDecl>(Decl);
+  }
+  std::string BoundsStr =
+    ABRewriter.getBoundsString(CV->getExternal(), Decl,
+                               !getExistingIType(CV->getExternal()).empty());
+
   // Variables that do not need to be rewritten fall through to here.
   // Try to use the source.
   ParmVarDecl *PVD = dyn_cast_or_null<ParmVarDecl>(Decl);
@@ -723,8 +734,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
     if (Range.isValid() && !inParamMultiDecl(PVD) ) {
       Type = getSourceText(Range, *Context);
       if (!Type.empty()) {
-      // Great, we got the original source including any itype and bounds.
-        IType = "";
+        IType = getExistingIType(CV->getExternal()) + BoundsStr;
         return;
       }
     }
@@ -736,8 +746,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
     Type = CV->mkTypeStr(Info.getConstraints(),true,
                          CV->getExternal()->getName());
   }
-  IType = getExistingIType(CV->getExternal());
-  IType += ABRewriter.getBoundsString(CV->getExternal(), Decl, !IType.empty());
+  IType = getExistingIType(CV->getExternal()) + BoundsStr;
 }
 
 std::string FunctionDeclBuilder::getExistingIType(ConstraintVariable *DeclC) {

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -107,9 +107,10 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
     if (Decl *D = std::get<1>(PSLMap[PLoc])) {
       ConstraintVariable *CV = V.second;
       PVConstraint *PV = dyn_cast<PVConstraint>(CV);
-
-      if (PV && PV->anyChanges(Info.getConstraints().getVariables()) &&
-          !PV->isPartOfFunctionPrototype()) {
+      bool PVChanged = PV &&
+                       (PV->anyChanges(Info.getConstraints().getVariables()) ||
+                        ABRewriter.hasNewBoundsString(PV, D));
+      if (PVChanged && !PV->isPartOfFunctionPrototype()) {
         // Rewrite a declaration, only if it is not part of function prototype.
         DeclStmt *DS = nullptr;
         if (VDLToStmtMap.find(D) != VDLToStmtMap.end())

--- a/clang/test/3C/add_bounds.c
+++ b/clang/test/3C/add_bounds.c
@@ -23,3 +23,24 @@ void fuz(int * a : itype(_Array_ptr<int>)) {
   fiz(a, 4);
   buz(a);
 }
+
+void biz(){
+  _Array_ptr<int> x : count(1) = 0;
+  _Array_ptr<int> y  = x;
+  //CHECK_ALL: _Array_ptr<int> y : count(1) = x;
+
+  int a[10];
+  _Array_ptr<int> b = a;
+  //CHECK_ALL:  int a _Checked[10];
+  //CHECK_ALL: _Array_ptr<int> b : count(10) = a;
+}
+
+#include<stddef.h>
+_Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+_Array_ptr<int> faz(void) {
+//CHECK_ALL: _Array_ptr<int> faz(void) : count(100) {
+  int *c = malloc(100 * sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> c : count(100) = malloc<int>(100 * sizeof(int));
+
+  return c;
+}

--- a/clang/test/3C/add_bounds.c
+++ b/clang/test/3C/add_bounds.c
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/add_bounds.c -- | diff %t.checked/add_bounds.c -
+
+void foo(_Array_ptr<int> b, int n) { }
+// CHECK_ALL: void foo(_Array_ptr<int> b : count(n), int n) _Checked { }
+
+void bar(_Array_ptr<int> b, int n, int *c) { }
+// CHECK_ALL: void bar(_Array_ptr<int> b : count(n), int n, _Ptr<int> c) _Checked { }
+
+_Array_ptr<int> baz(_Array_ptr<int> b) {
+// CHECK_ALL: _Array_ptr<int> baz(_Array_ptr<int> b : count(10)) : count(10) _Checked {
+  foo(b, 10);
+  return b;
+}
+
+void buz(int *);
+void fiz(int * a : itype(_Array_ptr<int>) count(n), int n);
+void fuz(int * a : itype(_Array_ptr<int>)) {
+//CHECK_ALL: void fuz(int * a : itype(_Array_ptr<int>) count(4)) {
+  fiz(a, 4);
+  buz(a);
+}


### PR DESCRIPTION
This change lets 3C add inferred bounds onto checked array pointer even when the type of the pointer has not otherwise changed. Fixes #538 

---

[benchmarks](https://github.com/correctcomputation/actions/actions/runs/733775948)