### PR TITLE
Root cause fixes

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -2110,10 +2110,14 @@ FVComponentVariable::FVComponentVariable(const QualType &QT,
                                          std::string *InFunc, bool HasItype) {
   ExternalConstraint =
       new PVConstraint(QT, D, N, I, C, InFunc, -1, HasItype, nullptr, ITypeT);
-  InternalConstraint =
-      new PVConstraint(QT, D, N, I, C, InFunc, -1, HasItype, nullptr, ITypeT);
-  bool EquateChecked = (QT->isVoidPointerType() || QT->isFunctionPointerType());
-  linkInternalExternal(I, EquateChecked);
+  if (!HasItype && QT->isVoidPointerType()) {
+    InternalConstraint = ExternalConstraint;
+  } else {
+    InternalConstraint =
+        new PVConstraint(QT, D, N, I, C, InFunc, -1, HasItype, nullptr, ITypeT);
+    bool EquateChecked = QT->isVoidPointerType() || QT->isFunctionPointerType();
+    linkInternalExternal(I, EquateChecked);
+  }
 
   // Save the original source for the declaration if this is a param
   // declaration. This lets us avoid macro expansion in function pointer

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -595,13 +595,13 @@ void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
 
   if (isa<ParmVarDecl>(D))
     IsGeneric = PVC && PVC->getIsGeneric();
-  if (isVarArgType(D->getType().getAsString()) ||
-      (hasVoidType(D) && !IsGeneric)) {
+  bool IsVarArg = isVarArgType(D->getType().getAsString());
+  bool IsVoidPtr = hasVoidType(D) && !IsGeneric;
+  if (IsVarArg || IsVoidPtr) {
     // Set the reason for making this variable WILD.
-    std::string Rsn = "Variable type void.";
     PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(D, *Context);
-    if (!D->getType()->isVoidType())
-      Rsn = "Variable type is va_list.";
+    std::string Rsn = IsVoidPtr ? "Variable type void."
+                                : "Variable type is va_list.";
     if (PVC != nullptr)
       PVC->constrainToWild(CS, Rsn, &PL);
   }

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -22,7 +22,7 @@ void test0() {
 void test1() {
   int a;
   int *b;
-  b = malloc(sizeof(int)); // expected-warning {{Bad pointer type solution}}
+  b = malloc(sizeof(int)); // expected-warning {{1 unchecked pointer: Bad pointer type solution}}
   b[0] = 1;
 
   union u {
@@ -33,7 +33,7 @@ void test1() {
   void (*c)(void);
   c++; // expected-warning {{1 unchecked pointer: Pointer arithmetic performed on a function pointer}}
 
-  int *d = malloc(1); // expected-warning {{Unsafe call to allocator function}}
+  int *d = malloc(1); // expected-warning {{1 unchecked pointer: Unsafe call to allocator function}}
 }
 
 // expected-warning@+1 {{1 unchecked pointer: External global variable glob has no definition}}
@@ -42,13 +42,18 @@ extern int *glob;
 // expected-warning@+1 {{1 unchecked pointer: Unchecked pointer in parameter or return of external function glob_f}}
 int *glob_f(void);
 
-void (*f)(void *); // expected-warning {{1 unchecked pointer: Default void* type}}
+void (*void_star_fptr)(void *); // expected-warning {{1 unchecked pointer: Default void* type}}
+void void_star_fn(void *p); // expected-warning {{1 unchecked pointer: Default void* type}}
 
 typedef struct {
   int x;
   float f;
 } A, *PA;
-// expected-warning@-1 {{0 unchecked pointers: Unable to rewrite a typedef with multiple names}}
+// expected-warning@-1 {{2 unchecked pointers: Unable to rewrite a typedef with multiple names}}
+// Two pointers affected by the above root cause. Do not count the typedef
+// itself as a root cause even though that's where the star is written. Count
+// each of the variables below even though no star is actually written.
+PA pa_test0, pa_test1;
 
-// expected-warning@+1 {{Internal constraint for generic function declaration, for which 3C currently does not support re-solving.}}
+// expected-warning@+1 {{1 unchecked pointer: Internal constraint for generic function declaration, for which 3C currently does not support re-solving.}}
 _Itype_for_any(T) void remember(void *p : itype(_Ptr<T>)) {}

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -51,8 +51,8 @@ typedef struct {
 } A, *PA;
 // expected-warning@-1 {{2 unchecked pointers: Unable to rewrite a typedef with multiple names}}
 // Two pointers affected by the above root cause. Do not count the typedef
-// itself as a root cause even though that's where the star is written. Count
-// each of the variables below even though no star is actually written.
+// itself as an affected pointer even though that's where the star is written.
+// Count each of the variables below even though no star is actually written.
 PA pa_test0, pa_test1;
 
 // expected-warning@+1 {{1 unchecked pointer: Internal constraint for generic function declaration, for which 3C currently does not support re-solving.}}

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -4,19 +4,19 @@
 
 #include <stdlib.h>
 
-void *x; // expected-warning {{Default void* type}}
+void *x; // expected-warning {{1 unchecked pointer: Default void* type}}
 
 void test0() {
   int *a;
   char *b;
-  a = b; // expected-warning {{Cast from char * to int *}}
+  a = b; // expected-warning {{2 unchecked pointers: Cast from char * to int *}}
 
   int *c;
-  (char *)c; // expected-warning {{Cast from int * to char *}}
+  (char *)c; // expected-warning {{1 unchecked pointer: Cast from int * to char *}}
 
   int *e;
   char *f;
-  f = (char *)e; // expected-warning {{Cast from int * to char *}}
+  f = (char *)e; // expected-warning {{2 unchecked pointers: Cast from int * to char *}}
 }
 
 void test1() {
@@ -26,29 +26,29 @@ void test1() {
   b[0] = 1;
 
   union u {
-    int *a; // expected-warning {{Union or external struct field encountered}}
-    int *b; // expected-warning {{Union or external struct field encountered}}
+    int *a; // expected-warning {{1 unchecked pointer: Union or external struct field encountered}}
+    int *b; // expected-warning {{1 unchecked pointer: Union or external struct field encountered}}
   };
 
   void (*c)(void);
-  c++; // expected-warning {{Pointer arithmetic performed on a function pointer}}
+  c++; // expected-warning {{1 unchecked pointer: Pointer arithmetic performed on a function pointer}}
 
   int *d = malloc(1); // expected-warning {{Unsafe call to allocator function}}
 }
 
-// expected-warning@+1 {{External global variable glob has no definition}}
+// expected-warning@+1 {{1 unchecked pointer: External global variable glob has no definition}}
 extern int *glob;
 
-// expected-warning@+1 {{Unchecked pointer in parameter or return of external function glob_f}}
+// expected-warning@+1 {{1 unchecked pointer: Unchecked pointer in parameter or return of external function glob_f}}
 int *glob_f(void);
 
-void (*f)(void *); // expected-warning {{Default void* type}}
+void (*f)(void *); // expected-warning {{1 unchecked pointer: Default void* type}}
 
 typedef struct {
   int x;
   float f;
 } A, *PA;
-// expected-warning@-1 {{Unable to rewrite a typedef with multiple names}}
+// expected-warning@-1 {{0 unchecked pointers: Unable to rewrite a typedef with multiple names}}
 
 // expected-warning@+1 {{Internal constraint for generic function declaration, for which 3C currently does not support re-solving.}}
 _Itype_for_any(T) void remember(void *p : itype(_Ptr<T>)) {}


### PR DESCRIPTION
Fixes issue where pointers in unwritable code were counted in the root cause analysis. Also fixes an error in `specialCaseVarIntros` where a `void` pointer was sometimes reported as an varargs parameter.