### PR TITLE
Merge from Microsoft 2021-04-30

### DIFF
--- a/clang/automation/travis/README.md
+++ b/clang/automation/travis/README.md
@@ -1,7 +1,7 @@
 # Build System for Checked C
 
 Because Building Clang/LLVM is actually really complicated, we have
-this repository as a completely seperate space to build within.
+this repository as a completely separate space to build within.
 
 Effectively, we clone all the repos we want to build into the correct
 structure within this directory, and then build. This works because it means we can
@@ -35,8 +35,8 @@ All the following commands should be run within the current directory.
   checks out the correct branches for the build. It then uses cmake to make a build directory, installs lnt
   into the virtualenv that `install.sh` created. It's probably sensible to run this as `. ./checkout.sh` too.
 - Run `make -j${NPROC} --no-print-directory -C llvm.build`, which goes into the llvm.build directory
-  and builds all the executables, including clang. This is a seperate step to the next one on travis so
-  that the logs are kept seperate (this produces lots of logs, most of which are useless).
+  and builds all the executables, including clang. This is a separate step to the next one on travis so
+  that the logs are kept separate (this produces lots of logs, most of which are useless).
 - Run `make -j${NPROC} --no-print-directory -C llvm.build --keep-going check-checkedc check-clang`,
   which goes into llvm.build and runs the checkedc tests and clang regression tests
 - Run `./llvm.lnt.ve/bin/lnt runtest nt --sandbox ./llvm.lnt.sandbox --cc ./llvm.build/bin/clang --test-suite ./llvm-test-suite --cflags -fcheckedc-extension`,

--- a/clang/include/clang/AST/ExprUtils.h
+++ b/clang/include/clang/AST/ExprUtils.h
@@ -17,6 +17,7 @@
 
 #include "clang/AST/Expr.h"
 #include "clang/Sema/Sema.h"
+#include <queue>
 
 namespace clang {
 
@@ -64,5 +65,42 @@ public:
                    const llvm::APInt &I, llvm::APInt &Result);
 };
 
+} // end namespace clang
+
+namespace clang {
+  // QueueSet is a queue backed by a set. The queue is useful for processing
+  // the items in a Topological sort order which means that if item1 is a
+  // predecessor of item2 then item1 is processed before item2. The set is
+  // useful for maintaining uniqueness of items added to the queue.
+
+  template <class T>
+  class QueueSet {
+  private:
+    std::queue<T *> _queue;
+    llvm::DenseSet<T *> _set;
+
+  public:
+    T *next() const {
+      return _queue.front();
+    }
+
+    void remove(T *B) {
+      if (_queue.empty())
+        return;
+      _queue.pop();
+      _set.erase(B);
+    }
+
+    void append(T *B) {
+      if (!_set.count(B)) {
+        _queue.push(B);
+        _set.insert(B);
+      }
+    }
+
+    bool empty() const {
+      return _queue.empty();
+    }
+  };
 } // end namespace clang
 #endif

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1843,6 +1843,9 @@ class ValueStmt : public Stmt {
 protected:
   using Stmt::Stmt;
 
+private:
+  WhereClause *WClause = nullptr;
+
 public:
   const Expr *getExprStmt() const;
   Expr *getExprStmt() {
@@ -1854,6 +1857,9 @@ public:
     return T->getStmtClass() >= firstValueStmtConstant &&
            T->getStmtClass() <= lastValueStmtConstant;
   }
+
+  void setWhereClause(WhereClause *WC) { WClause = WC; }
+  WhereClause *getWhereClause() const { return WClause; }
 };
 
 /// LabelStmt - Represents a label, which has a substatement.  For example:

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -264,6 +264,7 @@ BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables
 BENIGN_LANGOPT(DumpInferredBounds, 1, 0, "dump inferred Checked C bounds for assignments and declarations")
 BENIGN_LANGOPT(DumpExtractedComparisonFacts, 1, 0, "dump extracted comparison facts")
 BENIGN_LANGOPT(DumpWidenedBounds, 1, 0, "dump widened bounds")
+BENIGN_LANGOPT(DumpBoundsVars, 1, 0, "dump bounds vars")
 BENIGN_LANGOPT(DumpPreorderAST, 1, 0, "dump the preorder AST")
 BENIGN_LANGOPT(DumpCheckingState, 1, 0, "dump the state during bounds checking")
 LANGOPT(InjectVerifierCalls, 1, 0, "Injects calls to VERIFIER_assume and VERIFIER_error in the bitcode")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -854,6 +854,8 @@ def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-f
   HelpText<"Dump extracted comparison facts">;
 def fdump_widened_bounds : Flag<["-"], "fdump-widened-bounds">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump widened bounds">;
+def fdump_boundsvars : Flag<["-"], "fdump-boundsvars">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Dump bounds vars">;
 def fdump_preorder_ast : Flag<["-"], "fdump-preorder-ast">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump the preorder AST">;
 def fdump_checking_state : Flag<["-"], "fdump-checking-state">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/include/clang/Sema/BoundsAnalysis.h
+++ b/clang/include/clang/Sema/BoundsAnalysis.h
@@ -20,45 +20,6 @@
 #include "clang/AST/ExprUtils.h"
 #include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Sema/Sema.h"
-#include <queue>
-
-namespace clang {
-  // QueueSet is a queue backed by a set. The queue is useful for processing
-  // the items in a Topological sort order which means that if item1 is a
-  // predecessor of item2 then item1 is processed before item2. The set is
-  // useful for maintaining uniqueness of items added to the queue.
-
-  template <class T>
-  class QueueSet {
-  private:
-    std::queue<T *> _queue;
-    llvm::DenseSet<T *> _set;
-
-  public:
-    T *next() const {
-      return _queue.front();
-    }
-
-    void remove(T *B) {
-      if (_queue.empty())
-        return;
-      _queue.pop();
-      _set.erase(B);
-    }
-
-    void append(T *B) {
-      if (!_set.count(B)) {
-        _queue.push(B);
-        _set.insert(B);
-      }
-    }
-
-    bool empty() const {
-      return _queue.empty();
-    }
-  };
-
-} // end namespace clang
 
 namespace clang {
   // Note: We use the shorthand "ntptr" to denote _Nt_array_ptr. We extract the

--- a/clang/include/clang/Sema/BoundsWideningAnalysis.h
+++ b/clang/include/clang/Sema/BoundsWideningAnalysis.h
@@ -1,0 +1,69 @@
+//===== BoundsWideningAnalysis.h - Dataflow analysis for bounds widening ====//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//  This file defines the interface for a dataflow analysis for bounds
+//  widening.
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
+#define LLVM_CLANG_BOUNDS_WIDENING_ANALYSIS_H
+
+#include "clang/AST/CanonBounds.h"
+#include "clang/Analysis/Analyses/PostOrderCFGView.h"
+#include "clang/Sema/CheckedCAnalysesPrepass.h"
+#include "clang/Sema/Sema.h"
+
+namespace clang {
+  // BoundsMapTy maps a null-terminated array variable to its bounds
+  // expression.
+  using BoundsMapTy = llvm::DenseMap<const VarDecl *, BoundsExpr *>;
+
+  // StmtBoundsMapTy maps each null-terminated array variable that occurs in a
+  // statement to its bounds expression.
+  using StmtBoundsMapTy = llvm::DenseMap<const Stmt *, BoundsMapTy>;
+
+  // StmtVarSetTy denotes a set of null-terminated array variables that are
+  // associated with a statement. The set of variables whose bounds are killed
+  // by a statement has the type StmtVarSetTy.
+  using StmtVarSetTy = llvm::DenseMap<const Stmt *, VarSetTy>;
+
+  // The BoundsWideningAnalysis class represents the dataflow analysis for
+  // bounds widening. The sets In, Out, Gen and Kill that are used by the
+  // analysis are members of this class. The class also has methods that act on
+  // these sets to perform the dataflow analysis.
+  class BoundsWideningAnalysis {
+  private:
+    Sema &S;
+    CFG *Cfg;
+    ASTContext &Ctx;
+    Lexicographic Lex;
+    llvm::raw_ostream &OS;
+
+    class ElevatedCFGBlock {
+    public:
+      const CFGBlock *Block;
+      // The In and Out sets for a block.
+      BoundsMapTy In, Out;
+      // The Gen set for each statement in a block.
+      StmtBoundsMapTy Gen;
+      // The Kill set for each statement in a block.
+      StmtVarSetTy Kill;
+
+      ElevatedCFGBlock(const CFGBlock *B) : Block(B) {}
+    };
+  
+  public:
+    BoundsWideningAnalysis(Sema &S, CFG *Cfg) :
+      S(S), Cfg(Cfg), Ctx(S.Context),
+      Lex(Lexicographic(Ctx, nullptr)),
+      OS(llvm::outs()) {}
+  };
+
+} // end namespace clang
+#endif

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -1,0 +1,57 @@
+//===--- CheckedCAnalysesPrepass.h: Data used by Checked C analyses ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+//
+//  This file defines a set of information that is gathered in a single
+//  pass over a function. This information is used by different Checked C
+//  analyses such as bounds declaration checking, bounds widening, etc.
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CHECKEDC_ANALYSES_PREPASS_H
+#define LLVM_CLANG_CHECKEDC_ANALYSES_PREPASS_H
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+
+namespace clang {
+  // VarUsageTy maps a VarDecl to a DeclRefExpr that is a use of the VarDecl.
+  using VarUsageTy = llvm::DenseMap<const VarDecl *, DeclRefExpr *>;
+
+  // VarSetTy denotes a set of variables.
+  using VarSetTy = llvm::SmallPtrSet<const VarDecl *, 2>;
+
+  // BoundsVarsTy maps a variable Z to the set of all variables in whose bounds
+  // expressions Z occurs.
+  using BoundsVarsTy = llvm::DenseMap<const VarDecl *, VarSetTy>;
+
+  // VarListTy denotes a list of variables.
+  using VarListTy = llvm::SmallVector<const VarDecl *, 2>;
+
+  struct PrepassInfo {
+    // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
+    // that is the first use of V, if V fulfills the following conditions:
+    // 1. V is used in a declared bounds expression, or:
+    // 2. V has a declared bounds expression.
+    VarUsageTy VarUses;
+
+    // BoundsVars maps each variable Z in a function to the set of all
+    // variables in whose bounds expressions Z occurs. A variable Z can occur
+    // in the bounds expression of a variable V if
+    // 1. Z occurs in the declared bounds expression of V, or
+    // 2. A where clause declares bounds B of V and Z occurs in B.
+
+    // Note: BoundsVarsTy is a map of keys to values which are sets. As a
+    // result, there is no defined iteration order for either its keys or its
+    // values. So in case we want to iterate BoundsVars and need a determinstic
+    // iteration order we must remember to sort the keys as well as the values.
+    BoundsVarsTy BoundsVars;
+  };
+} // end namespace clang
+#endif

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -44,6 +44,7 @@
 #include "clang/Basic/TemplateKinds.h"
 #include "clang/Basic/TypeTraits.h"
 #include "clang/Sema/AnalysisBasedWarnings.h"
+#include "clang/Sema/CheckedCAnalysesPrepass.h"
 #include "clang/Sema/CleanupInfo.h"
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/ExternalSemaSource.h"
@@ -5738,6 +5739,11 @@ public:
   // will expand it to a range bounds expression.
   BoundsExpr *ExpandBoundsToRange(const VarDecl *D, const BoundsExpr *B);
 
+  // Returns the declared bounds for the lvalue expression E. Assignments
+  // to E must satisfy these bounds. After checking a top-level statement,
+  // the inferred bounds of E must imply these declared bounds.
+  BoundsExpr *GetLValueDeclaredBounds(Expr *E);
+
   //
   // Track variables that in-scope bounds declarations depend upon.
   // TODO: generalize this to other lvalue expressions.
@@ -5820,6 +5826,12 @@ public:
   /// been attached to FD yet.
   void ComputeBoundsDependencies(ModifiedBoundsDependencies &Tracker,
                                  FunctionDecl *FD, Stmt *Body);
+
+  /// \brief Traverse a function in order to gather information that is
+  /// used by different Checked C analyses such as bounds declaration
+  /// checking, bounds widening, etc.
+  void CheckedCAnalysesPrepass(PrepassInfo &Info, FunctionDecl *FD,
+                               Stmt *Body);
 
   /// \brief RAII class used to indicate that we are substituting an expression
   /// into another expression during bounds checking.  We need to suppress 

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -2085,9 +2085,24 @@ void CFGBuilder::prependAutomaticObjLifetimeWithTerminator(
   if (!BuildOpts.AddLifetime)
     return;
   BumpVectorContext &C = cfg->getBumpVectorContext();
+
+  // Note that B is the LocalScope iterator associated with the backpatched
+  // jump and E is the LocalScope iterator associated with the jump target.
+  //
+  // To go from B to E, one first goes up the scopes from B to AncestorOfB,
+  // then sideways in one scope from AncestorOfB to AncestorOfE and then down
+  // the scopes from AncestorOfE to E.
+  // The lifetime of all objects between B and AncestorOfE end.
+  //
+  // Get E's and B's nearest ancestors, both of which have the same LocalScope.
+  LocalScope::const_iterator AncestorOfE = E.shared_parent(B);
+  int Dist = B.distance(AncestorOfE);
+  if (Dist <= 0)
+    return;
+
   CFGBlock::iterator InsertPos =
-      Blk->beginLifetimeEndsInsert(Blk->end(), B.distance(E), C);
-  for (LocalScope::const_iterator I = B; I != E; ++I) {
+      Blk->beginLifetimeEndsInsert(Blk->end(), Dist, C);
+  for (LocalScope::const_iterator I = B; I != AncestorOfE; ++I) {
     InsertPos =
         Blk->insertLifetimeEnds(InsertPos, *I, Blk->getTerminatorStmt());
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2846,6 +2846,9 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   if (Args.hasArg(OPT_fdump_widened_bounds))
     Opts.DumpWidenedBounds = true;
 
+  if (Args.hasArg(OPT_fdump_boundsvars))
+    Opts.DumpBoundsVars = true;
+
   if (Args.hasArg(OPT_fdump_preorder_ast))
     Opts.DumpPreorderAST = true;
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -496,9 +496,29 @@ StmtResult Parser::ParseExprStatement(ParsedStmtContext StmtCtx) {
     return ParseCaseStatement(StmtCtx, /*MissingCase=*/true, Expr);
   }
 
+  // Parse where clause on an ExprStmt, if it exists.
+  WhereClause *WClause = nullptr;
+  bool WhereClauseExists = false;
+  if (StartsWhereClause(Tok)) {
+    WClause = ParseWhereClause();
+    if (!WClause)
+      return StmtError();
+    WhereClauseExists = true;
+  }
+
   // Otherwise, eat the semicolon.
   ExpectAndConsumeSemi(diag::err_expected_semi_after_expr);
-  return handleExprStmt(Expr, StmtCtx);
+
+  StmtResult StmtRes = handleExprStmt(Expr, StmtCtx);
+  if (StmtRes.isInvalid() || !WhereClauseExists)
+    return StmtRes;
+
+  ValueStmt *VS = dyn_cast<ValueStmt>(StmtRes.get());
+  if (!VS)
+    llvm_unreachable("where clause on invalid statement");
+
+  VS->setWhereClause(WClause);
+  return StmtRes;
 }
 
 /// ParseSEHTryBlockCommon

--- a/clang/lib/Sema/AvailableFactsAnalysis.cpp
+++ b/clang/lib/Sema/AvailableFactsAnalysis.cpp
@@ -73,12 +73,14 @@ void AvailableFactsAnalysis::Analyze() {
   // Which blocks contain potential pointer assignments?
   std::vector<bool> PointerAssignmentInBlocks(Blocks.size(), false);
   for (unsigned int Index = 0; Index < Blocks.size(); Index++) {
-    for (CFGElement Elem : *(Blocks[Index]->Block))
-      if (const Expr *E = dyn_cast<Expr>(Elem.castAs<CFGStmt>().getStmt()))
-        if (ContainsPointerAssignment(E)) {
-          PointerAssignmentInBlocks[Index] = true;
-          break;
-        }
+    for (CFGElement Elem : *(Blocks[Index]->Block)) {
+      if (Elem.getKind() == CFGElement::Statement)
+        if (const Expr *E = dyn_cast<Expr>(Elem.castAs<CFGStmt>().getStmt()))
+          if (ContainsPointerAssignment(E)) {
+            PointerAssignmentInBlocks[Index] = true;
+            break;
+          }
+    }
   }
 
   // Compute Kill Sets

--- a/clang/lib/Sema/BoundsAnalysis.cpp
+++ b/clang/lib/Sema/BoundsAnalysis.cpp
@@ -687,13 +687,13 @@ T BoundsAnalysis::Intersect(T &A, T &B) const {
     return Ret;
   }
 
-  for (auto I = Ret.begin(), E = Ret.end(); I != E;) {
+  // As the container iterated over by Ret is modified within the
+  // body of the loop, we need to evaluate Ret.end() each time.
+  for (auto I = Ret.begin(); I != Ret.end();) {
     const auto *V = I->first;
 
     if (!B.count(V)) {
-      auto Next = std::next(I);
-      Ret.erase(I);
-      I = Next;
+      I = Ret.erase(I);
     } else {
       Ret[V] = std::min(Ret[V], B[V]);
       ++I;

--- a/clang/lib/Sema/BoundsWideningAnalysis.cpp
+++ b/clang/lib/Sema/BoundsWideningAnalysis.cpp
@@ -1,0 +1,17 @@
+//===== BoundsWideningAnalysis.h - Dataflow analysis for bounds widening ====//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+// This file implements a dataflow analysis for bounds widening as described in
+// https://github.com/microsoft/checkedc-clang/blob/master/clang/docs/checkedc/Bounds-Widening-for-Null-Terminated-Arrays.md
+//===---------------------------------------------------------------------===//
+
+#include "clang/Sema/BoundsWideningAnalysis.h"
+
+namespace clang {
+} // end namespace clang

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -24,7 +24,9 @@ add_clang_library(clangSema
   AnalysisBasedWarnings.cpp
   AvailableFactsAnalysis.cpp
   BoundsAnalysis.cpp
+  BoundsWideningAnalysis.cpp
   CheckedCAlias.cpp
+  CheckedCAnalysesPrepass.cpp
   CheckedCInterop.cpp
   CheckedCSubst.cpp
   CodeCompleteConsumer.cpp

--- a/clang/lib/Sema/CheckedCAlias.cpp
+++ b/clang/lib/Sema/CheckedCAlias.cpp
@@ -498,6 +498,8 @@ namespace {
 // Update mapping from expressions that modify lvalues (assignments,
 // increment/decrement expressions) to bounds expressions that use those
 // lvalues.
+// Also update a mapping from VarDecls with bounds expressions to the first
+// use of the VarDecl that occurs within a given statement.
  class ModifyingExprDependencies {
  private:
    Sema &SemaRef;

--- a/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
+++ b/clang/lib/Sema/CheckedCAnalysesPrepass.cpp
@@ -1,0 +1,189 @@
+//===--- CheckedCAnalysesPrepass.cpp: Data used by Checked C analyses ---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+//  This file implements methods to traverse a function and gather different
+//  kinds of information. This information is used by different Checked C
+//  analyses such as bounds declaration checking, bounds widening, etc.
+//
+//===---------------------------------------------------------------------===//
+
+#include "clang/Sema/CheckedCAnalysesPrepass.h"
+#include "clang/Sema/Sema.h"
+
+using namespace clang;
+
+class PrepassHelper : public RecursiveASTVisitor<PrepassHelper> {
+  private:
+    Sema &SemaRef;
+    PrepassInfo &Info;
+
+    // VarWithBounds is a variable that has a bounds expression. It is used to
+    // track:
+    // 1. Whether a visited expression is within a declared or a where clause
+    // bounds expression. For example, VarWithBounds tracks the expressions
+    // "lower" and "upper" in the following:
+    // _Nt_array_ptr<char> p : bounds(lower, upper);
+    // int x = 1 _Where p : bounds(lower, upper);
+
+    // 2. The variable with which a declared or a where clause bounds
+    // expression is associated. For example, VarWithBounds tracks the variable
+    // "p" in the following:
+    // _Nt_array_ptr<char> p : bounds(lower, upper);
+    // int x = 1 _Where p : bounds(lower, upper);
+
+    VarDecl *VarWithBounds = nullptr;
+    llvm::raw_ostream &OS;
+
+  public:
+    PrepassHelper(Sema &SemaRef, PrepassInfo &Info) :
+      SemaRef(SemaRef), Info(Info), OS(llvm::outs()) {}
+
+    bool VisitVarDecl(VarDecl *V) {
+      if (!V || V->isInvalidDecl())
+        return true;
+      // If V has a bounds expression, traverse it so we visit the
+      // DeclRefExprs within the bounds.
+      if (V->hasBoundsExpr()) {
+        if (BoundsExpr *B = SemaRef.NormalizeBounds(V)) {
+          VarWithBounds = V;
+          TraverseStmt(B);
+          VarWithBounds = nullptr;
+        }
+      }
+      // Process any where clause attached to this VarDecl.
+      // Note: This also handles function parameters.
+      // For example,
+      // int x = 1 _Where p : bounds(lower, upper);
+      // void f(_Nt_array_ptr<char> p : bounds(lower, upper)) {}
+      return ProcessWhereClause(V->getWhereClause());
+    }
+
+    // We may modify the VarUses map when a DeclRefExpr is visited.
+    bool VisitDeclRefExpr(DeclRefExpr *E) {
+      const VarDecl *V = dyn_cast_or_null<VarDecl>(E->getDecl());
+      if (!V || V->isInvalidDecl())
+        return true;
+      // We only add the V => E pair to the VarUses map if:
+      // 1. E is within a declared bounds expression, or:
+      // 2. V has a declared bounds expression.
+      if (VarWithBounds || V->hasBoundsExpr()) {
+        if (!Info.VarUses.count(V))
+          Info.VarUses[V] = E;
+      }
+
+      // We add VarWithBounds to the set of all variables in whose bounds
+      // expressions V occurs.
+      if (VarWithBounds) {
+        auto It = Info.BoundsVars.find(V);
+        if (It != Info.BoundsVars.end())
+          It->second.insert(VarWithBounds);
+        else {
+          VarSetTy Vars;
+          Vars.insert(VarWithBounds);
+          Info.BoundsVars[V] = Vars;
+        }
+      }
+
+      return true;
+    }
+
+    bool ProcessWhereClause(WhereClause *WC) {
+      if (!WC)
+        return true;
+
+      for (WhereClauseFact *Fact : WC->getFacts()) {
+        if (BoundsDeclFact *BDF = dyn_cast<BoundsDeclFact>(Fact)) {
+          VarDecl *V = BDF->Var;
+          BoundsExpr *B = BDF->Bounds;
+
+          VarDecl *OrigVarWithBounds = VarWithBounds;
+          VarWithBounds = V;
+          TraverseStmt(B);
+          VarWithBounds = OrigVarWithBounds;
+        }
+      }
+
+      return true;
+    }
+
+    bool VisitNullStmt(NullStmt *S) {
+      // Process any where clause attached to a NullStmt. For example,
+      // _Where p : bounds(lower, upper);
+      return ProcessWhereClause(S->getWhereClause());
+    }
+
+    bool VisitValueStmt(ValueStmt *S) {
+      // Process any where clause attached to a ValueStmt. For example,
+      // x = 1 _Where p : bounds(lower, upper);
+      return ProcessWhereClause(S->getWhereClause());
+    }
+
+    void DumpBoundsVars(FunctionDecl *FD) {
+      OS << "--------------------------------------\n"
+         << "In function: " << FD->getName() << "\n"
+         << "BoundsVars:\n";
+
+      // Info.BoundsVars is a map of VarDecls (keys) to a set of VarDecls
+      // (values). So there is no defined iteration order for its keys or
+      // values. So we copy the keys to a vector, sort the vector and then
+      // iterate it. While iterating each key we also copy its value (which is
+      // a set of VarDecls) to a vector, sort the vector and iterate it.
+      VarListTy Vars;
+      for (const auto item : Info.BoundsVars)
+        Vars.push_back(item.first);
+
+      SortVars(Vars);
+
+      for (const auto V : Vars) {
+        OS << V->getQualifiedNameAsString() << ": { ";
+
+        VarListTy InnerVars;
+        for (const auto item : Info.BoundsVars[V])
+          InnerVars.push_back(item);
+
+        SortVars(InnerVars);
+
+        for (const auto InnerV : InnerVars)
+          OS << InnerV->getQualifiedNameAsString() << " ";
+        OS << "}\n";
+      }
+      OS << "--------------------------------------\n";
+    }
+
+    void SortVars(VarListTy &Vars) {
+      // Sort variables by their name. If two variables in a function have the
+      // same name (for example, a variable in a nested scope that shadows a
+      // variable from an outer scope), then we sort them by their source
+      // locations.
+      llvm::sort(Vars.begin(), Vars.end(),
+                 [](const VarDecl *A, const VarDecl *B) {
+                   int StrCompare = A->getQualifiedNameAsString().compare(
+                                    B->getQualifiedNameAsString());
+                   return StrCompare != 0 ?
+                          StrCompare < 0 :
+                          A->getLocation() < B->getLocation();
+                 });
+    }
+};
+
+// Traverse a function in order to gather information that is used by different
+// Checked C analyses such as bounds declaration checking, bounds widening, etc.
+void Sema::CheckedCAnalysesPrepass(PrepassInfo &Info, FunctionDecl *FD,
+                                   Stmt *Body) {
+  PrepassHelper Prepass(*this, Info);
+  for (auto I = FD->param_begin(); I != FD->param_end(); ++I) {
+    ParmVarDecl *Param = *I;
+    Prepass.VisitVarDecl(Param);
+  }
+  Prepass.TraverseStmt(Body);
+
+  if (getLangOpts().DumpBoundsVars)
+    Prepass.DumpBoundsVars(FD);
+}

--- a/clang/test/CheckedC/dump-dataflow-facts.c
+++ b/clang/test/CheckedC/dump-dataflow-facts.c
@@ -18,25 +18,25 @@ void fn_1(void) {
       b = c;
 
 // CHECK-LABEL: fn_1
+// CHECK-NEXT: Block #5: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #4: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #3: {
-// CHECK-NEXT: In:
+// CHECK-NEXT: In: (b, c),
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #2: {
 // CHECK-NEXT: In: (b, c),
 // CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
-// CHECK-NEXT: In: (b, c),
-// CHECK-NEXT: Kill:
 // CHECK-DAG: (b, c),
 // CHECK-DAG: (c, b),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #0: {
+// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -56,19 +56,23 @@ void fn_2(void) {
     q = n;
 
 // CHECK-LABEL: fn_2
+// CHECK-NEXT: Block #9: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #8: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #7: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In: (e1, e2),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (b, c),
 // CHECK-DAG: (c, b),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #6: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
@@ -78,21 +82,17 @@ void fn_2(void) {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #3: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: Block #2: {
 // CHECK-NEXT: In: (c, b),
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In: (b, c),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (b, c),
 // CHECK-DAG: (c, b),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #0: {
+// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -104,6 +104,10 @@ void fn_3(void) {
     a = b;
 
 // CHECK-LABEL: fn_3
+// CHECK-NEXT: Block #7: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
@@ -125,10 +129,6 @@ void fn_3(void) {
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #1: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -142,6 +142,10 @@ void fn_4(void) {
   }
 
 // CHECK-LABEL: fn_4
+// CHECK-NEXT: Block #7: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
@@ -149,28 +153,28 @@ void fn_4(void) {
 // CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #4: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
 // CHECK-DAG: (c, b),
 // CHECK-DAG: (b, c),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #3: {
+// CHECK-NEXT: Block #4: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In: (c, b),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (c, b),
 // CHECK-DAG: (b, c),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: Block #2: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -249,6 +253,10 @@ void fn_7(void) {
   }
 
 // CHECK-LABEL: fn_7
+// CHECK-NEXT: Block #9: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #8: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
@@ -256,36 +264,36 @@ void fn_7(void) {
 // CHECK-NEXT: Block #7: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #6: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
 // CHECK-DAG: (a, b),
 // CHECK-DAG: (b, a),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #5: {
+// CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #4: {
+// CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In: (a, b),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (c, b),
 // CHECK-DAG: (b, c),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #3: {
+// CHECK-NEXT: Block #4: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: Block #2: {
 // CHECK-NEXT: In: (b, c),
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In: (c, b),
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -302,6 +310,10 @@ void fn_8(void) {
     c = a;
 
 // CHECK-LABEL: fn_8
+// CHECK-NEXT: Block #6: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
@@ -319,10 +331,6 @@ void fn_8(void) {
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #1: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -471,21 +479,21 @@ void fn_11(void) {
   }
 
 // CHECK-LABEL: fn_11
+// CHECK-NEXT: Block #4: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #2: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In: (*p, a),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (*p, a),
 // CHECK-DAG: (a, *p),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #0: {
+// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -569,21 +577,29 @@ void fn_13(void) {
     _Unchecked { printf("\n"); }
 
 // CHECK-LABEL: fn_13
+// CHECK-NEXT: Block #8: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #7: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #6: {
+// CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
+// CHECK-DAG: (0, x),
+// CHECK-DAG: (x, 0),
 // CHECK-NEXT: Kill:
+// CHECK-DAG: (0, x),
+// CHECK-DAG: (x, 0),
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #4: {
 // CHECK-NEXT: In:
-// CHECK-DAG: (0, x),
-// CHECK-DAG: (x, 0),
 // CHECK-NEXT: Kill:
-// CHECK-DAG: (0, x),
-// CHECK-DAG: (x, 0),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In:
@@ -593,11 +609,7 @@ void fn_13(void) {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #5: {
+// CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -629,21 +641,25 @@ void fn_14(void) {
   }
 
 // CHECK-LABEL: fn_14
-// CHECK-NEXT: Block #11: {
+// CHECK-NEXT: Block #12: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #10: {
+// CHECK-NEXT: Block #11: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (arr1[c], a),
 // CHECK-DAG: (a, arr2[c]),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #9: {
+// CHECK-NEXT: Block #10: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #3: {
+// CHECK-NEXT: Block #4: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -651,13 +667,17 @@ void fn_14(void) {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (arr1[c], a),
 // CHECK-DAG: (a, arr2[c]),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #9: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
@@ -665,25 +685,21 @@ void fn_14(void) {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #7: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #5: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-DAG: (arr1[c], a),
-// CHECK-DAG: (a, arr2[c]),
-// CHECK-NEXT: }
 // CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-DAG: (arr1[c], a),
+// CHECK-DAG: (a, arr2[c]),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #7: {
+// CHECK-NEXT: In:
 // CHECK-DAG: (arr1[c], a),
 // CHECK-DAG: (a, arr2[c]),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (arr1[c], a),
 // CHECK-DAG: (a, arr2[c]),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #4: {
+// CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (arr1[c], a),
@@ -838,19 +854,23 @@ void fn_16(_Ptr<struct st_80_arr> arr, int b) {
     arr->e = a;
   }
 // CHECK-LABEL: fn_16
+// CHECK-NEXT: Block #4: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #2: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
 // CHECK-NEXT: In: (arr->c, b),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (arr->c, b),
 // CHECK-DAG: (b, arr->c),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
@@ -865,6 +885,10 @@ void fn_17(void) {
       ((c))++;
   }
 // CHECK-LABEL: fn_17
+// CHECK-NEXT: Block #7: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
+// CHECK-NEXT: }
 // CHECK-NEXT: Block #6: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
@@ -872,28 +896,28 @@ void fn_17(void) {
 // CHECK-NEXT: Block #5: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
-// CHECK-NEXT: }
-// CHECK-NEXT: Block #4: {
-// CHECK-NEXT: In:
-// CHECK-NEXT: Kill:
 // CHECK-DAG: (c, b),
 // CHECK-DAG: (b, c),
+// CHECK-NEXT: }
+// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: In:
+// CHECK-NEXT: Kill:
 // CHECK-NEXT: }
 // CHECK-NEXT: Block #0: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #3: {
+// CHECK-NEXT: Block #4: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #2: {
+// CHECK-NEXT: Block #3: {
 // CHECK-NEXT: In: (c, b),
 // CHECK-NEXT: Kill:
 // CHECK-DAG: (c, b),
 // CHECK-DAG: (b, c),
 // CHECK-NEXT: }
-// CHECK-NEXT: Block #1: {
+// CHECK-NEXT: Block #2: {
 // CHECK-NEXT: In:
 // CHECK-NEXT: Kill:
 // CHECK-NEXT: }

--- a/clang/test/CheckedC/inferred-bounds/bounds-context.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-context.c
@@ -31,10 +31,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -43,11 +41,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -59,7 +54,7 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 
-  // Observed bounds context: { a => bounds(a, a + 5), arr => bounds(arr, arr + len), b => bounds(b, b + size) }
+  // Observed bounds context: { a => bounds(a, a + 5), b => bounds(b, b + size), arr => bounds(arr, arr + len) }
   int b checked[] : count(size) = (int checked[]){ 0 };
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -73,10 +68,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 5
+  // CHECK: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -85,25 +78,8 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 5
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -113,6 +89,17 @@ void declared1(array_ptr<int> arr : count(len), int len, int size) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'size'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: }
 }
 
@@ -132,11 +119,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -163,11 +147,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:           IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -177,11 +158,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -207,11 +185,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:           IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -221,11 +196,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} a
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -235,11 +207,8 @@ void declared2(int flag, int x, int y) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
-    // CHECK: Variable:
-    // CHECK-NEXT: VarDecl {{.*}} b
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'y'
+    // CHECK: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'b' 'int _Checked[1]'
     // CHECK: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -266,11 +235,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -280,11 +246,8 @@ void declared2(int flag, int x, int y) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'x'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' 'int _Checked[1]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -317,10 +280,8 @@ void assign1(array_ptr<int> arr : count(1)) { // expected-note {{(expanded) decl
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -359,14 +320,8 @@ void assign2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -382,11 +337,8 @@ void assign2(
   // CHECK-NEXT:           IntegerLiteral {{.*}} 3
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} 'unsigned int' <IntegralCast>
   // CHECK-NEXT:         IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -413,15 +365,12 @@ void assign3(array_ptr<int> a : bounds(unknown), nt_array_ptr<char> b : count(1)
   // CHECK-NEXT:   IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   NullaryBoundsExpr {{.*}} Unknown
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<char>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -448,11 +397,8 @@ void assign4(array_ptr<int> a : count(len), unsigned len) { // expected-note {{(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -482,11 +428,8 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -512,11 +455,8 @@ void assign5(array_ptr<int> a : count(len), int len, int size) { // expected-not
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -546,11 +486,8 @@ void assign6(array_ptr<int> a : count(len), int len) { // expected-note {{(expan
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -578,37 +515,16 @@ void assign7(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -629,15 +545,8 @@ void assign7(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -646,15 +555,8 @@ void assign7(
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -663,15 +565,8 @@ void assign7(
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -690,7 +585,7 @@ void assign7(
 // Scalar-typed variable declarations (array_ptr, nt_array_ptr) set the observed bounds to the initializer bounds
 void source_bounds1(array_ptr<int> a: count(1)) {
   // Initializer bounds for a: bounds(a, a + 1)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(a, a + 1) }
+  // Observed bounds context after declaration:  { arr => bounds(a, a + 1), a => bounds(a, a + 1) }
   array_ptr<int> arr : count(0) = a;
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -701,11 +596,9 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
+  // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -713,11 +606,9 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK: Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -728,7 +619,7 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT: }
 
   // Initializer bounds for "abc": bounds(temp("abc"), temp("abc") + 3)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(arr, arr + 0), buf => bounds(temp("abc"), temp("abc") + 3) }
+  // Observed bounds context after declaration:  { arr => bounds(arr, arr + 0), buf => bounds(temp("abc"), temp("abc") + 3), a => bounds(a, a + 1) }
   nt_array_ptr<char> buf : count(2) = "abc";
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -740,22 +631,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:         StringLiteral {{.*}} "abc"
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -764,10 +641,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -776,10 +651,20 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       BoundsValueExpr {{.*}} 'char [4]'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 
   // Initializer bounds for getArr(): bounds(temp(getArr()), temp(getArr()) + 4)
-  // Observed bounds context after declaration:  { a => bounds(a, a + 1), arr => bounds(arr, arr + 0), buf => bounds(buf, buf + 2), c => bounds(temp(getArr()), temp(getArr()) + 4) }
+  // Observed bounds context after declaration:  { arr => bounds(arr, arr + 0), buf => bounds(buf, buf + 2), c => bounds(temp(getArr()), temp(getArr()) + 4), a => bounds(a, a + 1) }
   array_ptr<int> c : count(3) = getArr();
   // CHECK: Statement S:
   // CHECK-NEXT: DeclStmt
@@ -792,22 +677,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:           DeclRefExpr {{.*}} 'getArr'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: RangeBoundsExpr
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -816,10 +687,8 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' '_Nt_array_ptr<char>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -828,16 +697,24 @@ void source_bounds1(array_ptr<int> a: count(1)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'buf'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: RangeBoundsExpr
+  // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:   BinaryOperator {{.*}} '+'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 }
 
@@ -859,10 +736,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' 'int _Checked[3]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -884,10 +759,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:     StringLiteral {{.*}} "abcde"
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' 'int _Checked[3]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -896,10 +769,8 @@ void source_bounds2(void) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'arr'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} buf
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'buf' 'char _Nt_checked[6]'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
@@ -914,9 +785,9 @@ void source_bounds2(void) {
 // Assignments to variables set the observed bounds to the source bounds
 // where the LHS variable does not appear on the RHS of the assignment
 void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : count(1)) {
-  // Observed bounds context before assignment: { large => bounds(large, large + 1), small => bounds(small, small + 0) }
+  // Observed bounds context before assignment: { small => bounds(small, small + 0), large => bounds(large, large + 1) }
   // Source bounds for large: bounds(large, large + 1)
-  // Observed bounds context after assignment:  { large => bounds(large, large + 1), small => bounds(large, large + 1) }
+  // Observed bounds context after assignment:  { small => bounds(large, large + 1), large => bounds(large, large + 1) }
   small = large;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -925,10 +796,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -937,10 +806,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -951,9 +818,9 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
   // CHECK-NEXT: }
 
-  // Observed bounds context before assignment: { large => bounds(large, large + 1), small => bounds(small, small + 0) }
+  // Observed bounds context before assignment: { small => bounds(small, small + 0), large => bounds(large, large + 1),  }
   // Source bounds for NullToPointer(0): bounds(any)
-  // Observed bounds context after assignment:  { large = bounds(any), small => bounds(small, small + 0) }
+  // Observed bounds context after assignment:  { small => bounds(small, small + 0), large = bounds(any) }
   large = 0;
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
@@ -962,16 +829,8 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Bounds:
-  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK-NEXT:  CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:    IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -980,6 +839,10 @@ void source_bounds3(array_ptr<int> small : count(0), array_ptr<int> large : coun
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'small'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
+  // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 }
 
@@ -1001,10 +864,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 2
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
@@ -1030,10 +891,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   CStyleCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
@@ -1061,10 +920,8 @@ void source_bounds4(array_ptr<int> arr : count(1)) {
   // CHECK-NEXT:       IntegerLiteral {{.*}} 4
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
@@ -1090,9 +947,9 @@ void source_bounds5(array_ptr<int> arr_array_literal : count(2)) {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} arr_array_literal
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr_array_literal' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <ArrayToPointerDecay>
   // CHECK-NEXT:     BoundsValueExpr {{.*}} 'int _Checked[2]' lvalue
@@ -1125,9 +982,9 @@ void source_bounds6() {
   // CHECK-NEXT:             IntegerLiteral {{.*}} 'int' 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} arr_struct_literal
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'arr_struct_literal' '_Array_ptr<struct a>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   UnaryOperator {{.*}} prefix '&'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} 'struct a':'struct a' lvalue
@@ -1162,11 +1019,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1176,11 +1030,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1209,11 +1060,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1227,11 +1075,8 @@ void multiple_assign1(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1262,11 +1107,8 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -1280,11 +1122,8 @@ void multiple_assign1(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1316,18 +1155,12 @@ void multiple_assign1(
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1367,11 +1200,8 @@ void multiple_assign2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1383,16 +1213,8 @@ void multiple_assign2(
   // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1428,23 +1250,12 @@ void multiple_assign2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1470,23 +1281,12 @@ void multiple_assign2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1528,16 +1328,12 @@ void multiple_assign3(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1562,11 +1358,8 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // CHECK-NEXT:   IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
   // CHECK-NEXT: }
@@ -1590,11 +1383,8 @@ void multiple_assign4(array_ptr<int> a : count(len), int len) { // expected-note
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'len'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1628,10 +1418,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:             DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1640,10 +1428,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<const int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1652,10 +1438,8 @@ void nested_assign1(nt_array_ptr<int> a : count(1), nt_array_ptr<const int> b : 
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Nt_array_ptr<volatile int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1687,10 +1471,8 @@ void nested_assign2(
   // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1703,10 +1485,8 @@ void nested_assign2(
   // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1742,20 +1522,16 @@ void nested_assign3(array_ptr<int> b : count(2)) {
   // CHECK-NEXT:               DeclRefExpr {{.*}} 'getArr'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: VarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
   // CHECK-NEXT:     BoundsValueExpr {{.*}} '_Array_ptr<int>'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 4
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BoundsValueExpr {{.*}} '_Array_ptr<int>'
@@ -1787,10 +1563,8 @@ void nested_assign4(array_ptr<int> a : count(2), array_ptr<int> b : count(3)) {
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1799,10 +1573,8 @@ void nested_assign4(array_ptr<int> a : count(2), array_ptr<int> b : count(3)) {
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 3
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -1841,15 +1613,8 @@ void update_result_bounds1(
   // CHECK-NEXT:         IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1862,10 +1627,8 @@ void update_result_bounds1(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1901,15 +1664,8 @@ void update_result_bounds2(
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1922,10 +1678,8 @@ void update_result_bounds2(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1959,15 +1713,8 @@ void update_result_bounds3(
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:     BinaryOperator {{.*}} '+'
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -1980,10 +1727,8 @@ void update_result_bounds3(
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:       IntegerLiteral {{.*}} 1
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2014,10 +1759,8 @@ void inc_dec_bounds1(nt_array_ptr<char> a) { // expected-note {{(expanded) decla
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 0
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<char>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2046,13 +1789,8 @@ void inc_dec_bounds2(nt_array_ptr<int> a : bounds(a, a)) { // expected-note {{(e
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Nt_array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2077,10 +1815,8 @@ void inc_dec_bounds3(array_ptr<float> a : count(2)) { // expected-note {{(expand
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<float>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -2109,13 +1845,8 @@ void inc_dec_bounds4(array_ptr<int> a : bounds(a, a)) { // expected-note {{(expa
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK-NEXT:   RangeBoundsExpr {{.*}}
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
   // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   BinaryOperator {{.*}} '+'
@@ -2198,11 +1929,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2222,11 +1950,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2252,11 +1977,8 @@ void killed_widened_bounds1(
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'other'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
     // CHECK-NEXT: }
@@ -2274,10 +1996,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
     // CHECK:      Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2309,10 +2029,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:     IntegerLiteral {{.*}} 1
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2341,10 +2059,8 @@ void killed_widened_bounds2(nt_array_ptr<char> p : count(0), int other) {
     // CHECK-NEXT:     IntegerLiteral {{.*}} 0
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT: CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:   IntegerLiteral {{.*}} 0
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
     // CHECK-NEXT: }
@@ -2367,11 +2083,8 @@ void killed_widened_bounds3(
     // CHECK:            DeclRefExpr {{.*}} 'i'
     // CHECK: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-    // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2381,10 +2094,8 @@ void killed_widened_bounds3(
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
     // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} q
-    // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-    // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
     // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2406,11 +2117,8 @@ void killed_widened_bounds3(
       // CHECK:          IntegerLiteral {{.*}} 1
       // CHECK: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2422,10 +2130,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2444,11 +2150,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:   DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2460,10 +2163,8 @@ void killed_widened_bounds3(
       // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:         DeclRefExpr {{.*}} 'i'
       // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
@@ -2491,17 +2192,12 @@ void killed_widened_bounds3(
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
       // CHECK: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
-      // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: NullaryBoundsExpr {{.*}} Unknown
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK-NEXT:   CountBoundsExpr {{.*}} Element
-      // CHECK-NEXT:     IntegerLiteral {{.*}} 1
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<int>'
       // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   BinaryOperator {{.*}} '-'
@@ -2542,9 +2238,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2552,9 +2248,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2591,13 +2287,13 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:           IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: NullaryBoundsExpr {{.*}} Any
   // CHECK-NEXT: }
 
@@ -2621,9 +2317,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2631,9 +2327,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2659,9 +2355,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2669,9 +2365,9 @@ void conditionals1(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2703,9 +2399,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2713,9 +2409,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2723,9 +2419,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2733,9 +2429,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2769,9 +2465,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2779,9 +2475,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2789,9 +2485,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2799,9 +2495,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2834,9 +2530,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} a
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'a' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'a'
@@ -2844,9 +2540,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'a'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 1
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} b
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'b' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'b'
@@ -2854,9 +2550,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'b'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} c
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'c' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'c'
@@ -2864,9 +2560,9 @@ void conditional2(array_ptr<int> a : count(1),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'c'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} d
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'd' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'd'
@@ -2895,9 +2591,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT: Observed bounds context after checking S:
     // CHECK-NEXT: {
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} p
-    // CHECK:      Bounds:
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+    // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
@@ -2910,9 +2606,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
     // CHECK-NEXT:           DeclRefExpr {{.*}} 'i'
     // CHECK-NEXT:         IntegerLiteral {{.*}} 'unsigned int' 1
     // CHECK-NEXT:       IntegerLiteral {{.*}} 'int' 1
-    // CHECK-NEXT: Variable:
-    // CHECK-NEXT: ParmVarDecl {{.*}} q
-    // CHECK:      Bounds:
+    // CHECK-NEXT: LValue Expression:
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<char>'
+    // CHECK-NEXT: Bounds:
     // CHECK-NEXT: RangeBoundsExpr
     // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
     // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
@@ -2945,9 +2641,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
       // CHECK-NEXT: Observed bounds context after checking S:
       // CHECK-NEXT: {
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} p
-      // CHECK:      Bounds:
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'p' '_Nt_array_ptr<char>'
+      // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'p'
@@ -2956,9 +2652,9 @@ void conditional3(nt_array_ptr<char> p : count(i), // expected-note {{(expanded)
       // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
       // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:       DeclRefExpr {{.*}} 'i'
-      // CHECK-NEXT: Variable:
-      // CHECK-NEXT: ParmVarDecl {{.*}} q
-      // CHECK:      Bounds:
+      // CHECK-NEXT: LValue Expression:
+      // CHECK-NEXT: DeclRefExpr {{.*}} 'q' '_Nt_array_ptr<char>'
+      // CHECK-NEXT: Bounds:
       // CHECK-NEXT: RangeBoundsExpr
       // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
       // CHECK-NEXT:     DeclRefExpr {{.*}} 'q'
@@ -3001,9 +2697,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
@@ -3011,9 +2707,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} medium
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'medium' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'medium'
@@ -3021,9 +2717,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'small'
@@ -3051,9 +2747,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:         IntegerLiteral {{.*}} 0
   // CHECK-NEXT: Observed bounds context after checking S:
   // CHECK-NEXT: {
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} large
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'large' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'large'
@@ -3061,9 +2757,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'large'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 3
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} medium
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'medium' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'medium'
@@ -3071,9 +2767,9 @@ void conditional4(array_ptr<int> large : count(3),
   // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:       DeclRefExpr {{.*}} 'medium'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 2
-  // CHECK-NEXT: Variable:
-  // CHECK-NEXT: ParmVarDecl {{.*}} small
-  // CHECK:      Bounds:
+  // CHECK-NEXT: LValue Expression:
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'small' '_Array_ptr<int>'
+  // CHECK-NEXT: Bounds:
   // CHECK-NEXT: RangeBoundsExpr
   // CHECK-NEXT:   ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:     DeclRefExpr {{.*}} 'small'

--- a/clang/test/CheckedC/inferred-bounds/bounds-vars.c
+++ b/clang/test/CheckedC/inferred-bounds/bounds-vars.c
@@ -1,0 +1,52 @@
+// Tests for variables occurring in bounds expressions for checked pointers
+// like _Array_ptr and _Nt_array_ptr.
+//
+// RUN: %clang_cc1 -fdump-boundsvars -verify -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s | FileCheck %s
+
+// expected-no-diagnostics
+
+void f1(_Array_ptr<char> param1 : bounds(param1, param1 + 1),
+        _Nt_array_ptr<char> param2 : bounds(param2, param2 + 1),
+        int x, int y) {
+  _Array_ptr<char> p : bounds(p, p + 1) = "a";
+  _Nt_array_ptr<char> q : bounds(q, q + 1) = "a";
+
+  _Where p : bounds(p + x, p + y);
+  _Where q : count(x);
+  _Where param1 : count(x + y);
+  _Where param2 : bounds(param2, param2 + y);
+
+  {
+    int z;
+    _Nt_array_ptr<char> p : bounds(p, p + 1) = "a";
+    _Nt_array_ptr<char> q : bounds(q, q + 1) = "a";
+    _Nt_array_ptr<char> m : bounds(m, m + 1) = "a";
+
+    _Where q : bounds(p, p + z) _And p : bounds(p, p + z);
+    _Where m : bounds(q, q + z);
+  }
+
+  {
+    int w;
+    _Nt_array_ptr<char> a : bounds(a, a + 1) = "a";
+
+    w = 1 _Where a : bounds(a, a + 1);
+    x = 2 _Where a : count(x + y + w);
+    y = 3 _Where param2 : bounds(param1, param1 + w);
+  }
+
+// CHECK-LABEL: In function: f1
+// CHECK: BoundsVars:
+// CHECK: a: { a }
+// CHECK: m: { m }
+// CHECK: p: { p }
+// CHECK: p: { p q }
+// CHECK: param1: { param1 param2 }
+// CHECK: param2: { param2 }
+// CHECK: q: { q }
+// CHECK: q: { m q }
+// CHECK: w: { a param2 }
+// CHECK: x: { a p param1 q }
+// CHECK: y: { a p param1 param2 }
+// CHECK: z: { m p q }
+}

--- a/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-exprs.c
@@ -310,3 +310,29 @@ void f9(array_ptr<int [3]> arr : count(1), int i) {
   // CHECK: Expressions that produce the same value as S:
   // CHECK-NEXT: { }
 }
+
+// Variables in equivalent expressions going out of scope
+void f10(void) {
+  char c = 'a';
+  {
+    int x = 6;
+    char d = c;
+  }
+  int marker = 0;
+  // CHECK: Statement S:
+  // CHECK:   VarDecl {{.*}}  marker 'int'
+  // CHECK: Sets of equivalent expressions after checking S:
+  // CHECK: ImplicitCastExpr {{.*}} 'char' <IntegralCast>
+  // CHECK-NEXT:   CharacterLiteral {{.*}} 'int' 97
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'char' <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'c' 'char'
+  // CHECK-NOT:    DeclRefExpr {{.*}} 'd' 'char'
+
+  // CHECK-NOT: IntegerLiteral {{.*}} 'int' 6
+  // CHECK-NOT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+  // CHECK-NOT:   DeclRefExpr {{.*}} 'x' 'int'
+
+  // CHECK: IntegerLiteral {{.*}} 'int' 0
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
+  // CHECK-NEXT:   DeclRefExpr {{.*}} 'marker' 'int'
+}

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-multiple-derefs.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-multiple-derefs.c
@@ -8,12 +8,12 @@ void f1() {
   if (*p && *(p + 1)) {}
 
 // CHECK: In function: f1
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   2: *p
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -24,15 +24,15 @@ void f2() {
   {}
 
 // CHECK: In function: f2
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: *p
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -46,15 +46,15 @@ void f3() {
   }
 
 // CHECK: In function: f3
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   3: *p
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: p = "a"
 // CHECK: upper_bound(p) = 2
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }
 
@@ -62,28 +62,28 @@ void f4(_Nt_array_ptr<char> p : count(0)) {
   if (p[0] && p[1]) {}
 
 // CHECK: In function: f4
-// CHECK: [B9]
+// CHECK: [B10]
 // CHECK:   1: p[0]
-// CHECK: [B8]
+// CHECK: [B9]
 // CHECK:   1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B7]
+// CHECK: [B8]
 // CHECK: upper_bound(p) = 2
 
   _Nt_array_ptr<char> q : count(0) = "a";
   if (0[q] && 1[q]) {}
-// CHECK: [B6]
+// CHECK: [B7]
 // CHECK:   2: 0[q]
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK:   1: 1[q]
 // CHECK: upper_bound(q) = 1
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK: upper_bound(q) = 2
 
   if ((((q[0]))) && (((q[1])))) {}
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: (((q[0])))
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: (((q[1])))
 // CHECK: upper_bound(q) = 1
 // CHECk: [B1]
@@ -97,15 +97,15 @@ void f5() {
   {}
 
 // CHECK: In function: f5
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: p[0]
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: p[2]
 // CHECK: upper_bound(p) = 2
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 // It seems it is not correct!
@@ -118,47 +118,47 @@ void f6(int i) {
   }
 
 // CHECK: In function: f6
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:  2: p[0]
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:  1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:  1: i = 0
 // CHECK:  2: p[2]
 // CHECK: upper_bound(p) = 2
-// CHECK : [B1]
+// CHECK: [B1]
 // CHECK-NOT: upper_bound(p)
 }
 void f7(char p _Nt_checked[] : count(0)) {
   if (p[0] && p[1]) {}
 
 // CHECK: In function: f7
-// CHECK: [B9]
+// CHECK: [B10]
 // CHECK:   1: p[0]
-// CHECK: [B8]
+// CHECK: [B9]
 // CHECK:   1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B7]
+// CHECK: [B8]
 // CHECK: upper_bound(p) = 2
 
   char q _Nt_checked[] : count(0) = "a";
   if (0[q] && 1[q]) {}
-// CHECK: [B6]
+// CHECK: [B7]
 // CHECK:   2: 0[q]
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK:   1: 1[q]
 // CHECK: upper_bound(q) = 1
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK: upper_bound(q) = 2
 
   if ((((q[0]))) && (((q[1])))) {}
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: (((q[0])))
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: (((q[1])))
 // CHECK: upper_bound(q) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(q) = 2
 }
 
@@ -169,18 +169,18 @@ void f8() {
   {}
 
 // CHECK: In function: f8
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK:   2: *p
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   1: *(p + 1)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + 2)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 3)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -190,15 +190,15 @@ void f9(int i) {
   if (*p && *(p + i) && *(p + i + 1)) {}
 
 // CHECK: In function: f9
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: *p
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + i)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + i + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -208,15 +208,15 @@ void f10(int i) {
   if (*(i + p + 1 + 2 + 3) && *(3 + p + i + 4) && *(p + i + 9)) {}
 
 // CHECK: In function: f10
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(i + p + 1 + 2 + 3)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(3 + p + i + 4)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + i + 9)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -229,16 +229,16 @@ void f11(int i, int j) {
   }
 
 // CHECK: In function: f11
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:    2: *(p + j)
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    1: *(p + j + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: i = 0
 // CHECK:    2: *(p + j + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK-NOT: upper_bound(p)
 
   if (*(p + j) && *(p + j + 1)) {
@@ -246,16 +246,16 @@ void f11(int i, int j) {
     if (*(p + j + 2)) {}
   }
 
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + j)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + j + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: j = 0
 // CHECK:    2: *(p + j + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }
 
@@ -265,15 +265,15 @@ void f12(int i, int j) {
   if (*(((p + i + j))) && *((p) + (i) + (j) + (1)) && *((p + i + j) + 2)) {}
 
 // CHECK: In function: f12
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(((p + i + j)))
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *((p) + (i) + (j) + (1))
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *((p + i + j) + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -284,18 +284,18 @@ void f13() {
   {}
 
 // CHECK: In function: f13
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    2: p[0]
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: 1[p]
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p[2]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: 3[p]
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -305,15 +305,15 @@ void f14(int i) {
   if ((1 + i)[p] && p[i] && (1 + i)[p]) {}
 
 // CHECK: In function: f14
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: (1 + i)[p]
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p[i]
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: (1 + i)[p]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -322,51 +322,51 @@ void f15(int i) {
   if (*(p - i) && *(p - i + 1)) {}
 
 // CHECK: In function: f15
-// CHECK:  [B13]
+// CHECK: [B14]
 // CHECK:    2: *(p - i)
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:    1: *(p - i + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK: upper_bound(p) = 2
 
   _Nt_array_ptr<char> q : count(0) = "a";
   if (*q && *(q - 1))
   {}
 
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:    2: *q
-// CHECK:  [B9]
+// CHECK: [B10]
 // CHECK:    1: *(q - 1)
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK: upper_bound(q) = 1
 
   _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
   if (*(r + +1) && *(r + +2))
   {}
 
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    2: *(r + +1)
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: *(r + +2)
 // CHECK: upper_bound(r) = 1
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK: upper_bound(r) = 2
 
   _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
   if (*(s + -1) && *(s) && *(s + +1)) // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(s + -1)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(s)
 // CHECK: upper_bound(s) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(s + +1)
 // CHECK: upper_bound(s) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(s) = 3
 }
 
@@ -378,13 +378,13 @@ void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
   {}
 
 // CHECK: In function: f16
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    3: *(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 // CHECK: upper_bound(q) = 2
 // CHECK: upper_bound(r) = 1
@@ -398,12 +398,12 @@ void f17(char p _Nt_checked[] : count(1)) {
   {}
 
 // CHECK: In function: f17
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    3: *(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(r) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 1
 // CHECK: upper_bound(q) = 1
 // CHECK: upper_bound(r) = 2
@@ -419,44 +419,44 @@ void f18() {
   {}
 
 // CHECK: In function: f18
-// CHECK:  [B13]
+// CHECK: [B14]
 // CHECK:    5: p[0]
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:    1: p[1]
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK: upper_bound(p) = 1
 
   if (q[0] && q[1] && q[2])
   {}
 
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:    1: q[0]
-// CHECK:  [B9]
+// CHECK: [B10]
 // CHECK:    1: q[1]
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:    1: q[2]
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK: upper_bound(q) = 1
 
   if (r[0] && r[1]) 
   {}
 
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: r[0]
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: r[1]
 // CHECK: upper_bound(r) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK: upper_bound(r) = 2
 
   if (s[0] && s[1])
   {}
 
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: s[0]
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: s[1]
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(s) = 1
 }
 
@@ -467,18 +467,18 @@ void f19() {
   {}
 
 // CHECK: In function: f19
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    2: *p
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + 3)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -488,12 +488,12 @@ void f20() {
   if (*(((p + 1))) && *(((p + 2)))) {}
 
 // CHECK: In function: f20
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   2: *(((p + 1)))
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(((p + 2)))
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -506,21 +506,21 @@ void f21(_Nt_array_ptr<char> p : count(i), int i, int flag) {
   }
 
 // CHECK: In function: f21
-// CHECK:  [B7]
+// CHECK: [B7]
 // CHECK:    1: *(p + i)
-// CHECK:  [B6]
+// CHECK: [B6]
 // CHECK:    1: *(p + i + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B5]
+// CHECK: [B5]
 // CHECK:    1: flag
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B4]
+// CHECK: [B4]
 // CHECK:    1: i
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B3]
+// CHECK: [B3]
 // CHECK:    1: i++
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B2]
+// CHECK: [B2]
 // CHECK:    2: *(p + i + 2)
 // CHECK: upper_bound(p) = 2
 // CHECK: [B1]
@@ -535,21 +535,21 @@ void f22() {
  {}
 
 // CHECK: In function: f22
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    2: *p
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + 3)
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 4)
 // CHECK: upper_bound(p) = 4
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 5
  }
 
@@ -561,30 +561,30 @@ void f23() {
  {}
 
 // CHECK: In function: f23
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:    3: *p
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: *q
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(q + 1)
 // CHECK: upper_bound(p) = 3
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + 3)
 // CHECK: upper_bound(p) = 3
 // CHECK: upper_bound(q) = 2
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 4)
 // CHECK: upper_bound(p) = 4
 // CHECK: upper_bound(q) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 5
 // CHECK: upper_bound(q) = 2
 }
@@ -596,11 +596,11 @@ void f24() {
 {}
 
 // CHECK: In function: f24
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   2: *p
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 1)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-semantic-compare.c
@@ -111,13 +111,13 @@ void f11(int i, int j) {
   {}
 
 // CHECK: In function: f11
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: _Nt_array_ptr<char> p : bounds(p, p + i + j) = "a";
 // CHECK:    2: *(j + i + p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(i + j + p - 1 - -4 + -2)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -129,13 +129,13 @@ void f12() {
   {}
 
 // CHECK: In function: f12
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: _Nt_array_ptr<char> p : bounds(p, p) = "a";
 // CHECK:    2: *(p + 0)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 1 - 1 + -1 - +1 - -3)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -147,13 +147,13 @@ void f13(int i, int j) {
   {}
 
 // CHECK: In function: f13
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: _Nt_array_ptr<char> p : bounds(p, p + (i * j * 2 + 2 + 1)) = "a";
 // CHECK:    2: *(p + (i * j * 2 + 3))
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + (i * j * 2 + 1 + 1 + 1) + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -164,7 +164,7 @@ void f14(int i) {
   {}
 
 // CHECK: In function: f14
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }
 

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-strings-examples.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-strings-examples.c
@@ -16,7 +16,7 @@ int my_strlen(_Nt_array_ptr<char> p) {
   return i;
 
 // CHECK: In function: my_strlen
-// CHECK:  [B3]
+// CHECK:  [B4]
 // CHECK:    1: ++i
 // CHECK: upper_bound(s) = 1
 }
@@ -28,8 +28,7 @@ void squeeze(_Nt_array_ptr<char> p, char c) {
   // Create a temporary whose count of elements can
   // change.
   _Nt_array_ptr<char> s : count(i) = p;
-  for ( ; s[i]; i++) { // expected-error {{inferred bounds for 's' are unknown after increment}} \
-                       // expected-error {{inferred bounds for 'tmp' are unknown after increment}}
+  for ( ; s[i]; i++) { // expected-error {{inferred bounds for 's' are unknown after increment}}
     // We will widen the bounds of s so that we
     // can assign to s[j] when j == i.
     _Nt_array_ptr<char> tmp : count(i + 1) = s;
@@ -42,12 +41,12 @@ void squeeze(_Nt_array_ptr<char> p, char c) {
   s[j] = 0;
 
 // CHECK: In function: squeeze
-// CHECK:  [B4]
+// CHECK:  [B5]
 // CHECK:    1: _Nt_array_ptr<char> tmp : count(i + 1) = s;
 // CHECK:    2: tmp[i] != c
 // CHECK: upper_bound(s) = 1
 
-// CHECK:  [B3]
+// CHECK:  [B4]
 // CHECK:    1: tmp[j++] = tmp[i]
 // CHECK: upper_bound(s) = 1
 
@@ -72,7 +71,7 @@ void reverse(_Nt_array_ptr<char> p) {
   }
 
 // CHECK: In function: reverse
-// CHECK:  [B5]
+// CHECK:  [B6]
 // CHECK:    1: len++
 // CHECK: upper_bound(s) = 1
 }

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds.c
@@ -11,9 +11,9 @@ void f1() {
   if (*p) {}
 
 // CHECK: In function: f1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   2: *p
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 1
 }
 
@@ -26,15 +26,15 @@ void f2() {
   {}
 
 // CHECK: In function: f2
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: *p
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -48,12 +48,12 @@ void f3() {
   }
 
 // CHECK: In function: f3
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   3: *p
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: p = "a"
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p) = 1
 }
 
@@ -61,22 +61,22 @@ void f4(_Nt_array_ptr<char> p : count(0)) {
   if (p[0]) {}
 
 // CHECK: In function: f4
-// CHECK: [B6]
+// CHECK: [B7]
 // CHECK:   1: p[0]
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK: upper_bound(p) = 1
 
   _Nt_array_ptr<char> q : count(0) = "a";
   if (0[q]) {}
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: 0[q]
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK: upper_bound(q) = 1
 
   if ((((q[0])))) {}
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: (((q[0])))
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(q) = 1
 }
 
@@ -89,15 +89,15 @@ void f5() {
   {}
 
 // CHECK: In function: f5
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: p[0]
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: p[2]
 // CHECK: upper_bound(p) = 2
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -110,13 +110,13 @@ void f6(int i) {
   }
 
 // CHECK: In function: f6
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   2: p[0]
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: i = 0
 // CHECK:   2: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }
 
@@ -124,22 +124,22 @@ void f7(char p _Nt_checked[] : count(0)) {
   if (p[0]) {}
 
 // CHECK: In function: f7
-// CHECK: [B6]
+// CHECK: [B7]
 // CHECK:   1: p[0]
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK: upper_bound(p) = 1
 
   char q _Nt_checked[] : count(0) = "a";
   if (0[q]) {}
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: 0[q]
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK: upper_bound(q) = 1
 
   if ((((q[0])))) {}
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: (((q[0])))
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(q) = 1
 }
 
@@ -153,18 +153,18 @@ void f8() {
   {}
 
 // CHECK: In function: f8
-// CHECK: [B5]
+// CHECK: [B6]
 // CHECK:   2: *p
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   1: *(p + 1)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + 2)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + 3)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -176,15 +176,15 @@ _Nt_array_ptr<char> p : bounds(p, p + i) = "a"; // expected-error {{it is not po
       if (*(p + i + 1)) {}
 
 // CHECK: In function: f9
-// CHECK: [B4]
+// CHECK: [B5]
 // CHECK:   2: *p
-// CHECK: [B3]
+// CHECK: [B4]
 // CHECK:   1: *(p + i)
 // CHECK-NOT: upper_bound(p)
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   1: *(p + i + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -196,15 +196,15 @@ void f10(int i) {
       if (*(p + i + 9)) {}
 
 // CHECK: In function: f10
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(i + p + 1 + 2 + 3)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(3 + p + i + 4)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + i + 9)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -217,13 +217,13 @@ void f11(int i, int j) {
   }
 
 // CHECK: In function: f11
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    2: *(p + j)
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: i = 0
 // CHECK:    2: *(p + j + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK-NOT: upper_bound(p)
 
   if (*(p + j)) {
@@ -231,13 +231,13 @@ void f11(int i, int j) {
     if (*(p + j + 1)) {}
   }
 
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + j)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: j = 0
 // CHECK:    2: *(p + j + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(p)
 }
 
@@ -249,15 +249,15 @@ void f12(int i, int j) {
       if (*((p + i + j) + 2)) {}
 
 // CHECK: In function: f12
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(((p + i + j)))
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *((p) + (i) + (j) + (1))
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *((p + i + j) + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -271,18 +271,18 @@ void f13() {
   {}
 
 // CHECK: In function: f13
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    2: p[0]
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: 1[p]
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p[2]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: 3[p]
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -294,15 +294,15 @@ void f14(int i) {
       if ((1 + i)[p]) {}
 
 // CHECK: In function: f14
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: (1 + i)[p]
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p[i]
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: (1 + i)[p]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -311,9 +311,9 @@ void f15(int i) {
   if (*(p - i)) {}
 
 // CHECK: In function: f15
-// CHECK:  [B9]
+// CHECK: [B10]
 // CHECK:    2: *(p - i)
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK: upper_bound(p) = 1
 
   _Nt_array_ptr<char> q : count(0) = "a";
@@ -321,30 +321,30 @@ void f15(int i) {
     if (*(q - 1))
   {}
 
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    2: *q
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: *(q - 1)
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK: upper_bound(q) = 1
 
   _Nt_array_ptr<char> r : bounds(r, r + +1) = "a";
   if (*(r + +1))
   {}
 
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(r + +1)
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK: upper_bound(r) = 1
 
   _Nt_array_ptr<char> s : bounds(s, s + -1) = "a";
   if (*(s + -1)) // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    2: *(s + -1)
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(s) = 1
 }
 
@@ -357,13 +357,13 @@ void f16(_Nt_array_ptr<char> p : bounds(p, p)) {
   {}
 
 // CHECK: In function: f16
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    3: *(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
 // CHECK: upper_bound(q) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 // CHECK: upper_bound(q) = 2
 // CHECK: upper_bound(r) = 1
@@ -378,12 +378,12 @@ void f17(char p _Nt_checked[] : count(1)) {
   {}
 
 // CHECK: In function: f17
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    3: *(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(r) = 1
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 1
 // CHECK: upper_bound(q) = 1
 // CHECK: upper_bound(r) = 2
@@ -400,11 +400,11 @@ void f18() {
   {}
 
 // CHECK: In function: f18
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:    5: p[0]
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK:    1: p[1]
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK: upper_bound(p) = 1
 
   if (q[0])
@@ -412,32 +412,32 @@ void f18() {
       if (q[2])
   {}
 
-// CHECK:  [B9]
+// CHECK: [B10]
 // CHECK:    1: q[0]
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:    1: q[1]
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    1: q[2]
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK: upper_bound(q) = 1
 
   if (r[0])
   {}
 
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: r[0]
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK: upper_bound(r) = 1
 
   if (s[0])
     if (s[1])
   {}
 
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: s[0]
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: s[1]
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(s) = 1
 }
 
@@ -451,18 +451,18 @@ void f19() {
   {}
 
 // CHECK: In function: f19
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    2: *p
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + 3)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 3
 }
 
@@ -473,9 +473,9 @@ void f20() {
   {}
 
 // CHECK: In function: f20
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:    2: *(p + {{.*}})
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK: upper_bound(p) = 1
 
   // Declared bounds and deref offset are both INT_MIN. Valid widening.
@@ -483,9 +483,9 @@ void f20() {
   if (*(q + INT_MIN))                               // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:    2: *(q + {{.*}})
-// CHECK:  [B9]
+// CHECK: [B10]
 // CHECK: upper_bound(q) = 1
 
   // Declared bounds (INT_MIN) and deref offset (INT_MAX - 1). No sequential deref tests. No widening.
@@ -498,9 +498,9 @@ void f20() {
   if (*(r + INT_MAX - 1))                               // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:    2: *(r + {{.*}})
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK-NOT: upper_bound(r)
 
   // Declared bounds and deref offset are both (INT_MAX + 1). Integer overflow. No widening.
@@ -508,9 +508,9 @@ void f20() {
   if (*(s + INT_MAX + 1))                           // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    2: *(s + {{.*}})
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK-NOT: upper_bound(s)
 
   // Declared bounds and deref offset are both (INT_MIN + 1). Valid widening.
@@ -518,9 +518,9 @@ void f20() {
   if (*(t + INT_MIN + 1))                           // expected-error {{out-of-bounds memory access}}
   {}
 
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    2: *(t + {{.*}})
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK: upper_bound(t) = 1
 
   // Declared bounds and deref offset are both (INT_MIN + -1). Integer underflow. No widening.
@@ -528,9 +528,9 @@ void f20() {
   if (*(u + INT_MIN + -1))
   {}
 
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    2: *(u + {{.*}})
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK-NOT: upper_bound(u)
 }
 
@@ -543,19 +543,19 @@ void f21() {
   {}
 
 // CHECK: In function: f21
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: p[0]
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: p[1]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: p[2]
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 1
 }
 
@@ -568,17 +568,17 @@ void f22() {
   {}
 
 // CHECK: In function: f22
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    2: *p
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 1)
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: *(p + 2)
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 2
 }
 
@@ -595,19 +595,19 @@ B:  p;
     }
   }
 
-// CHECK:  [B14]
+// CHECK: [B15]
 // CHECK:    T: goto B;
-// CHECK:  [B13]
+// CHECK: [B14]
 // CHECK:    1: *p
 // CHECK:    T: while
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:   B:
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: while
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 
@@ -619,23 +619,23 @@ C:    p;
   }
   goto C;
 
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    1: *p
 // CHECK:    T: while
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: p
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: while
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:   C:
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B1]
+// CHECK: [B2]
 // CHECK:    T: goto C;
 }
 
@@ -650,16 +650,16 @@ void f24() {
   }
 
 // CHECK: In function: f24
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: *p
 // CHECK:    T: while
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: p++
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: while
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 }
@@ -680,31 +680,31 @@ void f25() {
     }
   }
 
-// CHECK:  [B22]
+// CHECK: [B23]
 // CHECK:    1: *p
 // CHECK:    T: for
-// CHECK:  [B21]
+// CHECK: [B22]
 // CHECK:    1: i = 0
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B20]
+// CHECK: [B21]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: for
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B19]
+// CHECK: [B20]
 // CHECK:    1: i = 1
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B18]
+// CHECK: [B19]
 // CHECK:    1: *(p + 2)
 // CHECK:    T: for
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B17]
+// CHECK: [B18]
 // CHECK:    1: i = 2
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B16]
+// CHECK: [B17]
 // CHECK: upper_bound(p) = 3
-// CHECK:  [B15]
+// CHECK: [B16]
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B14]
+// CHECK: [B15]
 // CHECK: upper_bound(p) = 1
 
   for (; *p; ) {
@@ -715,20 +715,20 @@ D:  p;
   }
   goto D;
 
-// CHECK:  [B13]
+// CHECK: [B14]
 // CHECK:    1: *p
 // CHECK:    T: for
-// CHECK:  [B12]
+// CHECK: [B13]
 // CHECK:   D:
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: for
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:    T: goto D;
 
   for (; *p; ) {
@@ -738,16 +738,16 @@ D:  p;
     }
   }
 
-// CHECK:  [B6]
+// CHECK: [B7]
 // CHECK:    1: *p
 // CHECK:    T: for
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:    1: p++
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK:    1: *(p + 1)
 // CHECK:    T: for
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: p
 // CHECK-NOT: upper_bound(p)
 }
@@ -884,10 +884,10 @@ void f28() {
 
       case 1: break;
     }
-// CHECK:  [B11]
+// CHECK: [B12]
 // CHECK:   case 1:
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B10]
+// CHECK: [B11]
 // CHECK:   case 0:
 // CHECK-NOT: upper_bound(p)
   }
@@ -897,11 +897,11 @@ void f28() {
     switch (*(p + 1)) {
       case 2: break;
     }
-// CHECK:  [B8]
+// CHECK: [B9]
 // CHECK:   case 2:
 // CHECK:    T: break;
 // CHECK: upper_bound(p) = 2
-// CHECK:  [B7]
+// CHECK: [B8]
 // CHECK:   case 1:
 // CHECK:    1: *(p + 1)
 // CHECK:    T: switch
@@ -912,15 +912,15 @@ void f28() {
   case 1: do { a;
           } while (a);
   }
-// CHECK:  [B5]
+// CHECK: [B6]
 // CHECK:   case 1:
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B5]
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B3]
+// CHECK: [B4]
 // CHECK:    1: a
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B3]
 // CHECK:    1: a
 // CHECK:    T: do ... while
 // CHECK: upper_bound(p) = 1
@@ -1235,9 +1235,9 @@ void f33() {
   if (*(((p + 1)))) {}
 
 // CHECK: In function: f33
-// CHECK: [B2]
+// CHECK: [B3]
 // CHECK:   2: *(((p + 1)))
-// CHECK: [B1]
+// CHECK: [B2]
 // CHECK: upper_bound(p) = 1
 }
 
@@ -1250,18 +1250,18 @@ void f34(_Nt_array_ptr<char> p : count(i), int i, int flag) {
   }
 
 // CHECK: In function: f34
-// CHECK:  [B6]
+// CHECK: [B6]
 // CHECK:    1: *(p + i)
-// CHECK:  [B5]
+// CHECK: [B5]
 // CHECK:    1: flag
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B4]
+// CHECK: [B4]
 // CHECK:    1: i
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B3]
+// CHECK: [B3]
 // CHECK:    1: i++
 // CHECK: upper_bound(p) = 1
-// CHECK:  [B2]
+// CHECK: [B2]
 // CHECK:    2: *(p + i + 1)
 // CHECK: upper_bound(p) = 1
 }
@@ -1278,18 +1278,18 @@ void f35(void) {
   }
 
 // CHECK: In function: f35
-// CHECK:  [B5]
+// CHECK: [B7]
 // CHECK:    1: int i;
 // CHECK:    2: int j;
-// CHECK:  [B4]
+// CHECK: [B6]
 // CHECK:    T: for (; ; )
-// CHECK:  [B3]
+// CHECK: [B5]
 // CHECK:    1: i = 1
 // CHECK:    2: j = 2
 // CHECK:    3: _Nt_array_ptr<char> p : count(i + j) = 0;
 // CHECK:    4: p[i + j] (ImplicitCastExpr, LValueToRValue, char)
-// CHECK:    T: if [B3.4]
-// CHECK:  [B2]
+// CHECK:    T: if [B5.4]
+// CHECK: [B4]
 // CHECK:    1: return;
 // CHECK: upper_bound(p) = 1
 }

--- a/clang/test/CheckedC/parsing/invalid-where-clause.c
+++ b/clang/test/CheckedC/parsing/invalid-where-clause.c
@@ -37,6 +37,17 @@ void invalid_cases_nullstmt(_Nt_array_ptr<char> p, int a, int b) {
   _Where a _And p : _And q : count(0) _And x _And a = 1 _And f() < 0 _And; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{expected comparison operator in equality expression}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
 }
 
+void invalid_cases_exprstmt(_Nt_array_ptr<char> p, int a) {
+  a = 0 _Where a _And p : _And q : count(0) _And x _Where b = 1 _And f() < 0 _And; // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}} expected-error {{use of undeclared identifier q}} expected-error {{use of undeclared identifier 'x'}} expected-error {{use of undeclared identifier 'b'}} expected-error {{call expression not allowed in expression}} expected-error {{expected bounds declaration or equality expression in where clause}}
+
+  int x, y;
+  // For an ExprStmt with commas, a where clause cannot be attached after each
+  // comma. This is because the entire expression including commas is parsed as
+  // one ExprStmt. Hence a where clause can only be attached at the end of the
+  // entire ExprStmt.
+  x = 1 _Where x > 0, y = 2 _Where y > 1; // expected-error {{expected ';' after expression}}
+}
+
 void f1(int a _Where a, _Nt_array_ptr<int> p : count(0) _Where p :); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}} expected-error {{expected bounds expression}}
 
 void f2(int *p : itype(_Ptr<int>) _Where p, int n); // expected-error {{invalid expression in where clause, expected bounds declaration or equality expression}}

--- a/clang/test/CheckedC/parsing/unsupported-where-clause.c
+++ b/clang/test/CheckedC/parsing/unsupported-where-clause.c
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// Various cases that currently do not support where clauses. We are choosing
+// not to support these in order to strike a balance between extensive support
+// for where clauses and the resulting usefulness but not because we need to
+// handle them separately.
+
+void f(int i, int j, int k);
+unsigned strlen_test(_Nt_array_ptr<char> p);
+
+void unsupported_cases(int i, int j, int k) {
+  // According to the C11 spec, the conditionals of selection-statements (like
+  // if and switch) and iteration-statements (like while, do-while and for) are
+  // expressions (and not expression-statements) and they evaluate to a scalar.
+  // So we need separate handling of where clauses inside these conditionals.
+
+  if (i _Where i > 0) {} // expected-error {{expected ')'}} expected-note {{to match this '('}}
+  if (i = 0 _Where i > 0) {} // expected-error {{expected ')'}} expected-note {{to match this '('}} expected-warning {{using the result of an assignment as a condition without parentheses}} expected-note {{place parentheses around the assignment to silence this warning}} expected-note {{use '==' to turn this assignment into an equality comparison}}
+  if (i == 0 _Where i > 0) {} // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+  _Nt_array_ptr<char> p = ""; // expected-note {{(expanded) declared bounds are 'bounds(p, p + 0)'}}
+  if ((i = strlen_test(p) _Where p : bounds(p, p + i)) > 0) {} // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+  while (i _Where i > 0) {} // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+  do {} while (i _Where i > 0); // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+  // Where clauses on parameters in function calls are currently not supported.
+  f(i _Where i > 0, j, k); // expected-error {{expected ')'}} expected-note {{to match this '('}}
+  f(i, (j=1 _Where j > 0, j+2), k); // expected-error {{expected ')'}} expected-note {{to match this '('}}
+
+  // Where clauses on struct members are currently not supported.
+  struct S { int a _Where a != 0; }; // expected-error {{expected ';' at end of declaration list}}
+
+  for (; p < p + 1 && *p; p++ _Where p : bounds(p, p + 1)) {} // expected-error {{expected ')'}} expected-note {{to match this '('}} expected-warning {{cannot prove declared bounds for 'p' are valid after increment}} expected-note {{(expanded) inferred bounds are 'bounds(p - 1, p - 1 + 0)'}}
+
+  // The initializer of a for-loop is processed as part of processing the
+  // for-loop itself (and not as part of processing an ExprStmt). So we need
+  // separate handling of where clauses inside a for-loop.
+  for (i = 0 _Where i > 0; i > 0; i++) {} // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected expression}} expected-error {{expected ')'}} expected-error {{expected ';' after expression}} expected-error {{expected expression}} expected-warning {{relational comparison result unused}} expected-note {{to match this '('}}
+}

--- a/clang/test/CheckedC/parsing/valid-where-clause.c
+++ b/clang/test/CheckedC/parsing/valid-where-clause.c
@@ -66,3 +66,21 @@ void f4(_Nt_array_ptr<char> p : count(n) _Where p : count(n) _And p : count(n), 
 void f5(_Nt_array_ptr<char> p : count(n), int a _Where p : count(n) _And n > 0 _And a < 0, int n) {}
 void f6(int *p : itype(_Ptr<int>) _Where p == 0 _And n > 0, int n);
 void f7(int a _Where (((((a == 0))))));
+
+// Test where clauses on ExprStmts.
+void valid_cases_exprstmt(_Nt_array_ptr<char> p, int a) {
+  int b;
+  a = 0 _Where a < 1 _And a >= 0;
+  b = a _Where a > b _And a != b;
+  p = 0 _Where p : bounds(p, p + 1) _And a < 1;
+L1: a = 0 _Where a > 1;
+
+  // For an ExprStmt with commas, a where clause can be attached at the end of
+  // the ExprStmt. This is because the entire expression including commas is
+  // parsed as one ExprStmt. Hence a where clause can only be attached at the
+  // end of this ExprStmt.
+  int x, y, z;
+  x = 1, y = 2, z = 3 _Where x > 0 _And y > 1 _And z > 2;
+
+  for (int i = 0 _Where i != 0; i > 0; i ++) {}
+}

--- a/clang/test/CheckedC/static-checking/bounds-decl-checking.c
+++ b/clang/test/CheckedC/static-checking/bounds-decl-checking.c
@@ -690,3 +690,14 @@ void f85(_Ptr<struct st_80_arr> arr, int b) {
     arr->c = b * b;
   }
 }
+
+// No error on the bounds of dest getting invalidated when len is
+// assigned to, because dest is no longer in scope.
+void f86(void) {
+  int arr _Checked[5];
+  int len = 5;
+  {
+    _Array_ptr<int> dest : count(len) = arr;
+  }
+  len = 4;
+}


### PR DESCRIPTION
Microsoft has made some compiler changes since our last merge from them (implicit checked header inclusion on 2021-04-01).  I don't know if we'll end up wanting to merge the changes before the paper submission, but I'm going ahead and creating a draft PR to make it easier for anyone interested to try the changes and see if they help with anything.  Whenever we end up doing a merge from Microsoft, we can reuse this PR.

Tests of this PR (as of 2021-04-30):
- [X] 3C regression tests: Pass except for pre-existing issue #560.
- [X] GitHub workflow run + `summarize-benchmark-errors.py`: [Minimal differences](https://github.com/correctcomputation/checkedc-clang/files/6407802/pr561-benchmark-error-comparison.csv.txt).
- [X] thttpd iterative port: Makes no difference at the current state of the port.
- ~~Effect on other ongoing experiments: Help me identify all of them?~~ The paper submission is done, and any experiments still in progress will be adapted to this PR as needed.