### PR TITLE
Adding bounds inference of the form count(i+1)

### DIFF
--- a/clang/include/clang/3C/ABounds.h
+++ b/clang/include/clang/3C/ABounds.h
@@ -28,6 +28,8 @@ public:
     InvalidKind,
     // Bounds that represent number of items.
     CountBoundKind,
+    // Count bounds but plus one, i.e., count(i+1)
+    CountPlusOneBoundKind,
     // Bounds that represent number of bytes.
     ByteBoundKind,
     // Bounds that represent range.
@@ -35,7 +37,7 @@ public:
   };
   BoundsKind getKind() const { return Kind; }
 
-private:
+protected:
   BoundsKind Kind;
 
 protected:
@@ -83,8 +85,22 @@ public:
 
   BoundsKey getCountVar() { return CountVar; }
 
-private:
+protected:
   BoundsKey CountVar;
+};
+
+class CountPlusOneBound : public CountBound {
+public:
+  CountPlusOneBound(BoundsKey Var) : CountBound(Var) {
+    this->Kind = CountPlusOneBoundKind;
+  }
+
+  std::string mkString(AVarBoundsInfo *ABI, clang::Decl *D = nullptr) override;
+  bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
+
+  static bool classof(const ABounds *S) {
+    return S->getKind() == CountPlusOneBoundKind;
+  }
 };
 
 class ByteBound : public ABounds {

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -138,6 +138,8 @@ private:
   bool hasImpossibleBounds(BoundsKey BK);
   // Set the given pointer to have impossible bounds.
   void setImpossibleBounds(BoundsKey BK);
+  // Infer bounds of the given pointer key from potential bounds.
+  bool inferFromPotentialBounds(BoundsKey BK, AVarGraph &BKGraph);
 
   AVarBoundsInfo *BI;
 
@@ -145,6 +147,31 @@ private:
   std::map<BoundsKey, BndsKindMap> CurrIterInferBounds;
   // BoundsKey that failed the flow inference.
   std::set<BoundsKey> BKsFailedFlowInference;
+};
+
+// Class that maintains information about potential bounds for
+// various pointer variables.
+class PotentialBoundsInfo {
+public:
+  PotentialBoundsInfo() {
+    PotentialCntBounds.clear();
+    PotentialCntPOneBounds.clear();
+  }
+  // Count Bounds, i.e., count(i).
+  bool hasPotentialCountBounds(BoundsKey PtrBK);
+  std::set<BoundsKey> &getPotentialBounds(BoundsKey PtrBK);
+  void addPotentialBounds(BoundsKey BK, const std::set<BoundsKey> &PotK);
+
+  // Count Bounds Plus one, i.e., count(i+1).
+  bool hasPotentialCountPOneBounds(BoundsKey PtrBK);
+  std::set<BoundsKey> &getPotentialBoundsPOne(BoundsKey PtrBK);
+  void addPotentialBoundsPOne(BoundsKey BK, const std::set<BoundsKey> &PotK);
+private:
+  // This is the map of pointer variable bounds key and set of bounds key
+  // which can be the count bounds.
+  std::map<BoundsKey, std::set<BoundsKey>> PotentialCntBounds;
+  // Potential count + 1 bounds.
+  std::map<BoundsKey, std::set<BoundsKey>> PotentialCntPOneBounds;
 };
 
 class AVarBoundsInfo {
@@ -171,7 +198,10 @@ public:
   bool replaceBounds(BoundsKey L, BoundsPriority P, ABounds *B);
   ABounds *getBounds(BoundsKey L, BoundsPriority ReqP = Invalid,
                      BoundsPriority *RetP = nullptr);
-  bool updatePotentialCountBounds(BoundsKey BK, std::set<BoundsKey> &CntBK);
+  bool updatePotentialCountBounds(BoundsKey BK,
+                                  const std::set<BoundsKey> &CntBK);
+  bool updatePotentialCountPOneBounds(BoundsKey BK,
+                                      const std::set<BoundsKey> &CntBK);
 
   // Try and get BoundsKey, into R, for the given declaration. If the
   // declaration does not have a BoundsKey then return false.
@@ -316,9 +346,8 @@ private:
   AVarGraph RevCtxSensProgVarGraph;
   // Stats on techniques used to find length for various variables.
   AVarBoundsStats BoundsInferStats;
-  // This is the map of pointer variable bounds key and set of bounds key
-  // which can be the count bounds.
-  std::map<BoundsKey, std::set<BoundsKey>> PotentialCntBounds;
+  // Information about potential bounds.
+  PotentialBoundsInfo PotBoundsInfo;
   // Context-sensitive bounds key handler
   CtxSensitiveBoundsKeyHandler CSBKeyHandler;
 
@@ -351,7 +380,8 @@ private:
   // Perform worklist based inference on the requested array variables using
   // the provided graph and potential length variables.
   bool performWorkListInference(const std::set<BoundsKey> &ArrNeededBounds,
-                                AVarGraph &BKGraph, AvarBoundsInference &BI);
+                                AVarGraph &BKGraph, AvarBoundsInference &BI,
+                                bool FromPB);
 
   void insertParamKey(ParamDeclType ParamDecl, BoundsKey NK);
 };

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -198,9 +198,9 @@ public:
   bool replaceBounds(BoundsKey L, BoundsPriority P, ABounds *B);
   ABounds *getBounds(BoundsKey L, BoundsPriority ReqP = Invalid,
                      BoundsPriority *RetP = nullptr);
-  bool updatePotentialCountBounds(BoundsKey BK,
+  void updatePotentialCountBounds(BoundsKey BK,
                                   const std::set<BoundsKey> &CntBK);
-  bool updatePotentialCountPOneBounds(BoundsKey BK,
+  void updatePotentialCountPOneBounds(BoundsKey BK,
                                       const std::set<BoundsKey> &CntBK);
 
   // Try and get BoundsKey, into R, for the given declaration. If the

--- a/clang/lib/3C/ABounds.cpp
+++ b/clang/lib/3C/ABounds.cpp
@@ -97,11 +97,10 @@ std::string CountPlusOneBound::mkString(AVarBoundsInfo *ABI, clang::Decl *D) {
   std::string CVar = ABounds::getBoundsKeyStr(CountVar, ABI, D);
   return "count(" + CVar + " + 1)";
 }
+
 bool CountPlusOneBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
-  if (O != nullptr) {
-    if (CountPlusOneBound *OT = dyn_cast<CountPlusOneBound>(O))
-      return ABI->areSameProgramVar(this->CountVar, OT->CountVar);
-  }
+  if (CountPlusOneBound *OT = dyn_cast_or_null<CountPlusOneBound>(O))
+    return ABI->areSameProgramVar(this->CountVar, OT->CountVar);
   return false;
 }
 
@@ -110,11 +109,8 @@ std::string ByteBound::mkString(AVarBoundsInfo *ABI, clang::Decl *D) {
 }
 
 bool ByteBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
-  if (O != nullptr) {
-    if (ByteBound *BB = dyn_cast<ByteBound>(O)) {
-      return ABI->areSameProgramVar(this->ByteVar, BB->ByteVar);
-    }
-  }
+  if (ByteBound *BB = dyn_cast_or_null<ByteBound>(O))
+    return ABI->areSameProgramVar(this->ByteVar, BB->ByteVar);
   return false;
 }
 
@@ -130,11 +126,8 @@ std::string RangeBound::mkString(AVarBoundsInfo *ABI, clang::Decl *D) {
 }
 
 bool RangeBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
-  if (O != nullptr) {
-    if (RangeBound *RB = dyn_cast<RangeBound>(O)) {
-      return ABI->areSameProgramVar(this->LB, RB->LB) &&
-             ABI->areSameProgramVar(this->UB, RB->UB);
-    }
-  }
+  if (RangeBound *RB = dyn_cast_or_null<RangeBound>(O))
+    return ABI->areSameProgramVar(this->LB, RB->LB) &&
+           ABI->areSameProgramVar(this->UB, RB->UB);
   return false;
 }

--- a/clang/lib/3C/ABounds.cpp
+++ b/clang/lib/3C/ABounds.cpp
@@ -93,6 +93,18 @@ BoundsKey CountBound::getBKey() { return this->CountVar; }
 
 ABounds *CountBound::makeCopy(BoundsKey NK) { return new CountBound(NK); }
 
+std::string CountPlusOneBound::mkString(AVarBoundsInfo *ABI, clang::Decl *D) {
+  std::string CVar = ABounds::getBoundsKeyStr(CountVar, ABI, D);
+  return "count(" + CVar + " + 1)";
+}
+bool CountPlusOneBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
+  if (O != nullptr) {
+    if (CountPlusOneBound *OT = dyn_cast<CountPlusOneBound>(O))
+      return ABI->areSameProgramVar(this->CountVar, OT->CountVar);
+  }
+  return false;
+}
+
 std::string ByteBound::mkString(AVarBoundsInfo *ABI, clang::Decl *D) {
   return "byte_count(" + ABounds::getBoundsKeyStr(ByteVar, ABI, D) + ")";
 }

--- a/clang/lib/3C/ABounds.cpp
+++ b/clang/lib/3C/ABounds.cpp
@@ -72,6 +72,10 @@ std::string ABounds::getBoundsKeyStr(BoundsKey BK,
     if (FD->getNumParams() > PIdx) {
       auto *NewPVD = FD->getParamDecl(PIdx);
       BKStr = NewPVD->getNameAsString();
+      // If the parameter in the new declaration does not have a name?
+      // then use the old name.
+      if (BKStr.empty())
+        BKStr = PV->mkString();
     }
   }
   return BKStr;

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -132,6 +132,25 @@ mergeReachableProgramVars(BoundsKey TarBK, std::set<BoundsKey> &AllVars) {
     ProgramVar *BVar = nullptr;
     bool IsTarNTArr = BI->NtArrPointerBoundsKey.find(TarBK) !=
                       BI->NtArrPointerBoundsKey.end();
+    // First, find all variables that are in the SAME scope as TarBK.
+    // If there is only one? Then use it.
+    std::set<BoundsKey> SameScopeVars;
+    ProgramVar *TarBVar = BI->getProgramVar(TarBK);
+    if (TarBVar != nullptr) {
+      for (auto TB : AllVars) {
+        if (*(BI->getProgramVar(TB)->getScope()) ==
+            *(TarBVar->getScope())) {
+          SameScopeVars.insert(TB);
+        }
+      }
+      // There is only one same scope variable.
+      // Consider only that.
+      if (SameScopeVars.size() == 1) {
+        AllVars.clear();
+        AllVars.insert(*SameScopeVars.begin());
+        return;
+      }
+    }
     // We want to merge all bounds vars. We give preference to
     // non-constants if there are multiple non-constant variables,
     // we give up.
@@ -210,6 +229,9 @@ AvarBoundsInference::convergeInferredBounds() {
       } else if (BTypeMap.find(ABounds::ByteBoundKind) != BTypeMap.end() &&
                  !BTypeMap[ABounds::ByteBoundKind].empty()) {
         AB = new ByteBound(*BTypeMap[ABounds::ByteBoundKind].begin());
+      } else if (BTypeMap.find(ABounds::CountPlusOneBoundKind) != BTypeMap.end() &&
+                 !BTypeMap[ABounds::CountPlusOneBoundKind].empty()) {
+        AB = new CountPlusOneBound(*BTypeMap[ABounds::CountPlusOneBoundKind].begin());
       }
 
       // If we found any bounds?
@@ -486,36 +508,7 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, AVarGraph &BKGraph, bool From
   if (BI->InvalidBounds.find(K) == BI->InvalidBounds.end()) {
     // Infer from potential bounds?
     if (FromPB) {
-      auto &PotBDs = BI->PotentialCntBounds;
-      if (PotBDs.find(K) != PotBDs.end()) {
-        ProgramVar *Kvar = BI->getProgramVar(K);
-        std::set<BoundsKey> PotentialB;
-        PotentialB.clear();
-        for (auto TK : PotBDs[K])
-          getReachableBoundKeys(Kvar->getScope(), TK, PotentialB, BKGraph, true);
-
-        if (!PotentialB.empty()) {
-          bool Handled = false;
-          // Potential bounds are always count bounds.
-          // We use potential bounds
-          ABounds::BoundsKind PotKind = ABounds::CountBoundKind;
-          if (CurrIterInferBounds.find(K) != CurrIterInferBounds.end()) {
-            auto &BM = CurrIterInferBounds[K];
-            // If we have any inferred bounds for K then ignore potential
-            // bounds.
-            for (auto &PosB : BM) {
-              if (!PosB.second.empty()) {
-                Handled = true;
-                break;
-              }
-            }
-          }
-          if (!Handled) {
-            CurrIterInferBounds[K][PotKind] = PotentialB;
-            IsChanged = true;
-          }
-        }
-      }
+      IsChanged = inferFromPotentialBounds(K, BKGraph);
     } else {
       // Infer from the flow-graph.
       std::set<BoundsKey> TmpBkeys;
@@ -525,6 +518,86 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, AVarGraph &BKGraph, bool From
     }
   }
   return IsChanged;
+}
+
+bool AvarBoundsInference::inferFromPotentialBounds(BoundsKey BK,
+                                                   AVarGraph &BKGraph) {
+  bool IsChanged = false;
+  bool Handled = false;
+  if (CurrIterInferBounds.find(BK) != CurrIterInferBounds.end()) {
+    auto &BM = CurrIterInferBounds[BK];
+    // If we have any inferred bounds for K then ignore potential
+    // bounds.
+    for (auto &PosB : BM) {
+      if (!PosB.second.empty()) {
+        Handled = true;
+        break;
+      }
+    }
+  }
+
+  if (!Handled) {
+    auto &PotBDs = BI->PotBoundsInfo;
+    // Here, the logic is:
+    // We first try potential bounds and if there are no potential bounds?
+    // then, we check if there are count(i+1) bounds.
+    ProgramVar *Kvar = BI->getProgramVar(BK);
+    // These are potential count bounds.
+    ABounds::BoundsKind PotKind = ABounds::CountBoundKind;
+    std::set<BoundsKey> PotentialB;
+    if (PotBDs.hasPotentialCountBounds(BK)) {
+      for (auto TK : PotBDs.getPotentialBounds(BK))
+        getReachableBoundKeys(Kvar->getScope(), TK, PotentialB, BKGraph, true);
+    }
+    if (PotentialB.empty() && PotBDs.hasPotentialCountPOneBounds(BK)) {
+      // These are potential count (i + 1) bounds.
+      PotKind = ABounds::CountPlusOneBoundKind;
+      for (auto TK : PotBDs.getPotentialBoundsPOne(BK))
+        getReachableBoundKeys(Kvar->getScope(), TK, PotentialB, BKGraph, true);
+    }
+    if (!PotentialB.empty()) {
+      CurrIterInferBounds[BK][PotKind] = PotentialB;
+      IsChanged = true;
+    }
+  }
+  return IsChanged;
+}
+
+bool PotentialBoundsInfo::hasPotentialCountBounds(BoundsKey PtrBK) {
+  return PotentialCntBounds.find(PtrBK) != PotentialCntBounds.end();
+}
+
+std::set<BoundsKey> &PotentialBoundsInfo::getPotentialBounds(BoundsKey PtrBK) {
+  assert(hasPotentialCountBounds(PtrBK) && "Has no potential bounds");
+  return PotentialCntBounds[PtrBK];
+}
+
+void
+PotentialBoundsInfo::addPotentialBounds(BoundsKey BK,
+                                        const std::set<BoundsKey> &PotK) {
+  if (!PotK.empty()) {
+    auto &TmpK = PotentialCntBounds[BK];
+    TmpK.insert(PotK.begin(), PotK.end());
+  }
+}
+
+bool PotentialBoundsInfo::hasPotentialCountPOneBounds(BoundsKey PtrBK) {
+  return PotentialCntPOneBounds.find(PtrBK) != PotentialCntPOneBounds.end();
+}
+
+std::set<BoundsKey> &
+    PotentialBoundsInfo::getPotentialBoundsPOne(BoundsKey PtrBK) {
+  assert(hasPotentialCountPOneBounds(PtrBK) &&
+         "Has no potential count+1 bounds");
+  return PotentialCntPOneBounds[PtrBK];
+}
+void
+PotentialBoundsInfo::addPotentialBoundsPOne(BoundsKey BK,
+                                            const std::set<BoundsKey> &PotK) {
+  if (!PotK.empty()) {
+    auto &TmpK = PotentialCntPOneBounds[BK];
+    TmpK.insert(PotK.begin(), PotK.end());
+  }
 }
 
 bool AVarBoundsInfo::isValidBoundVariable(clang::Decl *D) {
@@ -674,15 +747,18 @@ ABounds *AVarBoundsInfo::getBounds(BoundsKey L, BoundsPriority ReqP,
   return nullptr;
 }
 
-bool AVarBoundsInfo::updatePotentialCountBounds(BoundsKey BK,
-                                                std::set<BoundsKey> &CntBK) {
-  bool RetVal = false;
-  if (!CntBK.empty()) {
-    auto &TmpK = PotentialCntBounds[BK];
-    TmpK.insert(CntBK.begin(), CntBK.end());
-    RetVal = true;
-  }
-  return RetVal;
+bool
+AVarBoundsInfo::updatePotentialCountBounds(BoundsKey BK,
+                                           const std::set<BoundsKey> &CntBK) {
+  PotBoundsInfo.addPotentialBounds(BK, CntBK);
+  return true;
+}
+
+bool
+AVarBoundsInfo::updatePotentialCountPOneBounds(BoundsKey BK,
+                                               const std::set<BoundsKey> &CntBK) {
+  PotBoundsInfo.addPotentialBoundsPOne(BK, CntBK);
+  return true;
 }
 
 void AVarBoundsInfo::insertVariable(clang::Decl *D) {
@@ -1009,39 +1085,32 @@ void AVarBoundsInfo::insertProgramVar(BoundsKey NK, ProgramVar *PV) {
 
 bool AVarBoundsInfo::performWorkListInference(const std::set<BoundsKey> &ArrNeededBounds,
                                               AVarGraph &BKGraph,
-                                              AvarBoundsInference &BI) {
+                                              AvarBoundsInference &BI,
+                                              bool FromPB) {
   bool RetVal = false;
   std::set<BoundsKey> WorkList;
   std::set<BoundsKey> NextIterArrs;
-  std::vector<bool> FromBVals;
-  // We first infer with using only flow information
-  // i.e., without using any potential bounds.
-  FromBVals.push_back(false);
-  // Next, we try using potential bounds.
-  FromBVals.push_back(true);
-  for (auto FromPB : FromBVals) {
-    WorkList.clear();
-    WorkList.insert(ArrNeededBounds.begin(), ArrNeededBounds.end());
-    bool Changed = true;
-    while (Changed) {
-      Changed = false;
-      NextIterArrs.clear();
-      // Are there any ARR atoms that need bounds?
-      while (!WorkList.empty()) {
-        BoundsKey CurrArrKey = *WorkList.begin();
-        // Remove the bounds key from the worklist.
-        WorkList.erase(CurrArrKey);
-        // Can we find bounds for this Arr?
-        if (BI.inferBounds(CurrArrKey, BKGraph, FromPB)) {
-          RetVal = true;
-          Changed = true;
-          // Get all the successors of the ARR whose bounds we just found.
-          BKGraph.getSuccessors(CurrArrKey, NextIterArrs);
-        }
+  WorkList.clear();
+  WorkList.insert(ArrNeededBounds.begin(), ArrNeededBounds.end());
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    NextIterArrs.clear();
+    // Are there any ARR atoms that need bounds?
+    while (!WorkList.empty()) {
+      BoundsKey CurrArrKey = *WorkList.begin();
+      // Remove the bounds key from the worklist.
+      WorkList.erase(CurrArrKey);
+      // Can we find bounds for this Arr?
+      if (BI.inferBounds(CurrArrKey, BKGraph, FromPB)) {
+        RetVal = true;
+        Changed = true;
+        // Get all the successors of the ARR whose bounds we just found.
+        BKGraph.getSuccessors(CurrArrKey, NextIterArrs);
       }
-      if (Changed) {
-        findIntersection(ArrNeededBounds, NextIterArrs, WorkList);
-      }
+    }
+    if (Changed) {
+      findIntersection(ArrNeededBounds, NextIterArrs, WorkList);
     }
   }
   return RetVal;
@@ -1242,63 +1311,79 @@ bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
   for (auto TBK : ArrPointerBoundsKey)
     removeBounds(TBK, FlowInferred);
 
-  std::set<BoundsKey> ArrNeededBounds, ArrNeededBoundsNew;
+  std::set<BoundsKey> ArrNeededBounds, ArrNeededBoundsNew, TmpArrNeededBounds;
   ArrNeededBounds.clear();
 
   getBoundsNeededArrPointers(ArrPointers, ArrNeededBounds);
 
-  bool Changed = !ArrNeededBounds.empty();
+  bool OuterChanged, InnerChanged;
+  std::vector<bool> FromBVals;
+  // We first infer with using only flow information
+  // i.e., without using any potential bounds.
+  FromBVals.push_back(false);
+  // Next, we try using potential bounds.
+  FromBVals.push_back(true);
 
   // Now compute the bounds information of all the ARR pointers that need it.
   // We iterate until there are no new array variables whose bounds are found.
   // The expectation is every iteration we will find bounds for at least one
   // array variable.
-  while (Changed) {
-    // Clear all inferred bounds.
-    ABI.clearInferredBounds();
-    // Regular flow inference (with no edges between callers and callees).
-    performWorkListInference(ArrNeededBounds, this->ProgVarGraph, ABI);
+  TmpArrNeededBounds = ArrNeededBounds;
+  OuterChanged = !ArrNeededBounds.empty();
+  while (OuterChanged) {
+    TmpArrNeededBounds = ArrNeededBounds;
+    for (auto FromPB : FromBVals) {
+      InnerChanged = !ArrNeededBounds.empty();
+      while (InnerChanged) {
+        // Clear all inferred bounds.
+        ABI.clearInferredBounds();
+        // Regular flow inference (with no edges between callers and callees).
+        performWorkListInference(ArrNeededBounds, this->ProgVarGraph, ABI,
+                                 FromPB);
 
-    // Converge using local bounds (i.e., within each function).
-    // From all the sets of bounds computed for various array variables.
-    // Intersect them and find the common bound variable.
-    ABI.convergeInferredBounds();
+        // Converge using local bounds (i.e., within each function).
+        // From all the sets of bounds computed for various array variables.
+        // Intersect them and find the common bound variable.
+        ABI.convergeInferredBounds();
 
-    ArrNeededBoundsNew.clear();
-    getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
-    // Now propagate the bounds information from context-sensitive keys
-    // to original keys (i.e., edges from callers to callees are present,
-    //   but no local edges)
-    performWorkListInference(ArrNeededBoundsNew, this->CtxSensProgVarGraph,
-                             ABI);
+        ArrNeededBoundsNew.clear();
+        getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
+        // Now propagate the bounds information from context-sensitive keys
+        // to original keys (i.e., edges from callers to callees are present,
+        //   but no local edges)
+        performWorkListInference(ArrNeededBoundsNew, this->CtxSensProgVarGraph,
+                                 ABI, FromPB);
 
-    ABI.convergeInferredBounds();
-    // Now clear all inferred bounds so that context-sensitive nodes do not
-    // interfere with each other.
-    ABI.clearInferredBounds();
-    ArrNeededBoundsNew.clear();
-    // Get array variables that still need bounds.
-    getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
+        ABI.convergeInferredBounds();
+        // Now clear all inferred bounds so that context-sensitive nodes do not
+        // interfere with each other.
+        ABI.clearInferredBounds();
+        ArrNeededBoundsNew.clear();
+        // Get array variables that still need bounds.
+        getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
 
-    // Now propagate the bounds information from normal keys to
-    // context-sensitive keys.
-    performWorkListInference(ArrNeededBoundsNew, this->RevCtxSensProgVarGraph,
-                             ABI);
+        // Now propagate the bounds information from normal keys to
+        // context-sensitive keys.
+        performWorkListInference(ArrNeededBoundsNew,
+                                 this->RevCtxSensProgVarGraph, ABI, FromPB);
 
-    ABI.convergeInferredBounds();
-    ArrNeededBoundsNew.clear();
-    // Get array variables that still need bounds.
-    getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
+        ABI.convergeInferredBounds();
+        ArrNeededBoundsNew.clear();
+        // Get array variables that still need bounds.
+        getBoundsNeededArrPointers(ArrPointers, ArrNeededBoundsNew);
 
-    // Did we find bounds for new array variables?
-    Changed = ArrNeededBounds != ArrNeededBoundsNew;
-    if (ArrNeededBounds.size() == ArrNeededBoundsNew.size()) {
-      assert(!Changed && "New arrays needed bounds after inference");
+        // Did we find bounds for new array variables?
+        InnerChanged = (ArrNeededBounds != ArrNeededBoundsNew);
+        if (ArrNeededBounds.size() == ArrNeededBoundsNew.size()) {
+          assert(!InnerChanged && "New arrays needed bounds after inference");
+        }
+        assert(ArrNeededBoundsNew.size() <= ArrNeededBounds.size() &&
+               "We should always have less number of arrays whose bounds needs "
+               "to be inferred after each round.");
+        ArrNeededBounds = ArrNeededBoundsNew;
+      }
     }
-    assert(ArrNeededBoundsNew.size() <= ArrNeededBounds.size() &&
-           "We should always have less number of arrays whose bounds needs "
-           "to be inferred after each round.");
-    ArrNeededBounds = ArrNeededBoundsNew;
+    OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
 
   PStats.endArrayBoundsInferenceTime();

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -747,18 +747,16 @@ ABounds *AVarBoundsInfo::getBounds(BoundsKey L, BoundsPriority ReqP,
   return nullptr;
 }
 
-bool
+void
 AVarBoundsInfo::updatePotentialCountBounds(BoundsKey BK,
                                            const std::set<BoundsKey> &CntBK) {
   PotBoundsInfo.addPotentialBounds(BK, CntBK);
-  return true;
 }
 
-bool
+void
 AVarBoundsInfo::updatePotentialCountPOneBounds(BoundsKey BK,
                                                const std::set<BoundsKey> &CntBK) {
   PotBoundsInfo.addPotentialBoundsPOne(BK, CntBK);
-  return true;
 }
 
 void AVarBoundsInfo::insertVariable(clang::Decl *D) {

--- a/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
@@ -886,6 +886,8 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
         CV.TraverseStmt(CDGNode->getTerminatorStmt());
       }
       ABI.updatePotentialCountBounds(BasePtr, PossibleLens);
+    } else {
+      ABI.updatePotentialCountPOneBounds(BasePtr, {IdxKey});
     }
   }
 }

--- a/clang/test/3C/allarrays.c
+++ b/clang/test/3C/allarrays.c
@@ -8,7 +8,7 @@ void bar(void) {
   int *p = 0;
   //CHECK: _Array_ptr<int> p = 0;
   int *q = foo(p);
-  //CHECK: _Array_ptr<int> q = foo(p);
+  //CHECK: _Array_ptr<int> q : count(1 + 1) = foo(p);
   q[1] = 0;
 }
 int *foo(int *r);

--- a/clang/test/3C/arrboundsheuristics.c
+++ b/clang/test/3C/arrboundsheuristics.c
@@ -15,7 +15,7 @@ int lenplusone;
 //CHECK_NOALL: int *glob;
 
 void foo(int *p, int idx) { p[idx] = 0; }
-//CHECK_ALL: void foo(_Array_ptr<int> p, int idx) { p[idx] = 0; }
+//CHECK_ALL: void foo(_Array_ptr<int> p : count(idx + 1), int idx) { p[idx] = 0; }
 //CHECK_NOALL: void foo(int *p : itype(_Ptr<int>), int idx) { p[idx] = 0; }
 
 void bar(int *p, int flag) {

--- a/clang/test/3C/arrctxsenbounds.c
+++ b/clang/test/3C/arrctxsenbounds.c
@@ -13,7 +13,7 @@ struct foo {
   unsigned fail_y_len;
 };
 //CHECK:    _Array_ptr<int> x : count(olol);
-//CHECK:    _Array_ptr<int> y;
+//CHECK:    _Array_ptr<int> y : count(0 + 1);
 
 void ctx_(struct foo *f, struct foo *f2) {
   f2->y = f->x;

--- a/clang/test/3C/lowerbound.c
+++ b/clang/test/3C/lowerbound.c
@@ -13,5 +13,5 @@ void bar() {
   y = foo(z);
   y[2] = 1;
 }
-//CHECK: _Array_ptr<int> y =  0;
+//CHECK: _Array_ptr<int> y : count(2 + 1) =  0;
 //CHECK-NEXT: _Array_ptr<int> z =  0;

--- a/clang/test/3C/malloc_array.c
+++ b/clang/test/3C/malloc_array.c
@@ -9,7 +9,7 @@
 
 int *foo(int *x) {
   //CHECK_NOALL: int *foo(int *x : itype(_Ptr<int>)) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> foo(_Array_ptr<int> x) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(_Array_ptr<int> x : count(2 + 1)) : count(2 + 1) _Checked {
   x[2] = 1;
   return x;
 }
@@ -20,7 +20,7 @@ void bar(void) {
   //CHECK: y = (int *)5;
   int *z = foo(y);
   //CHECK_NOALL: _Ptr<int> z = foo(y);
-  //CHECK_ALL: _Ptr<int> z = foo(_Assume_bounds_cast<_Array_ptr<int>>(y, byte_count(0)));
+  //CHECK_ALL: _Ptr<int> z = foo(_Assume_bounds_cast<_Array_ptr<int>>(y,  count(2 + 1)));
 }
 
 void force(int *x) {}

--- a/clang/test/3C/multidef1a.c
+++ b/clang/test/3C/multidef1a.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
 }
 
 int foo(int argc, char **argv) {
-//CHECK_ALL: int foo(int argc, _Array_ptr<_Nt_array_ptr<char>> argv) _Checked {
+//CHECK_ALL: int foo(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(0 + 1)) _Checked {
 //CHECK_NOALL: int foo(int argc, char **argv : itype(_Ptr<_Ptr<char>>)) {
   char p = argv[0][0];
   return 0;

--- a/clang/test/3C/multidef1b.c
+++ b/clang/test/3C/multidef1b.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 
 int foo(int argc, char **argv) {
 //CHECK_NOALL: int foo(int argc, char **argv : itype(_Ptr<_Ptr<char>>)) {
-//CHECK_ALL: int foo(int argc, _Array_ptr<_Nt_array_ptr<char>> argv) _Checked {
+//CHECK_ALL: int foo(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(0 + 1)) _Checked {
   if (argc > 1) {
     int x = strlen(argv[1]);
     return x;

--- a/clang/test/3C/placements.c
+++ b/clang/test/3C/placements.c
@@ -11,11 +11,11 @@
 // expected-no-diagnostics
 void what(const char *s, int q);
 //CHECK_NOALL: void what(const char *s : itype(_Ptr<const char>), int q);
-//CHECK_ALL: void what(_Array_ptr<const char> s : count(q), int q);
+//CHECK_ALL: void what(_Array_ptr<const char> s : count(5 + 1), int q);
 
 void what(const char *s, int q) { char v = s[5]; }
 //CHECK_NOALL: void what(const char *s : itype(_Ptr<const char>), int q) { char v = s[5]; }
-//CHECK_ALL: void what(_Array_ptr<const char> s : count(q), int q) _Checked { char v = s[5]; }
+//CHECK_ALL: void what(_Array_ptr<const char> s : count(5 + 1), int q) _Checked { char v = s[5]; }
 
 void foo(_Ptr<int> a) { *a = 0; }
 //CHECK: void foo(_Ptr<int> a) _Checked { *a = 0; }

--- a/clang/test/3C/realloc.c
+++ b/clang/test/3C/realloc.c
@@ -15,6 +15,6 @@ void foo(int *w) {
   y[1] = 3;
   int *z = realloc(y, 5 * sizeof(int));
   //CHECK_NOALL: int *z = realloc<int>(y, 5 * sizeof(int));
-  //CHECK_ALL: _Array_ptr<int> z = realloc<int>(y, 5 * sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> z : count(3 + 1) = realloc<int>(y, 5 * sizeof(int));
   z[3] = 2;
 }

--- a/clang/test/3C/realloc_complex.c
+++ b/clang/test/3C/realloc_complex.c
@@ -42,10 +42,10 @@ void foo(int *count) {
   y[1] = 3;
   int *z = realloc(y, 5 * sizeof(int));
   //CHECK_NOALL: int *z = realloc<int>(y, 5 * sizeof(int));
-  //CHECK_ALL: _Array_ptr<int> z = realloc<int>(y, 5 * sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> z : count(3 + 1) = realloc<int>(y, 5 * sizeof(int));
   int *m = realloc(w, 2 * sizeof(int));
   //CHECK_NOALL: int *m = realloc<int>(w, 2 * sizeof(int));
-  //CHECK_ALL: _Array_ptr<int> m = realloc<int>(w, 2 * sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> m : count(1 + 1) = realloc<int>(w, 2 * sizeof(int));
   m[1] = 5;
   z[3] = 2;
 }

--- a/clang/test/3C/refarrsubscript.c
+++ b/clang/test/3C/refarrsubscript.c
@@ -7,19 +7,19 @@
 
 int **func(int **p, int *x) {
   //CHECK_NOALL: int **func(int **p : itype(_Ptr<_Ptr<int>>), _Ptr<int> x) : itype(_Ptr<int *>) {
-  //CHECK_ALL: _Array_ptr<_Ptr<int>> func(_Array_ptr<_Ptr<int>> p, _Ptr<int> x) _Checked {
+  //CHECK_ALL: _Array_ptr<_Ptr<int>> func(_Array_ptr<_Ptr<int>> p : count(1 + 1), _Ptr<int> x) : count(1 + 1) _Checked {
   return &(p[1]);
 }
 
 struct foo {
   int **b;
   //CHECK_NOALL: int **b;
-  //CHECK_ALL: _Array_ptr<_Ptr<int>> b;
+  //CHECK_ALL: _Array_ptr<_Ptr<int>> b : count(1 + 1);
   int n;
 };
 int **bar(struct foo *p) {
   //CHECK_NOALL: int **bar(_Ptr<struct foo> p) : itype(_Ptr<int *>) {
-  //CHECK_ALL: _Array_ptr<_Ptr<int>> bar(_Ptr<struct foo> p) _Checked {
+  //CHECK_ALL: _Array_ptr<_Ptr<int>> bar(_Ptr<struct foo> p) : count(1 + 1) _Checked {
   int *n = &p->n;
   //CHECK: _Ptr<int> n = &p->n;
   return &(p->b[1]);

--- a/clang/test/3C/resolve_itypes.c
+++ b/clang/test/3C/resolve_itypes.c
@@ -7,7 +7,7 @@
 
 void foo(int *a : itype(_Ptr<int>)) {
 //CHECK_NOALL: void foo(int *a : itype(_Ptr<int>)) {
-//CHECK_ALL: void foo(int *a : itype(_Array_ptr<int>)) {
+//CHECK_ALL: void foo(int *a : itype(_Array_ptr<int>) count(0 + 1)) {
   a = (int*) 1;
   (void) a[0];
 }

--- a/clang/test/3C/simple_locals.c
+++ b/clang/test/3C/simple_locals.c
@@ -117,11 +117,11 @@ int baz(int *a, int b, int c) {
 //CHECK-NEXT: return tmp;
 
 int arrcheck(int *a, int b) { return a[b]; }
-//CHECK_ALL: int arrcheck(_Array_ptr<int> a : count(b), int b) _Checked { return a[b]; }
+//CHECK_ALL: int arrcheck(_Array_ptr<int> a : count(b + 1), int b) _Checked { return a[b]; }
 //CHECK_NOALL: int arrcheck(int *a : itype(_Ptr<int>), int b) { return a[b]; }
 
 int badcall(int *a, int b) { return arrcheck(a, b); }
-//CHECK_ALL: int badcall(_Array_ptr<int> a : count(b), int b) _Checked { return arrcheck(a, b); }
+//CHECK_ALL: int badcall(_Array_ptr<int> a : count(b + 1), int b) _Checked { return arrcheck(a, b); }
 //CHECK_NOALL: int badcall(_Ptr<int> a, int b) _Checked { return arrcheck(a, b); }
 
 void pullit(char *base, char *out, int *index) {

--- a/clang/test/3C/untypedprototypes.c
+++ b/clang/test/3C/untypedprototypes.c
@@ -3,17 +3,17 @@
 // RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -f3c-tool -fcheckedc-extension -x c -o %t.unused -
 
 int *foo();
-//CHECK: _Array_ptr<int> foo(_Array_ptr<int> q);
+//CHECK: _Array_ptr<int> foo(_Array_ptr<int> q) : count(10 + 1);
 
 void bar(void) {
   int *x = 0;
   //CHECK: _Array_ptr<int> x = 0;
   int *y = foo(x);
-  //CHECK: _Array_ptr<int> y = foo(x);
+  //CHECK: _Array_ptr<int> y : count(10 + 1) = foo(x);
   y[10] = 1;
 }
 
 int *foo(int *q) {
-  //CHECK: _Array_ptr<int> foo(_Array_ptr<int> q) {
+  //CHECK: _Array_ptr<int> foo(_Array_ptr<int> q) : count(10 + 1) {
   return q;
 }


### PR DESCRIPTION
This will add a new heuristic, where the bounds of an array will be inferred as index + 1.

For instance, for the following code:
```
int getX(int *x) { return x[0]; }
int getY(int *x, int i) { return x[i]; }
```

The bounds will be inferred as follows:
```
int getX(_Array_ptr<int> x : count(0 + 1)) { return x[0]; }
int getY(_Array_ptr<int> x : count(i + 1), int i) { return x[i]; }
```

More details: https://github.com/correctcomputation/checkedc-clang/issues/599

This improves the bounds inference of other benchmarks as well.

For `yacr2` of `ptrdist`:

```
ulong ExistPathAboveVCG(_Array_ptr<nodeVCGType> VCG : count(below + 1), ulong above, ulong below)
{
    DFSClearVCG(VCG);
    DFSAboveVCG(VCG, above);
    return(VCG[below].netsAboveReached);
}
```

That further added bounds to other functions:

```
ulong VCV(_Array_ptr<nodeVCGType> VCG : count(check + 1), ulong check, ulong track, _Array_ptr<ulong> assign)
{
    ulong	net;
    ulong	vcv;
    vcv = 0;
    for (net = 1; net <= channelNets; net++) {
	if (assign[net]) {
	    if (assign[net] < track) {
		/*
		 * Above VCV?
		 */
		if (ExistPathAboveVCG(VCG, net, check)) {
		    vcv++;
		}
	    }
	    else if (assign[net] > track) {
		/*
		 * Below VCV?
		 */
		if (ExistPathAboveVCG(VCG, check, net)) {
		    vcv++;
		}
	    }
	    else {
		/*
		 * Above or Below VCV?
		 */
		if (ExistPathAboveVCG(VCG, net, check) || ExistPathAboveVCG(VCG, check, net)) {
		    vcv++;
		}
	    }
	}
    }
    return(vcv);
}
```