### PR TITLE
Fix statstest.

### DIFF
--- a/clang/test/3C/statstest.c
+++ b/clang/test/3C/statstest.c
@@ -1,5 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -dump-stats -base-dir=%S -alltypes -addcr %s -- 2>&1 | FileCheck -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -dump-stats -base-dir=%S -alltypes -addcr %s -- 2>%t.stderr | FileCheck -match-full-lines %s
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_STDERR" --input-file %t.stderr %s
 
 
 #include <stdlib.h>
@@ -40,32 +41,32 @@ void j() {
   //CHECK: _Ptr<void (int * : itype(_Ptr<int>))> fp = i;
 }
 
-//CHECK: Summary
-//CHECK: TotalConstraints|TotalPtrs|TotalNTArr|TotalArr|TotalWild
-//CHECK: 18|14|0|1|3
-//CHECK: NumPointersNeedBounds:1,
-//CHECK: NumNTNoBounds:0,
-//CHECK: Details:
-//CHECK: Invalid:0
-//CHECK: ,BoundsFound:
-//CHECK: Array Bounds Inference Stats:
-//CHECK: NamePrefixMatch:0
-//CHECK: AllocatorMatch:0
-//CHECK: VariableNameMatch:0
-//CHECK: NeighbourParamMatch:0
-//CHECK: DataflowMatch:0
-//CHECK: Declared:1
-//CHECK: TimeStats
-//CHECK: TotalTime:{.*}
-//CHECK: ConstraintBuilderTime:{.*}
-//CHECK: ConstraintSolverTime:{.*}
-//CHECK: ArrayBoundsInferenceTime:{.*}
-//CHECK: RewritingTime:{.*}
-//CHECK: ReWriteStats
-//CHECK: NumAssumeBoundsCasts:1
-//CHECK: NumCheckedCasts:0
-//CHECK: NumWildCasts:0
-//CHECK: NumFixedCasts:0
-//CHECK: NumITypes:0
-//CHECK: NumCheckedRegions:3
-//CHECK: NumUnCheckedRegions:0
+//CHECK_STDERR: Summary
+//CHECK_STDERR: TotalConstraints|TotalPtrs|TotalNTArr|TotalArr|TotalWild
+//CHECK_STDERR: 18|14|0|1|3
+//CHECK_STDERR: NumPointersNeedBounds:1,
+//CHECK_STDERR: NumNTNoBounds:0,
+//CHECK_STDERR: Details:
+//CHECK_STDERR: Invalid:0
+//CHECK_STDERR: ,BoundsFound:
+//CHECK_STDERR: Array Bounds Inference Stats:
+//CHECK_STDERR: NamePrefixMatch:0
+//CHECK_STDERR: AllocatorMatch:0
+//CHECK_STDERR: VariableNameMatch:0
+//CHECK_STDERR: NeighbourParamMatch:0
+//CHECK_STDERR: DataflowMatch:0
+//CHECK_STDERR: Declared:1
+//CHECK_STDERR: TimeStats
+//CHECK_STDERR: TotalTime:{{.*}}
+//CHECK_STDERR: ConstraintBuilderTime:{{.*}}
+//CHECK_STDERR: ConstraintSolverTime:{{.*}}
+//CHECK_STDERR: ArrayBoundsInferenceTime:{{.*}}
+//CHECK_STDERR: RewritingTime:{{.*}}
+//CHECK_STDERR: ReWriteStats
+//CHECK_STDERR: NumAssumeBoundsCasts:1
+//CHECK_STDERR: NumCheckedCasts:0
+//CHECK_STDERR: NumWildCasts:0
+//CHECK_STDERR: NumFixedCasts:0
+//CHECK_STDERR: NumITypes:2
+//CHECK_STDERR: NumCheckedRegions:4
+//CHECK_STDERR: NumUnCheckedRegions:0


### PR DESCRIPTION
- It made an invalid assumption that stdout was flushed before stderr, which failed on Windows. To avoid that, check stdout and stderr separately.

- That fix revealed that the CHECK comments weren't correct, but they were passing because they were matching themselves (!) because -match-full-lines was removed in #566. Fix the syntax for regular expressions (double curly braces, not single) and the incorrect expected values for two statistics.