### PR TITLE
Avoid expanding macros in array declarations

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -250,6 +250,10 @@ private:
   //  * An unsized array, then U -(a,b) , a = O_UnSizedArray, b has no meaning.
   std::map<uint32_t, std::pair<OriginalArrType, uint64_t>> ArrSizes;
 
+  // To help rewriting preserve macros and constant expressions in arrays size
+  // expressions, the source strings for bounds of arrays are also stored.
+  std::map<uint32_t, std::string> ArrSizeStrs;
+
   // True if this variable has an itype in the original source code.
   bool SrcHasItype;
   // The string representation of the itype of in the original source. This

--- a/clang/test/3C/basic.c
+++ b/clang/test/3C/basic.c
@@ -18,7 +18,7 @@ void basic1() {
 }
 
 //CHECK_NOALL: char data[] = "abcdefghijklmnop";
-//CHECK_ALL: char data _Nt_checked[17] =  "abcdefghijklmnop";
+//CHECK_ALL: char data _Nt_checked[] =  "abcdefghijklmnop";
 //CHECK: char *buffer = malloc<char>(50);
 
 char *basic2(int temp) {
@@ -43,8 +43,8 @@ char *basic2(int temp) {
 }
 //CHECK_ALL: char *basic2(int temp) : itype(_Nt_array_ptr<char>) {
 //CHECK_NOALL: char *basic2(int temp) : itype(_Ptr<char>) {
-//CHECK_ALL: char data _Nt_checked[17] =  "abcdefghijklmnop";
-//CHECK_ALL: char data2 _Nt_checked[65] =
+//CHECK_ALL: char data _Nt_checked[] =  "abcdefghijklmnop";
+//CHECK_ALL: char data2 _Nt_checked[] =
 //CHECK: char *buffer = malloc<char>(8);
 //CHECK: char *buffer = malloc<char>(1024);
 
@@ -183,7 +183,7 @@ struct student *new_student() {
 }
 //CHECK: _Ptr<struct student> new_student(void) {
 //CHECK_NOALL: char name[] = "Bilbo Baggins";
-//CHECK_ALL: char name _Nt_checked[14] =  "Bilbo Baggins";
+//CHECK_ALL: char name _Nt_checked[] =  "Bilbo Baggins";
 //CHECK: _Ptr<struct student> new_s =  malloc<struct student>(sizeof(struct student));
 
 int main() {

--- a/clang/test/3C/graphs.c
+++ b/clang/test/3C/graphs.c
@@ -57,8 +57,7 @@ struct Stack
 
   int arr[MAX_SIZE];
   //CHECK_NOALL: int arr[MAX_SIZE];
-  //CHECK_ALL: int arr _Checked[40];
-
+  //CHECK_ALL: int arr _Checked[MAX_SIZE];
   int top;
 };
 

--- a/clang/test/3C/keep_array_size_expr.c
+++ b/clang/test/3C/keep_array_size_expr.c
@@ -1,0 +1,59 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/keep_array_size_expr.c -- | diff %t.checked/keep_array_size_expr.c -
+
+int a[1];
+int b[1 + 1];
+int c[1 /*test*/];
+#define FOO 10
+int d[FOO];
+int e[FOO + FOO];
+int f[sizeof(int)];
+//CHECK_ALL: int a _Checked[1];
+//CHECK_ALL: int b _Checked[1 + 1];
+//CHECK_ALL: int c _Checked[1 /*test*/];
+//CHECK_ALL: #define FOO 10
+//CHECK_ALL: int d _Checked[FOO];
+//CHECK_ALL: int e _Checked[FOO + FOO];
+//CHECK_ALL: int f _Checked[sizeof(int)];
+
+#define BAR(x) (x + 10)
+int g[BAR(10)];
+//CHECK_ALL: #define BAR(x) (x + 10)
+//CHECK_ALL: int g _Checked[BAR(10)];
+
+#define BAZ(x) x##1
+int h[BAZ(1)];
+//CHECK_ALL: #define BAZ(x) x##1
+//CHECK_ALL: int h _Checked[BAZ(1)];
+
+int i[];
+//CHECK_ALL: int i _Checked[];
+
+int j[10][10];
+int k[1 + 1][FOO + FOO];
+int l[FOO][BAR(1)];
+int m[/*test*/10][BAR(1)][1+1][sizeof(int)][FOO];
+//CHECK_ALL: int j _Checked[10] _Checked[10];
+//CHECK_ALL: int k _Checked[1 + 1] _Checked[FOO + FOO];
+//CHECK_ALL: int l _Checked[FOO] _Checked[BAR(1)];
+//CHECK_ALL: int m _Checked[/*test*/10] _Checked[BAR(1)] _Checked[1+1] _Checked[sizeof(int)] _Checked[FOO];
+
+
+int *n[FOO];
+int **o[BAR(1+1)];
+//CHECK_ALL: _Ptr<int> n _Checked[FOO] = {((void *)0)};
+//CHECK_ALL: _Ptr<_Ptr<int>> o _Checked[BAR(1+1)] = {((void *)0)};
+
+
+int (*p)[FOO];
+int (*q[/*test*/10/*test*/])[FOO];
+int (*r[/*test*/10/*test*/][BAR(1)])[FOO][BAZ(1)];
+//CHECK_ALL: _Ptr<int _Checked[FOO]> p = ((void *)0);
+//CHECK_ALL: _Ptr<int _Checked[FOO]> q _Checked[/*test*/10/*test*/] = {((void *)0)};
+//CHECK_ALL: _Ptr<int _Checked[FOO] _Checked[BAZ(1)]> r _Checked[/*test*/10/*test*/] _Checked[BAR(1)] = {((void *)0)};
+
+int s <: 10 :>;
+//CHECK_ALL: int s _Checked <: 10 :>;

--- a/clang/test/3C/macro_end_of_decl.c
+++ b/clang/test/3C/macro_end_of_decl.c
@@ -29,8 +29,8 @@ int d SIZE;
 int e SIZE[1];
 //CHECK_NOALL: int d SIZE;
 //CHECK_NOALL: int e SIZE[1];
-//CHECK_ALL: int d _Checked[1];
-//CHECK_ALL: int e _Checked[1] _Checked[1];
+//CHECK_ALL: int d _Checked SIZE;
+//CHECK_ALL: int e _Checked SIZE _Checked[1];
 
 #define EQ =
 int *f EQ 0;
@@ -39,7 +39,7 @@ int *f EQ 0;
 int(*g0) ARGS, g1 SIZE, *g2 EQ 0;
 //CHECK: _Ptr<int (void)> g0 = ((void *)0);
 //CHECK_NOALL: int g1[1];
-//CHECK_ALL: int g1 _Checked[1];
+//CHECK_ALL: int g1 _Checked SIZE;
 //CHECK: _Ptr<int> g2 = 0;
 
 #define RPAREN )

--- a/clang/test/3C/multivardecls.c
+++ b/clang/test/3C/multivardecls.c
@@ -41,7 +41,7 @@ void test() {
   //CHECK: int o;
   //CHECK_ALL: int p _Checked[1];
   //CHECK_NOALL: int p[1];
-  //CHECK_ALL: int q _Checked[2] = {1, 2};
+  //CHECK_ALL: int q _Checked[] = {1, 2};
   //CHECK_NOALL: int q[] = {1, 2};
   //CHECK_ALL: int r _Checked[1] _Checked[1];
   //CHECK_NOALL: int r[1][1];

--- a/clang/test/3C/patch_issue_272.c
+++ b/clang/test/3C/patch_issue_272.c
@@ -10,4 +10,4 @@
 int *a[];
 void b() { a[0][0]; }
 
-// CHECK: _Array_ptr<int> a _Checked[1] = {((void *)0)};
+// CHECK: _Array_ptr<int> a _Checked[] = {((void *)0)};


### PR DESCRIPTION
Keeps track of the original source representation for the size of constant sized arrays and use this when rewriting to a checked array types. This also handles various other constant expression in the size of an array.

```c
int a[1];
int b[1 + 1];
int c[1 /*test*/];
#define FOO 10
int d[FOO];
int e[FOO + FOO];
int f[sizeof(int)];
```
now converts to
```c
int a _Checked[1];
int b _Checked[1 + 1];
int c _Checked[1 /*test*/];
#define FOO 10
int d _Checked[FOO];
int e _Checked[FOO + FOO];
```

fixes #173