### PR TITLE
Fix intermittent error in bounds inference (#585)

### DIFF
--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -129,18 +129,15 @@ void
 AvarBoundsInference::
 mergeReachableProgramVars(BoundsKey TarBK, std::set<BoundsKey> &AllVars) {
   if (AllVars.size() > 1) {
-    // Convert the bounds key to corresponding program var.
-    std::set<ProgramVar *> AllProgVars;
-    for (auto AV : AllVars) {
-      AllProgVars.insert(BI->getProgramVar(AV));
-    }
     ProgramVar *BVar = nullptr;
     bool IsTarNTArr = BI->NtArrPointerBoundsKey.find(TarBK) !=
                       BI->NtArrPointerBoundsKey.end();
     // We want to merge all bounds vars. We give preference to
     // non-constants if there are multiple non-constant variables,
     // we give up.
-    for (auto *TmpB : AllProgVars) {
+    for (auto TmpBKey : AllVars) {
+      // Convert the bounds key to corresponding program var.
+      auto *TmpB = BI->getProgramVar(TmpBKey);
       // First case.
       if (BVar == nullptr) {
         BVar = TmpB;


### PR DESCRIPTION
Fix issue #585.
Iterate over a `BoundsKey` set instead of a `ProgramVar*` set so that the
iteration order does not depend on the address of the `ProgramVar`s.
This fixes the issue, but it is still potentially a problem that the
function depends on the order it iterates over the bounds keys. It is
also likely that other loops over sets of pointers exhibit this same
problem.

I've tested this locally  and everything still works. I also ran the test on 
windows ~50 times,  and no longer see the issue. Given that it was
intermittent in the first place, it's hard to sure that it's fixed, but it looks good.