### PR TITLE
Don't crash on a function call with parentheses around the function name.

### DIFF
--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -194,7 +194,7 @@ void TypeVarVisitor::setProgramInfoTypeVars() {
 // Check if type arguments have already been provided for this function
 // call so that we don't mess with anything already there.
 bool typeArgsProvided(CallExpr *Call) {
-  Expr *Callee = Call->getCallee()->IgnoreImpCasts();
+  Expr *Callee = Call->getCallee()->IgnoreParenImpCasts();
   if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(Callee)) {
     // ArgInfo is null if there are no type arguments anywhere in the program
     if (auto *ArgInfo = DRE->GetTypeArgumentInfo())

--- a/clang/test/3C/func_name_parens.c
+++ b/clang/test/3C/func_name_parens.c
@@ -1,0 +1,12 @@
+// Test that 3C doesn't crash on a function call with parentheses around the
+// function name
+// (https://github.com/correctcomputation/checkedc-clang/issues/543).
+
+// We only care that this doesn't crash.
+// RUN: 3c -base-dir=%S %s --
+
+void foo() {}
+
+void bar() {
+  (foo)();
+}


### PR DESCRIPTION
Fixes #543.