### PR TITLE
Remove old realloc, etc. declarations from basic.c and graphs.c.

### DIFF
--- a/clang/test/3C/basic.c
+++ b/clang/test/3C/basic.c
@@ -6,23 +6,6 @@
 #include <string.h>
 
 #include <stddef.h>
-extern _Itype_for_any(T) void *malloc(size_t size)
-    : itype(_Array_ptr<T>) byte_count(size);
-extern _Itype_for_any(T) void *realloc(void *pointer
-                                       : itype(_Array_ptr<T>) byte_count(1),
-                                         size_t size)
-    : itype(_Array_ptr<T>) byte_count(size);
-extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size)
-    : itype(_Array_ptr<T>) byte_count(nmemb * size);
-
-// From string_checked.h
-#if _FORTIFY_SOURCE == 0 || _FORTIFY_SOURCE == 2 || !defined(strcpy)
-#undef strcpy
-// Dest is left unchecked intentionally. There is no bound on dest, so this
-// is always an unchecked function
-_Unchecked char *strcpy(char *restrict dest, const char *restrict src
-                        : itype(restrict _Nt_array_ptr<const char>));
-#endif
 
 void basic1() {
   char data[] = "abcdefghijklmnop";

--- a/clang/test/3C/graphs.c
+++ b/clang/test/3C/graphs.c
@@ -10,16 +10,6 @@
 #include <stdlib.h>
 
 #include <stddef.h>
-extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size)
-    : itype(_Array_ptr<T>) byte_count(nmemb * size);
-extern _Itype_for_any(T) void free(void *pointer
-                                   : itype(_Array_ptr<T>) byte_count(0));
-extern _Itype_for_any(T) void *malloc(size_t size)
-    : itype(_Array_ptr<T>) byte_count(size);
-extern _Itype_for_any(T) void *realloc(void *pointer
-                                       : itype(_Array_ptr<T>) byte_count(1),
-                                         size_t size)
-    : itype(_Array_ptr<T>) byte_count(size);
 
 #define MAX_SIZE 40 /*Assume 40 nodes at max in graph*/
 #define INT_MIN 0


### PR DESCRIPTION
This is the minimum to fix the regression tests broken by our changes to system headers so far (#560) so we can more easily continue to test other changes to 3C. We plan to continue making changes to the system headers that may cause similar problems, so we want to finish cleaning up the rest of the regression tests ASAP.