### PR TITLE
Constrain `printf("%s")` arguments to `_Nt_array_ptr`.

### DIFF
--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -218,4 +218,9 @@ clang::FunctionTypeLoc getFunctionTypeLoc(clang::DeclaratorDecl *Decl);
 
 bool isKAndRFunctionDecl(clang::FunctionDecl *FD);
 
+void getPrintfStringArgIndices(const clang::CallExpr *CE,
+                               const clang::FunctionDecl *Callee,
+                               const clang::ASTContext &Context,
+                               std::set<unsigned> &StringArgIndices);
+
 #endif

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -233,6 +233,10 @@ public:
           TmpC = PVC->getFV();
           assert(TmpC != nullptr && "Function pointer with null FVConstraint.");
         }
+        std::set<unsigned> PrintfStringArgIndices;
+        if (TFD != nullptr)
+          getPrintfStringArgIndices(E, TFD, *Context,
+                                    PrintfStringArgIndices);
         // and for each arg to the function ...
         if (FVConstraint *TargetFV = dyn_cast<FVConstraint>(TmpC)) {
           unsigned I = 0;
@@ -285,6 +289,12 @@ public:
                                             "accepting var args.",
                                             E);
               } else {
+                if (PrintfStringArgIndices.find(I) !=
+                    PrintfStringArgIndices.end()) {
+                  // In `printf("%s", foo)`, foo should be an _Nt_array_ptr
+                  // (https://github.com/correctcomputation/checkedc-clang/issues/549).
+                  constrainVarsTo(ArgumentConstraints.first, CS.getNTArr());
+                }
                 if (Verbose) {
                   std::string FuncName = TargetFV->getName();
                   errs() << "Ignoring function as it contains varargs:"

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -291,7 +291,8 @@ public:
               } else {
                 if (PrintfStringArgIndices.find(I) !=
                     PrintfStringArgIndices.end()) {
-                  // In `printf("%s", foo)`, foo should be an _Nt_array_ptr
+                  // In `printf("... %s ...", ...)`, the argument corresponding
+                  // to the `%s` should be an _Nt_array_ptr
                   // (https://github.com/correctcomputation/checkedc-clang/issues/549).
                   constrainVarsTo(ArgumentConstraints.first, CS.getNTArr());
                 }

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -11,6 +11,8 @@
 #include "clang/3C/Utils.h"
 #include "clang/3C/3CGlobalOptions.h"
 #include "clang/3C/ConstraintVariables.h"
+#include "clang/AST/FormatString.h"
+#include "clang/Sema/Sema.h"
 #include "llvm/Support/Path.h"
 #include <errno.h>
 
@@ -504,4 +506,60 @@ FunctionTypeLoc getFunctionTypeLoc(DeclaratorDecl *Decl) {
 
 bool isKAndRFunctionDecl(FunctionDecl *FD) {
   return !FD->hasPrototype() && FD->getNumParams();
+}
+
+namespace {
+
+// See clang/docs/checkedc/3C/clang-tidy.md#_3c-name-prefix
+// NOLINTNEXTLINE(readability-identifier-naming)
+class _3CFormatStringHandler
+    : public analyze_format_string::FormatStringHandler {
+  unsigned DataStartIdx;
+  std::set<unsigned> &StringArgIndices;
+
+public:
+  _3CFormatStringHandler(unsigned DataStartIdx,
+                         std::set<unsigned> &StringArgIndices)
+      : DataStartIdx(DataStartIdx), StringArgIndices(StringArgIndices) {}
+  bool HandlePrintfSpecifier(const analyze_printf::PrintfSpecifier &FS,
+                             const char *StartSpecifier,
+                             unsigned SpecifierLen) override {
+    if (FS.consumesDataArgument() &&
+        FS.getConversionSpecifier().getKind() ==
+            analyze_printf::PrintfConversionSpecifier::sArg)
+      StringArgIndices.insert(DataStartIdx + FS.getArgIndex());
+    return true;
+  }
+};
+
+} // namespace
+
+// Unfortunately, this duplicates some logic from different parts of
+// SemaChecking.cpp. We handle only the common case. If we get this wrong, it's
+// not a big deal: 3C may just infer some checked pointer types incorrectly.
+void getPrintfStringArgIndices(const CallExpr *CE, const FunctionDecl *Callee,
+                               const clang::ASTContext &Context,
+                               std::set<unsigned> &StringArgIndices) {
+  for (const FormatAttr *Attr : Callee->specific_attrs<FormatAttr>()) {
+    if (Sema::GetFormatStringType(Attr) != Sema::FST_Printf)
+      continue;
+    if (Attr->getFirstArg() == 0)
+      // This means the data arguments are not available to check.
+      continue;
+    unsigned FormatIdx = Attr->getFormatIdx() - 1;
+    unsigned DataStartIdx = Attr->getFirstArg() - 1;
+    if (FormatIdx >= CE->getNumArgs())
+      continue;
+    const Expr *FormatExpr =
+        CE->getArg(FormatIdx)->IgnoreImpCasts()->IgnoreExprTmp();
+    const clang::StringLiteral *FormatLiteral =
+        dyn_cast<clang::StringLiteral>(FormatExpr);
+    if (!FormatLiteral || FormatLiteral->getCharByteWidth() != 1)
+      continue;
+    StringRef Str = FormatLiteral->getString();
+    _3CFormatStringHandler Handler(DataStartIdx, StringArgIndices);
+    analyze_format_string::ParsePrintfString(
+        Handler, Str.data(), Str.data() + Str.size(), Context.getLangOpts(),
+        Context.getTargetInfo(), false);
+  }
 }

--- a/clang/test/3C/printf_ntarr.c
+++ b/clang/test/3C/printf_ntarr.c
@@ -1,0 +1,20 @@
+// Test that "%s" arguments to printf-like functions get constrained to
+// _Nt_array_ptr
+// (https://github.com/correctcomputation/checkedc-clang/issues/549).
+
+// RUN: 3c -alltypes -base-dir=%S %s -- | FileCheck -match-full-lines %s
+
+void my_printf_like_function(int foo, const char *format
+                             : itype(_Nt_array_ptr<const char>), int bar, ...)
+    __attribute__((format(printf, 2, 4)));
+
+// `%s` and `%p` are both valid conversion specifiers for a `char *`: `%s`
+// prints it as a string while `%p` prints the pointer value. We keep everything
+// else the same to test that the conversion specifier causes the difference in
+// pointer type between s1 and s2. For good measure, test that `const char *`
+// also works and we don't fail on non-strings.
+
+void test(int foo, int bar, char *s1, char *s2, int i3, const char *s4) {
+  // CHECK: void test(int foo, int bar, _Nt_array_ptr<char> s1, _Ptr<char> s2, int i3, _Nt_array_ptr<const char> s4) {
+  my_printf_like_function(foo, "%s %p %d %s", bar, s1, s2, i3, s4);
+}


### PR DESCRIPTION
Fixes #549.