### PR TITLE
Fixing Bounds issue with Function Parameters

### DIFF
--- a/clang/include/clang/3C/ABounds.h
+++ b/clang/include/clang/3C/ABounds.h
@@ -41,11 +41,16 @@ private:
 protected:
   ABounds(BoundsKind K) : Kind(K) {}
   void addBoundsUsedKey(BoundsKey);
+  // Get the variable name of the the given bounds key that corresponds
+  // to the given declaration.
+  static std::string getBoundsKeyStr(BoundsKey ,
+                                     AVarBoundsInfo *,
+                                     clang::Decl *);
 
 public:
   virtual ~ABounds() {}
 
-  virtual std::string mkString(AVarBoundsInfo *) = 0;
+  virtual std::string mkString(AVarBoundsInfo *, clang::Decl *D = nullptr) = 0;
   virtual bool areSame(ABounds *, AVarBoundsInfo *) = 0;
   virtual BoundsKey getBKey() = 0;
   virtual ABounds *makeCopy(BoundsKey NK) = 0;
@@ -67,7 +72,7 @@ public:
 
   virtual ~CountBound() {}
 
-  std::string mkString(AVarBoundsInfo *ABI) override;
+  std::string mkString(AVarBoundsInfo *ABI, clang::Decl *D = nullptr) override;
   bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
   BoundsKey getBKey() override;
   ABounds *makeCopy(BoundsKey NK) override;
@@ -90,7 +95,7 @@ public:
 
   virtual ~ByteBound() {}
 
-  std::string mkString(AVarBoundsInfo *ABI) override;
+  std::string mkString(AVarBoundsInfo *ABI, clang::Decl *D = nullptr) override;
   bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
   BoundsKey getBKey() override;
   ABounds *makeCopy(BoundsKey NK) override;
@@ -113,7 +118,7 @@ public:
 
   virtual ~RangeBound() {}
 
-  std::string mkString(AVarBoundsInfo *ABI) override;
+  std::string mkString(AVarBoundsInfo *ABI, clang::Decl *D = nullptr) override;
   bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
 
   BoundsKey getBKey() override {

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -255,6 +255,10 @@ public:
 
   bool areSameProgramVar(BoundsKey B1, BoundsKey B2);
 
+  // Check if the provided BoundsKey is for a function param?
+  // If yes, provide the index of the parameter.
+  bool isFuncParamBoundsKey(BoundsKey BK, unsigned &PIdx);
+
 private:
   friend class AvarBoundsInference;
   friend class CtxSensitiveBoundsKeyHandler;

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1406,6 +1406,16 @@ bool AVarBoundsInfo::areSameProgramVar(BoundsKey B1, BoundsKey B2) {
   return B1 == B2;
 }
 
+bool AVarBoundsInfo::isFuncParamBoundsKey(BoundsKey BK, unsigned &PIdx) {
+  auto &ParmBkeyToPSL = ParamDeclVarMap.right();
+  if (ParmBkeyToPSL.find(BK) != ParmBkeyToPSL.end()) {
+    auto &ParmTup = ParmBkeyToPSL.at(BK);
+    PIdx = std::get<3>(ParmTup);
+    return true;
+  }
+  return false;
+}
+
 std::set<BoundsKey>
 AVarBoundsInfo::getCtxSensFieldBoundsKey(Expr *E, ASTContext *C,
                                          ProgramInfo &I) {

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -597,7 +597,7 @@ std::string ArrayBoundsRewriter::getBoundsString(const PVConstraint *PV,
     ABounds *ArrB = ABInfo.getBounds(DK);
     // Only we we have bounds and no pointer arithmetic on the variable.
     if (ArrB != nullptr && !ABInfo.hasPointerArithmetic(DK)) {
-      BString = ArrB->mkString(&ABInfo);
+      BString = ArrB->mkString(&ABInfo, D);
       if (!BString.empty())
         BString = Pfix + BString;
     }

--- a/clang/test/3C/func_parm_bounds.c
+++ b/clang/test/3C/func_parm_bounds.c
@@ -1,0 +1,49 @@
+/**
+Test for parameter bounds with parameter with in the declaration.
+Issue: https://github.com/correctcomputation/checkedc-clang/issues/573
+**/
+
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL" %s
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unusedl -
+// RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o %t2.unused -
+
+extern _Itype_for_any(T) void *malloc(unsigned long size);
+
+int gsize;
+int *glob;
+//CHECK_ALL: _Array_ptr<int> glob : count(gsize) = ((void *)0);
+
+int foo(int *c, int z);
+int foo(int *c, int l) {
+  if (0 < l) return c[0];
+  return 0;
+}
+//CHECK_ALL: int foo(_Array_ptr<int> c : count(z), int z);
+//CHECK_ALL: int foo(_Array_ptr<int> c : count(l), int l) {
+
+int consfoo(int *c);
+int consfoo(int *c) {
+  return c[0];
+}
+//CHECK_ALL: int consfoo(_Array_ptr<int> c : count(5));
+//CHECK_ALL: int consfoo(_Array_ptr<int> c : count(5)) {
+
+int globalfoo(int *c);
+int globalfoo(int *c) {
+  return c[0];
+}
+//CHECK_ALL: int globalfoo(_Array_ptr<int> c : count(gsize));
+//CHECK_ALL: int globalfoo(_Array_ptr<int> c : count(gsize)) {
+
+int caller() {
+  int arr[5];
+  gsize = 100;
+  glob = malloc(gsize*sizeof(int));
+  glob[0] = 1;
+  globalfoo(glob);
+  consfoo(arr);
+  return 0;
+}
+//CHECK_ALL: int arr _Checked[5];
+//CHECK_ALL: glob = _Assume_bounds_cast<_Array_ptr<int>>(malloc(gsize*sizeof(int)), byte_count(0));

--- a/clang/test/3C/func_parm_bounds.c
+++ b/clang/test/3C/func_parm_bounds.c
@@ -8,7 +8,7 @@ Issue: https://github.com/correctcomputation/checkedc-clang/issues/573
 // RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unusedl -
 // RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o %t2.unused -
 
-extern _Itype_for_any(T) void *malloc(unsigned long size);
+#include <stdlib.h>
 
 int gsize;
 int *glob;


### PR DESCRIPTION
Now, bounds strings for the parameters will be displayed in accordance with its declaration.

Reference issue: https://github.com/correctcomputation/checkedc-clang/issues/573