### PR TITLE
Fixing func_parm_bounds test case.

### DIFF
--- a/clang/test/3C/func_parm_bounds.c
+++ b/clang/test/3C/func_parm_bounds.c
@@ -46,4 +46,4 @@ int caller() {
   return 0;
 }
 //CHECK_ALL: int arr _Checked[5];
-//CHECK_ALL: glob = _Assume_bounds_cast<_Array_ptr<int>>(malloc(gsize*sizeof(int)), byte_count(0));
+//CHECK_ALL: glob = malloc<int>(gsize*sizeof(int));


### PR DESCRIPTION
Fixing a failing test case by removing unnecessary `_Assume_bounds_cast` (which was needed when `malloc` was declared explicitly). 

When the checked header is used, this is not needed.