### PR TITLE
Add regression test for #523.

### DIFF
--- a/clang/test/3C/issue523.c
+++ b/clang/test/3C/issue523.c
@@ -1,0 +1,17 @@
+// Regression test for a null dereference in
+// AvarBoundsInference::getReachableBoundKeys
+// (https://github.com/correctcomputation/checkedc-clang/issues/523). This
+// example was reduced from ImageMagick. We haven't analyzed the conditions that
+// trigger the crash in order to construct a targeted test that we are more
+// confident would catch a regression even if other changes are made to 3C, but
+// this is better than nothing.
+
+// We only care that this doesn't crash.
+// RUN: 3c -base-dir=%S -alltypes %s --
+
+int a;
+void b(int *f, int g) {
+  int *c = f;
+  (void)f[a];
+}
+void (*h)(int *, int) = b;


### PR DESCRIPTION
I checked that, as of now, this test still crashes 3C if 09544a0e3e7151787e6c08529f494e48caf412ce is reverted.