### PR TITLE
Fix `canwrite_constraints` test and constrain itypes in unwritable files.

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1954,8 +1954,8 @@ Atom *PointerVariableConstraint::getAtom(unsigned AtomIdx, Constraints &CS) {
   return nullptr;
 }
 
-void
-PointerVariableConstraint::equateWithItype(ProgramInfo &I, bool ForceEquate) {
+void PointerVariableConstraint::equateWithItype(
+    ProgramInfo &I, const std::string &ReasonUnchangeable) {
   Constraints &CS = I.getConstraints();
   assert(SrcVars.size() == Vars.size());
   for (unsigned VarIdx = 0; VarIdx < Vars.size(); VarIdx++) {
@@ -1966,7 +1966,7 @@ PointerVariableConstraint::equateWithItype(ProgramInfo &I, bool ForceEquate) {
       Vars[VarIdx] = SrcVars[VarIdx];
   }
   if (FV) {
-    FV->equateWithItype(I, ForceEquate);
+    FV->equateWithItype(I, ReasonUnchangeable);
   }
 }
 
@@ -2006,11 +2006,11 @@ bool FunctionVariableConstraint::isOriginallyChecked() const {
   return ReturnVar.ExternalConstraint->isOriginallyChecked();
 }
 
-void
-FunctionVariableConstraint::equateWithItype(ProgramInfo &I, bool ForceEquate) {
-  ReturnVar.equateWithItype(I, ForceEquate);
+void FunctionVariableConstraint::equateWithItype(
+    ProgramInfo &I, const std::string &ReasonUnchangeable) {
+  ReturnVar.equateWithItype(I, ReasonUnchangeable);
   for (auto Param : ParamVars)
-    Param.equateWithItype(I, ForceEquate);
+    Param.equateWithItype(I, ReasonUnchangeable);
 }
 
 void FVComponentVariable::mergeDeclaration(FVComponentVariable *From,
@@ -2115,18 +2115,31 @@ FVComponentVariable::FVComponentVariable(const QualType &QT,
   }
 }
 
-void
-FVComponentVariable::equateWithItype(ProgramInfo &I, bool ForceEquate) const {
+void FVComponentVariable::equateWithItype(
+    ProgramInfo &I, const std::string &ReasonUnchangeable) const {
   Constraints &CS = I.getConstraints();
-  bool IsGeneric = ExternalConstraint->getIsGeneric();
+  const std::string ReasonUnchangeable2 =
+      (ReasonUnchangeable.empty() && ExternalConstraint->getIsGeneric())
+          // TODO: Add a test for this root-cause message somewhere once
+          // diagnostic verification is re-enabled
+          // (https://github.com/correctcomputation/checkedc-clang/issues/503).
+          ? "Internal constraint for generic function declaration, "
+            "for which 3C currently does not support re-solving."
+          : ReasonUnchangeable;
   bool HasBounds = ExternalConstraint->srcHasBounds();
   bool HasItype = ExternalConstraint->srcHasItype();
-  if (HasItype && (ForceEquate || IsGeneric || HasBounds)) {
-    ExternalConstraint->equateWithItype(I, ForceEquate);
+  // If the type cannot change at all (ReasonUnchangeable2 is set), then we
+  // constrain both the external and internal types to not change. Otherwise, if
+  // the variable has bounds, then we don't want the checked (external) portion
+  // of the type to change because that could blow away the bounds, but we still
+  // allow the internal type to change so that the type can change from an itype
+  // to fully checked.
+  if (HasItype && (!ReasonUnchangeable2.empty() || HasBounds)) {
+    ExternalConstraint->equateWithItype(I, ReasonUnchangeable2);
     if (ExternalConstraint != InternalConstraint)
       linkInternalExternal(I, false);
-    if (IsGeneric)
-      InternalConstraint->constrainToWild(CS, "Internal constraint for generic function.");
+    if (!ReasonUnchangeable2.empty())
+      InternalConstraint->constrainToWild(CS, ReasonUnchangeable2);
   }
 }
 

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -2134,11 +2134,12 @@ void FVComponentVariable::equateWithItype(
   // of the type to change because that could blow away the bounds, but we still
   // allow the internal type to change so that the type can change from an itype
   // to fully checked.
-  if (HasItype && (!ReasonUnchangeable2.empty() || HasBounds)) {
+  bool MustConstrainInternalType = !ReasonUnchangeable2.empty();
+  if (HasItype && (MustConstrainInternalType || HasBounds)) {
     ExternalConstraint->equateWithItype(I, ReasonUnchangeable2);
     if (ExternalConstraint != InternalConstraint)
       linkInternalExternal(I, false);
-    if (!ReasonUnchangeable2.empty())
+    if (MustConstrainInternalType)
       InternalConstraint->constrainToWild(CS, ReasonUnchangeable2);
   }
 }

--- a/clang/test/3C/base_subdir/canwrite_constraints.c
+++ b/clang/test/3C/base_subdir/canwrite_constraints.c
@@ -1,14 +1,8 @@
-// TODO: refactor this test
-// https://github.com/correctcomputation/checkedc-clang/issues/503
-// XFAIL: *
-
 // Test that non-canWrite files are constrained not to change so that the final
 // annotations of other files are consistent with the original annotations of
 // the non-canWrite files. The currently supported cases are function and
 // variable declarations and checked regions.
 // (https://github.com/correctcomputation/checkedc-clang/issues/387)
-
-// TODO: Windows compatibility?
 
 // RUN: rm -rf %t*
 
@@ -16,7 +10,11 @@
 // not allow canwrite_constraints.h to change, and the internal types of q and
 // the return should remain wild.
 //
-// RUN: cd %S && 3c -addcr -output-dir=%t.checked/base_subdir -warn-all-root-cause -verify %s --
+// The root cause warning verification part of this test is currently disabled
+// because of https://github.com/correctcomputation/checkedc-clang/issues/503;
+// the rest of the test still works. TODO: Re-enable warning verification.
+//
+// RUN: cd %S && 3c -addcr -output-dir=%t.checked/base_subdir -warn-all-root-cause %s --
 // RUN: FileCheck -match-full-lines -check-prefixes=CHECK_LOWER --input-file %t.checked/base_subdir/canwrite_constraints.c %s
 // RUN: test ! -f %t.checked/canwrite_constraints.checked.h
 
@@ -38,7 +36,7 @@ int *bar(int *q) {
 
 int gar(intptr a) {
   int *b = a;
-  //CHECK_LOWER: int* b = a;
+  //CHECK_LOWER: int *b = a;
   //CHECK_HIGHER: _Ptr<int> b = a;
   return *b;
 }

--- a/clang/test/3C/base_subdir/canwrite_constraints.c
+++ b/clang/test/3C/base_subdir/canwrite_constraints.c
@@ -14,14 +14,14 @@
 // because of https://github.com/correctcomputation/checkedc-clang/issues/503;
 // the rest of the test still works. TODO: Re-enable warning verification.
 //
-// RUN: cd %S && 3c -addcr -output-dir=%t.checked/base_subdir -warn-all-root-cause %s --
+// RUN: cd %S && 3c -alltypes -addcr -output-dir=%t.checked/base_subdir -warn-all-root-cause %s --
 // RUN: FileCheck -match-full-lines -check-prefixes=CHECK_LOWER --input-file %t.checked/base_subdir/canwrite_constraints.c %s
 // RUN: test ! -f %t.checked/canwrite_constraints.checked.h
 
 // "Higher" case: When -base-dir is set to the parent directory, we can change
 // canwrite_constraints.h, so both q and the return should become checked.
 //
-// RUN: cd %S && 3c -addcr -base-dir=.. -output-dir=%t.checked2 %s --
+// RUN: cd %S && 3c -alltypes -addcr -base-dir=.. -output-dir=%t.checked2 %s --
 // RUN: FileCheck -match-full-lines -check-prefixes=CHECK_HIGHER --input-file %t.checked2/base_subdir/canwrite_constraints.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes=CHECK_HIGHER --input-file %t.checked2/canwrite_constraints.h %S/../canwrite_constraints.h
 

--- a/clang/test/3C/base_subdir/canwrite_constraints_unimplemented.c
+++ b/clang/test/3C/base_subdir/canwrite_constraints_unimplemented.c
@@ -7,8 +7,6 @@
 // an error diagnostic.
 // (https://github.com/correctcomputation/checkedc-clang/issues/387)
 
-// TODO: Ditto the TODO comments from canwrite_constraints.c re the RUN
-// commands.
 // RUN: cd %S && 3c -addcr -verify %s --
 
 // expected-error@../base_subdir_partial_defn.h:1 {{3C internal error: 3C generated changes to this file even though it is not allowed to write to the file}}

--- a/clang/test/3C/canwrite_constraints.h
+++ b/clang/test/3C/canwrite_constraints.h
@@ -47,3 +47,15 @@ void unwritable_cast(void((*g)(int *q)) : itype(_Ptr<void(_Ptr<int>)>)) {
   // expected-warning@+1 {{3C internal error: tried to insert a cast into an unwritable file}}
   (*g)(p);
 }
+
+// Make sure that FVComponentVariable::equateWithItype prevents both of these
+// from being changed.
+//
+// TODO: Add the correct expected root cause warnings once diagnostic
+// verification is re-enabled
+// (https://github.com/correctcomputation/checkedc-clang/issues/503).
+void unwritable_func_with_itype(int *p : itype(_Array_ptr<int>)) {}
+
+void unwritable_func_with_itype_and_bounds(int *p
+                                           : itype(_Array_ptr<int>) count(12)) {
+}


### PR DESCRIPTION
Fixes #581.

I'm aware of one potential behavior change in this PR: a generic `FVComponentVariable` will cause a `ReasonUnchangeable` to be set on the recursive `equateWithItype` call where the equivalent `ForceEquate` previously wasn't set, which IIUC could affect the handling of function pointers.  But this case isn't covered by our regression tests, and IMO it would be a bit unfair to expect me to investigate the behavior and test it one way or another as part of this PR.  Furthermore, I suspect there may be another bug with function pointers anyway: if a function parameter doesn't itself have an itype but some function pointer inside it has parameters that do, I imagine we want to process those itypes, but currently `equateWithItype` doesn't traverse them at all.  If we really want, I can adjust the PR to avoid the potential behavior change that I am aware of.