### PR TITLE
Handling function pointer bounds

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -2046,22 +2046,32 @@ FVComponentVariable::mkString(Constraints &CS, bool EmitName) const {
 std::string
 FVComponentVariable::mkTypeStr(Constraints &CS, bool EmitName,
                                std::string UseName) const {
+  std::string Ret;
   // if checked or given new name, generate type
-  if (hasCheckedSolution(CS) || (EmitName && !UseName.empty()))
-    return ExternalConstraint->mkString(CS, EmitName, false,
-                                        false, false, UseName);
-  // if no need to generate type, try to use source
-  if (!SourceDeclaration.empty())
-    return SourceDeclaration;
-  // if no source and no name, generate nameless type
-  if (EmitName && ExternalConstraint->getName().empty())
-    return ExternalConstraint->getOriginalTy();
-  // if no source and a have a needed name, generate named type
-  if (EmitName)
-    return ExternalConstraint->getRewritableOriginalTy()
-           + ExternalConstraint->getName();
-  // if no source and don't need a name, generate type ready for one
-  return ExternalConstraint->getRewritableOriginalTy();
+  if (hasCheckedSolution(CS) || (EmitName && !UseName.empty())) {
+    Ret = ExternalConstraint->mkString(CS, EmitName, false,
+                                       false, false,
+                                          UseName);
+  } else {
+    // if no need to generate type, try to use source
+    if (!SourceDeclaration.empty())
+      Ret = SourceDeclaration;
+    // if no source and no name, generate nameless type
+    else if (EmitName && ExternalConstraint->getName().empty())
+      Ret = ExternalConstraint->getOriginalTy();
+    // if no source and a have a needed name, generate named type
+    else if (EmitName)
+      Ret = ExternalConstraint->getRewritableOriginalTy() +
+            ExternalConstraint->getName();
+    else
+      // if no source and don't need a name, generate type ready for one
+      Ret = ExternalConstraint->getRewritableOriginalTy();
+  }
+
+  if (ExternalConstraint->srcHasBounds())
+    Ret += " : " + ExternalConstraint->getBoundsStr();
+
+  return Ret;
 }
 
 std::string FVComponentVariable::mkItypeStr(Constraints &CS) const {

--- a/clang/test/3C/funcptr_bounds.c
+++ b/clang/test/3C/funcptr_bounds.c
@@ -1,0 +1,12 @@
+/**
+Check function pointer bounds rewriting.
+**/
+
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unusedl -
+// RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o %t2.unused -
+
+void (*fn)(_Array_ptr<char> buf : count(l), unsigned int l);
+//CHECK: _Ptr<void (_Array_ptr<char> buf : count(l), unsigned int l)> fn = ((void *)0);


### PR DESCRIPTION
* Make it explicit to *not* handle bounds for parameters of function pointers.
* Fix writing of bounds to parameters of function pointers.

Issue: https://github.com/correctcomputation/checkedc-clang/issues/575