### PR TITLE
Fix one crash due to a PSL collision in TypeParamBindings.

### DIFF
--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -481,7 +481,7 @@ private:
   // Attempt to find the right spot to insert the type arguments. This should be
   // directly after the name of the function being called.
   SourceLocation getTypeArgLocation(CallExpr *Call) {
-    Expr *Callee = Call->getCallee()->IgnoreImpCasts();
+    Expr *Callee = Call->getCallee()->IgnoreParenImpCasts();
     if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(Callee)) {
       size_t NameLength = DRE->getNameInfo().getAsString().length();
       return Call->getBeginLoc().getLocWithOffset(NameLength);

--- a/clang/test/3C/type_param_psl_collision.c
+++ b/clang/test/3C/type_param_psl_collision.c
@@ -1,0 +1,20 @@
+// Apparently, two function calls expanded from the same macro call can have
+// colliding PersistentSourceLocs in the TypeParamBindings map
+// (https://github.com/correctcomputation/checkedc-clang/issues/568). One
+// symptom of the collision was that 3C would crash if one of the function names
+// was in parentheses. Test that we've fixed this crash. The underlying problem
+// described in the issue is not yet fixed.
+
+// We only care that this doesn't crash.
+// RUN: 3c -base-dir=%S %s --
+
+_Itype_for_any(T) void *fiddle(void *p : itype(_Ptr<T>)) : itype(_Ptr<T>) {
+  return p;
+}
+void foo() {}
+
+void bar() {
+  char y;
+  #define TWO_CALLS fiddle<char>(&y); (foo)();
+  TWO_CALLS
+}


### PR DESCRIPTION
See #568.