### PR TITLE
Fixing bounds of ntarr when strdup is used

### DIFF
--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -130,6 +130,11 @@ private:
 
   void mergeReachableProgramVars(std::set<BoundsKey> &AllVars);
 
+  // Check if the pointer variable has impossible bounds.
+  bool hasImpossibleBounds(BoundsKey BK);
+  // Set the given pointer to have impossible bounds.
+  void setImpossibleBounds(BoundsKey BK);
+
   AVarBoundsInfo *BI;
 
   // Potential Bounds for each bounds key inferred for the current iteration.
@@ -274,6 +279,10 @@ private:
   // Set of BoundsKey that correspond to array pointers.
   std::set<BoundsKey> ArrPointerBoundsKey;
   std::set<BoundsKey> NtArrPointerBoundsKey;
+  // These are array and nt arr pointers which cannot have bounds.
+  // E.g., return value of strdup and in general any return value
+  // which is an nt array.
+  std::set<BoundsKey> PointersWithImpossibleBounds;
   // Set of BoundsKey that correspond to array pointers with in the program
   // being compiled i.e., it does not include array pointers that belong
   // to libraries.

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -217,6 +217,16 @@ AvarBoundsInference::convergeInferredBounds() {
   return FoundSome;
 }
 
+bool AvarBoundsInference::hasImpossibleBounds(BoundsKey BK) {
+  return this->BI->PointersWithImpossibleBounds.find(BK) !=
+         this->BI->PointersWithImpossibleBounds.end();
+}
+
+void AvarBoundsInference::setImpossibleBounds(BoundsKey BK) {
+  this->BI->PointersWithImpossibleBounds.insert(BK);
+  this->BI->removeBounds(BK);
+}
+
 // This function finds all the BoundsKeys (i.e., variables) in
 // scope `DstScope` that are reachable from `FromVarK` in the
 // graph `BKGraph`. All the reachable bounds key will be stored in `PotK`.
@@ -373,10 +383,16 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
         }
       }
     } else if (IsFuncRet ||
-               (BKsFailedFlowInference.find(NBK) != BKsFailedFlowInference.end())) {
+               (BKsFailedFlowInference.find(NBK) !=
+                BKsFailedFlowInference.end())) {
 
       // If this is a function return we should have bounds from all
       // neighbours.
+      ErrorOccurred = true;
+    } else if (hasImpossibleBounds(NBK)) {
+      // if the neighbour has impossible bounds?
+      // Consider that current pointer to also have impossible bounds.
+      setImpossibleBounds(K);
       ErrorOccurred = true;
     }
     if (ErrorOccurred) {
@@ -1106,8 +1122,13 @@ void AVarBoundsInfo::computerArrPointers(ProgramInfo *PI,
         InProgramArrPtrBoundsKeys.insert(Bkey);
       }
 
-      if (hasOnlyNtArray(FV->getInternalReturn(), CS)) {
+      if (hasOnlyNtArray(FV->getExternalReturn(), CS)) {
         NtArrPointerBoundsKey.insert(Bkey);
+        // If the return value is an nt array pointer
+        // and there are no declared bounds? Then, we cannot
+        // find bounds for this pointer.
+        if (getBounds(Bkey) == nullptr)
+          PointersWithImpossibleBounds.insert(Bkey);
       }
       continue;
     }
@@ -1154,6 +1175,9 @@ void AVarBoundsInfo::getBoundsNeededArrPointers(
   }
   // Also add arrays with invalid bounds.
   ArrWithBounds.insert(InvalidBounds.begin(), InvalidBounds.end());
+  // Also, add arrays with impossible bounds.
+  ArrWithBounds.insert(PointersWithImpossibleBounds.begin(),
+                       PointersWithImpossibleBounds.end());
 
   // This are the array atoms that need bounds.
   // i.e., AB = ArrPtrs - ArrPtrsWithBounds.

--- a/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
@@ -533,7 +533,8 @@ bool GlobalABVisitor::VisitFunctionDecl(FunctionDecl *FD) {
         }
       }
 
-      for (auto &CurrNtArr : ParamNtArrays) {
+      // Do not use heuristics for param nt arrays.
+      /*for (auto &CurrNtArr : ParamNtArrays) {
         unsigned PIdx = CurrNtArr.first;
         BoundsKey PBKey = CurrNtArr.second.second;
         if (LengthParams.find(PIdx + 1) != LengthParams.end()) {
@@ -544,7 +545,7 @@ bool GlobalABVisitor::VisitFunctionDecl(FunctionDecl *FD) {
             continue;
           }
         }
-      }
+      }*/
     }
   }
   return true;

--- a/clang/test/3C/ntarrbounds.c
+++ b/clang/test/3C/ntarrbounds.c
@@ -1,0 +1,40 @@
+/**
+Tests for ntarr pointer bounds.
+Issue: https://github.com/correctcomputation/checkedc-clang/issues/553
+**/
+
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unusedl -
+// RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o %t2.unused -
+
+
+#include <string_checked.h>
+void foo(char *p, int x) {
+  char *q = p;
+  if (x)
+    q = strdup("hello"); // len("hello") < 15
+  else
+    x = strlen(q);
+}
+//CHECK_NOALL: void foo(char *p : itype(_Ptr<char>), int x) {
+//CHECK_ALL: void foo(_Nt_array_ptr<char> p, int x) {
+//CHECK_ALL: _Nt_array_ptr<char> q = p;
+//CHECK_ALL: q = ((_Nt_array_ptr<char> )strdup("hello")); // len("hello") < 15
+
+void bar(void) {
+  char buf[15];
+  foo(buf,1);
+}
+//CHECK_ALL: char buf _Nt_checked[15];
+
+char *baz(void) {
+  char *p;
+  p = strdup("baz");
+  return p;
+}
+//CHECK_NOALL: char *baz(void) : itype(_Ptr<char>) {
+//CHECK_ALL: _Nt_array_ptr<char> baz(void) {
+//CHECK_ALL: _Nt_array_ptr<char> p = ((void *)0);
+//CHECK_ALL: p = ((_Nt_array_ptr<char> )strdup("baz"));


### PR DESCRIPTION
We omit issuing bounds for nt array points that are return values.

More details refer Issue: https://github.com/correctcomputation/checkedc-clang/issues/553