### PR TITLE
Don't allow type arguments to be added to generic function calls in unwritable files.

### DIFF
--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -97,8 +97,10 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
       FDef = FD;
     if (auto *FVCon = Info.getFuncConstraint(FDef, Context)) {
       // if we need to rewrite it but can't (macro, etc), it isn't safe
-      bool ForcedInconsistent = !typeArgsProvided(CE)
-                                && !Rewriter::isRewritable(CE->getExprLoc());
+      bool ForcedInconsistent =
+          !typeArgsProvided(CE) &&
+          (!Rewriter::isRewritable(CE->getExprLoc()) ||
+           !canWrite(PersistentSourceLoc::mkPSL(CE, *Context).getFileName()));
       // Visit each function argument, and if it use a type variable, insert it
       // into the type variable binding map.
       unsigned int I = 0;

--- a/clang/test/3C/canwrite_constraints.h
+++ b/clang/test/3C/canwrite_constraints.h
@@ -59,3 +59,11 @@ void unwritable_func_with_itype(int *p : itype(_Array_ptr<int>)) {}
 void unwritable_func_with_itype_and_bounds(int *p
                                            : itype(_Array_ptr<int>) count(12)) {
 }
+
+// Test for https://github.com/correctcomputation/checkedc-clang/issues/580
+_Itype_for_any(T) void my_generic_function(void *p : itype(_Ptr<T>));
+
+void unwritable_type_argument() {
+  int i;
+  my_generic_function(&i);
+}


### PR DESCRIPTION
Fixes #580.