### PR TITLE
Fix bug in PVConstraint copy constructor

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -131,9 +131,9 @@ PointerVariableConstraint::PointerVariableConstraint(
       this->SrcVars.push_back(*CAIt);
       if (!isa<WildAtom>(*CAIt))
         CS.addConstraint(CS.createGeq(*CAIt, FreshVA, false));
-      ++VAIt;
-      ++CAIt;
     }
+    ++VAIt;
+    ++CAIt;
   }
 
   if (Ot->FV != nullptr) {


### PR DESCRIPTION
An unused code path would have resulted in a infinite loop if anything
ever tried to execute it.