### PR TITLE
Migrate 3C regression tests from %clang_cc1 to %clang.

### DIFF
--- a/clang/test/3C/addrof_crash.c
+++ b/clang/test/3C/addrof_crash.c
@@ -1,5 +1,5 @@
 // RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck %s
-// RUN: 3c -base-dir=%S -alltypes %s -- | %clang_cc1  -fno-builtin -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c  -fno-builtin -Xclang -verify -fcheckedc-extension -x c -
 
 // No conversions expected for these two, they just shouldn't crash
 

--- a/clang/test/3C/allocator.c
+++ b/clang/test/3C/allocator.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -fno-builtin -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -fno-builtin -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked %t.checked/allocator.c -- | diff %t.checked/allocator.c -
 // expected-no-diagnostics

--- a/clang/test/3C/basic_checks.c
+++ b/clang/test/3C/basic_checks.c
@@ -5,7 +5,7 @@
 //
 // RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
 

--- a/clang/test/3C/basic_inter_field.c
+++ b/clang/test/3C/basic_inter_field.c
@@ -3,7 +3,7 @@
 // Tests properties about constraint propagation of structure fields
 // across functions
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
 

--- a/clang/test/3C/basic_inter_field_arr.c
+++ b/clang/test/3C/basic_inter_field_arr.c
@@ -3,7 +3,7 @@
 // Tests properties about arr constraints propagation.
 //
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
 // This tests the propagation of constraints

--- a/clang/test/3C/basic_local_field.c
+++ b/clang/test/3C/basic_local_field.c
@@ -3,7 +3,7 @@
 // Tests properties about type re-writing and replacement of structure members
 //
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
 

--- a/clang/test/3C/boundary_tests.c
+++ b/clang/test/3C/boundary_tests.c
@@ -2,7 +2,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr %t.checked/boundary_tests.c -- | diff %t.checked/boundary_tests.c -
 // expected-no-diagnostics

--- a/clang/test/3C/bounds_interface.c
+++ b/clang/test/3C/bounds_interface.c
@@ -2,7 +2,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr %t.checked/bounds_interface.c -- | diff %t.checked/bounds_interface.c -
 // expected-no-diagnostics

--- a/clang/test/3C/cant_be_nt.c
+++ b/clang/test/3C/cant_be_nt.c
@@ -2,8 +2,8 @@
 //
 // Checks to make sure _Nt_arrrays only contain pointers & integers
 //
-// RUN: 3c -alltypes -base-dir=%S %s -- | %clang_cc1  -fcheckedc-extension -x c -
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -fcheckedc-extension -x c -
+// RUN: 3c -alltypes -base-dir=%S %s -- | %clang -c  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
 // RUN: 3c -alltypes -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // expected-no-diagnostics

--- a/clang/test/3C/const_tests.c
+++ b/clang/test/3C/const_tests.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr %t.checked/const_tests.c -- | diff %t.checked/const_tests.c -
 // expected-no-diagnostics

--- a/clang/test/3C/global.c
+++ b/clang/test/3C/global.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -fno-builtin -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -fno-builtin -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr %t.checked/global.c -- | diff %t.checked/global.c -
 // expected-no-diagnostics

--- a/clang/test/3C/multipledecls.c
+++ b/clang/test/3C/multipledecls.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1 -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr %t.checked/multipledecls.c -- | diff %t.checked/multipledecls.c -
 // expected-no-diagnostics

--- a/clang/test/3C/placements.c
+++ b/clang/test/3C/placements.c
@@ -5,7 +5,7 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK","CHECK_NOALL","CHECK-NEXT" %s
 // RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK","CHECK_ALL","CHECK-NEXT" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -addcr -alltypes %t.checked/placements.c -- | diff %t.checked/placements.c -
 // expected-no-diagnostics

--- a/clang/test/3C/ptrtoconstarr.c
+++ b/clang/test/3C/ptrtoconstarr.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S --addcr %s -- | %clang_cc1  -fcheckedc-extension -x c -
-// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang_cc1  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S --addcr %s -- | %clang -c  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang -c  -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/ptrtoconstarr.c -- | diff %t.checked/ptrtoconstarr.c -
 

--- a/clang/test/3C/simple_locals.c
+++ b/clang/test/3C/simple_locals.c
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/simple_locals.c -- | diff %t.checked/simple_locals.c -

--- a/clang/test/3C/some_checked.c
+++ b/clang/test/3C/some_checked.c
@@ -1,7 +1,7 @@
 // Tests for the 3C.
 //
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 //
 

--- a/clang/test/3C/struct_init_list.c
+++ b/clang/test/3C/struct_init_list.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines %s
 // RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes %s -- | %clang_cc1  -fno-builtin -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c  -fno-builtin -Xclang -verify -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/struct_init_list.c -- | diff %t.checked/struct_init_list.c -
 // expected-no-diagnostics

--- a/clang/test/3C/typedefbounds.c
+++ b/clang/test/3C/typedefbounds.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang_cc1  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang -c  -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/typedefbounds.c -- | diff %t.checked/typedefbounds.c -
 

--- a/clang/test/3C/typedefnoptr.c
+++ b/clang/test/3C/typedefnoptr.c
@@ -1,5 +1,5 @@
 //RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-//RUN: 3c -base-dir=%S --addcr %s -- | %clang_cc1  -fcheckedc-extension -x c -
+//RUN: 3c -base-dir=%S --addcr %s -- | %clang -c  -fcheckedc-extension -x c -
 
 typedef unsigned int uint_t;
 typedef uint_t *ptr_uint_t;

--- a/clang/test/3C/typedefs.c
+++ b/clang/test/3C/typedefs.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang_cc1  -fcheckedc-extension -x c -
-// RUN: 3c -base-dir=%S --addcr %s -- | %clang_cc1  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S --addcr --alltypes %s -- | %clang -c  -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S --addcr %s -- | %clang -c  -fcheckedc-extension -x c -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/typedefs.c -- | diff %t.checked/typedefs.c -
 

--- a/clang/test/3C/vargs.c
+++ b/clang/test/3C/vargs.c
@@ -4,7 +4,7 @@
 //
 // RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines %s
 // RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S %s -- | %clang_cc1  -verify -fcheckedc-extension -x c -
+// RUN: 3c -base-dir=%S %s -- | %clang -c  -Xclang -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 #include <stdarg.h>
 


### PR DESCRIPTION
This requires replacing `%clang_cc1 -verify` with `%clang -Xclang -verify` in the tests that use it.

This is one part of the RUN command cleanup that we've wanted to do for a while in #346, and now it is blocking part of #576. This is because the single behavior difference we know of between %clang_cc1 and %clang (other than the need for `-Xclang`) is that %clang_cc1 turns off the system headers, and we want two of our tests that currently use %clang_cc1 to be able to get checked declarations from the system headers.

As recently as dac3f9775eb966bd83055bfff2ef07de28a610a3 (August 2020), all of the tests that used %clang_cc1 used -verify. Since then, a few tests have been added that use %clang_cc1 and not -verify. This lends support to my theory that the only reason we used %clang_cc1 was that we were unaware that -verify could be used with %clang via -Xclang, and some subsequently added tests copied the use of %clang_cc1 only because the authors didn't know any better. Thus, I believe that the risk of the migration affecting the validity of the tests (e.g., causing them to falsely pass) is low.

---

Aaron, it looks like you added all of the tests that use `%clang_cc1` and not `-verify` (see `git grep '%clang_cc1' origin | grep -v -e '-verify'`) except for `ptrtoconstarr.c`.  Did you have a reason for using `%clang_cc1`?  Since I want to ask you this question anyway, I propose that you would be a good person to review the whole PR.