### PR TITLE
Fix json syntax in TotalConstraintStats.json

### DIFF
--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -353,10 +353,11 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
       O << "\"BoundsStats\":";
     }
     ArrBInfo.printStats(O, InSrcCVars, JsonFormat);
+    if (JsonFormat)
+      O << ",";
   }
 
   if (JsonFormat) {
-    O << ",";
     O << "\"PerformanceStats\":";
   }
 

--- a/clang/test/3C/json_formating.c
+++ b/clang/test/3C/json_formating.c
@@ -1,0 +1,8 @@
+// RUN: 3c -base-dir=%S -alltypes -dump-stats -dump-intermediate -debug-solver %s
+// RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
+// RUN: 3c -base-dir=%S -dump-stats -dump-intermediate -debug-solver %s
+// RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
+
+// Testing that json files output for statistics logging are well formed
+
+int *a;

--- a/clang/test/3C/json_formating.c
+++ b/clang/test/3C/json_formating.c
@@ -6,3 +6,6 @@
 // Testing that json files output for statistics logging are well formed
 
 int *a;
+int *b(int *c);
+static int *d() { return 0; }
+void e(int *f, int len) { f[0]; }


### PR DESCRIPTION
An extra comma was added in this file when running 3c without -alltypes.
Also adds a test case that checks the syntax in all generated json files.