### PR TITLE
Initialize typedef info structure

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -145,7 +145,7 @@ PointerVariableConstraint::PointerVariableConstraint(
   this->BaseType = Ot->BaseType;
   this->SrcHasItype = Ot->SrcHasItype;
   this->IsVoidPtr = Ot->IsVoidPtr;
-  // We need not initialize other members.
+  this->TypedefLevelInfo = Ot->TypedefLevelInfo;
 }
 
 PointerVariableConstraint::PointerVariableConstraint(DeclaratorDecl *D,


### PR DESCRIPTION
Fixes #584 by properly initializing the typedef info structure in the copy constructor for `PointerVariableConstraint`.