### PR TITLE
convert to generics draft

### DIFF
--- a/clang/include/clang/3C/ConstraintResolver.h
+++ b/clang/include/clang/3C/ConstraintResolver.h
@@ -42,6 +42,8 @@ public:
 
   CVarSet getCalleeConstraintVars(CallExpr *CE);
 
+  bool isCastofGeneric(CastExpr *C);
+
   // Handle assignment of RHS expression to LHS expression using the
   // given action.
   void constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -546,7 +546,10 @@ public:
   PVConstraint *getInternal() const { return InternalConstraint; }
   PVConstraint *getExternal() const { return ExternalConstraint; }
 
-  void setGenericIndex(int idx) { ExternalConstraint->setGenericIndex(idx); }
+  void setGenericIndex(int idx) {
+    ExternalConstraint->setGenericIndex(idx);
+    InternalConstraint->setGenericIndex(idx);
+  }
 
   void equateWithItype(ProgramInfo &CS,
                        const std::string &ReasonUnchangeable) const;

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -319,7 +319,10 @@ private:
   // Generic types can be used with fewer restrictions, so this field is used
   // stop assignments with generic variables from forcing constraint variables
   // to be wild.
-  int GenericIndex;
+  //
+  // Base is generated from the source code, New is set internally
+  int BaseGenericIndex;
+  int NewGenericIndex;
 
   // Empty array pointers are represented the same as standard pointers. This
   // lets pointers be passed to functions expecting a zero width array. This
@@ -345,8 +348,8 @@ private:
       : ConstraintVariable(PointerVariable, "" /*not used*/, Name), BaseType(T),
         Vars(V), SrcVars(SV), FV(F), SrcHasItype(!Is.empty()),
         ItypeStr(Is), PartOfFuncPrototype(false), Parent(nullptr),
-        BoundsAnnotationStr(""), GenericIndex(Generic), IsZeroWidthArray(false),
-        IsVoidPtr(false) {}
+        BoundsAnnotationStr(""), BaseGenericIndex(Generic),
+        NewGenericIndex(Generic), IsZeroWidthArray(false), IsVoidPtr(false) {}
 
 public:
 
@@ -374,9 +377,10 @@ public:
   // Get bounds annotation.
   std::string getBoundsStr() const { return BoundsAnnotationStr; }
 
-  bool getIsGeneric() const { return GenericIndex >= 0; }
-  int getGenericIndex() const { return GenericIndex; }
-
+  bool getIsGeneric() const { return NewGenericIndex >= 0; }
+  int getGenericIndex() const { return NewGenericIndex; }
+  int setGenericIndex(int idx) { NewGenericIndex = idx; }
+  bool isGenericChanged() const { return BaseGenericIndex != NewGenericIndex; }
   // Was this variable a checked pointer in the input program?
   // This is important for two reasons: (1) externs that are checked should be
   // kept that way during solving, (2) nothing that was originally checked
@@ -419,6 +423,10 @@ public:
   // ForceGenericIndex: CheckedC supports generic types (_Itype_for_any) which
   //                    need less restrictive constraints. Set >= 0 to indicate
   //                    that this variable should be considered generic.
+  // PotentialGeneric: Whether this may become generic after analysis. Disables
+  //                   constraint to wild for non-generics. If you use this
+  //                   you'll have to add that constraint later if it is
+  //                   not generic.
   // TSI: TypeSourceInfo object gives access to information about the source
   //      code representation of the type. Allows for more precise rewriting by
   //      preserving the exact syntax used to write types that aren't rewritten
@@ -428,6 +436,7 @@ public:
                             const clang::ASTContext &C,
                             std::string *InFunc = nullptr,
                             int ForceGenericIndex = -1,
+                            bool PotentialGeneric = false,
                             bool VarAtomForChecked = false,
                             TypeSourceInfo *TSI = nullptr,
                             const clang::QualType &ItypeT = QualType());
@@ -522,7 +531,7 @@ public:
   FVComponentVariable(const clang::QualType &QT, const clang::QualType &ITypeT,
                       clang::DeclaratorDecl *D, std::string N, ProgramInfo &I,
                       const clang::ASTContext &C, std::string *InFunc,
-                      bool HasItype);
+                      bool PotentialGeneric, bool HasItype);
 
   void mergeDeclaration(FVComponentVariable *From, ProgramInfo &I,
                         std::string &ReasonFailed);
@@ -536,6 +545,8 @@ public:
 
   PVConstraint *getInternal() const { return InternalConstraint; }
   PVConstraint *getExternal() const { return ExternalConstraint; }
+
+  void setGenericIndex(int idx) { ExternalConstraint->setGenericIndex(idx); }
 
   void equateWithItype(ProgramInfo &CS,
                        const std::string &ReasonUnchangeable) const;
@@ -565,7 +576,7 @@ private:
   // Flag to indicate whether this is a function pointer or not.
   bool IsFunctionPtr;
 
-  // Count of type parameters from `_Itype_for_any(...)`.
+  // Count of type parameters (originally from `_Itype_for_any(...)`).
   int TypeParams;
 
   void equateFVConstraintVars(ConstraintVariable *CV, ProgramInfo &Info) const;
@@ -574,7 +585,7 @@ public:
   FunctionVariableConstraint()
       : ConstraintVariable(FunctionVariable, "", ""), FileName(""),
         Hasproto(false), Hasbody(false), IsStatic(false), Parent(nullptr),
-        IsFunctionPtr(false) {}
+        IsFunctionPtr(false), TypeParams(0) {}
 
   FunctionVariableConstraint(clang::DeclaratorDecl *D, ProgramInfo &I,
                              const clang::ASTContext &C);
@@ -629,8 +640,17 @@ public:
   bool srcHasItype() const override;
   bool srcHasBounds() const override;
 
+  // The number of type variables
+  int getGenericParams() const {
+    return TypeParams;
+  }
+  // The type parameter index of the return
   int getGenericIndex() const {
     return ReturnVar.ExternalConstraint->getGenericIndex();
+  }
+  // Change the type parameter index of the return
+  void setGenericIndex(int idx) {
+    ReturnVar.ExternalConstraint->setGenericIndex(idx);
   }
 
   bool solutionEqualTo(Constraints &CS, const ConstraintVariable *CV,

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -647,6 +647,12 @@ public:
   int getGenericParams() const {
     return TypeParams;
   }
+  // remove added generics
+  // use when we constrain a potential generic param to wild
+  void resetGenericParams() {
+    TypeParams = 0;
+  }
+
   // The type parameter index of the return
   int getGenericIndex() const {
     return ReturnVar.ExternalConstraint->getGenericIndex();

--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -379,7 +379,7 @@ public:
 
   bool getIsGeneric() const { return NewGenericIndex >= 0; }
   int getGenericIndex() const { return NewGenericIndex; }
-  int setGenericIndex(int idx) { NewGenericIndex = idx; }
+  void setGenericIndex(int idx) { NewGenericIndex = idx; }
   bool isGenericChanged() const { return BaseGenericIndex != NewGenericIndex; }
   // Was this variable a checked pointer in the input program?
   // This is important for two reasons: (1) externs that are checked should be

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -104,7 +104,8 @@ protected:
   virtual void buildDeclVar(const FVComponentVariable *CV,
                             DeclaratorDecl *Decl, std::string &Type,
                             std::string &IType, std::string UseName,
-                            bool &RewriteParm, bool &RewriteRet);
+                            bool &RewriteGen, bool &RewriteParm,
+                            bool &RewriteRet);
   void buildCheckedDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
                         std::string &Type, std::string &IType,
                         std::string UseName,

--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -48,7 +48,12 @@ public:
   // This map holds similar information as the type variable map in
   // ConstraintBuilder.cpp, but it is stored in a form that is usable during
   // rewriting.
-  typedef std::map<unsigned int, ConstraintVariable *> CallTypeParamBindingsT;
+  // The pair of CVs are the type param constraint (first) and an optional
+  // constraint for the single identifier argument, used to get the generic
+  // index if the first is void.
+  typedef std::map<unsigned int,
+                   std::pair<ConstraintVariable *,
+                             ConstraintVariable *>> CallTypeParamBindingsT;
   typedef std::map<PersistentSourceLoc, CallTypeParamBindingsT>
       TypeParamBindingsT;
 
@@ -123,7 +128,8 @@ public:
   }
 
   void setTypeParamBinding(CallExpr *CE, unsigned int TypeVarIdx,
-                           ConstraintVariable *CV, ASTContext *C);
+                           ConstraintVariable *CV,
+                           ConstraintVariable* Ident, ASTContext *C);
   bool hasTypeParamBindings(CallExpr *CE, ASTContext *C) const;
   const CallTypeParamBindingsT &getTypeParamBindings(CallExpr *CE,
                                                      ASTContext *C) const;

--- a/clang/include/clang/3C/RewriteUtils.h
+++ b/clang/include/clang/3C/RewriteUtils.h
@@ -87,20 +87,22 @@ class FunctionDeclReplacement
                                   DeclReplacement::DRK_FunctionDecl> {
 public:
   explicit FunctionDeclReplacement(FunctionDecl *D, std::string R, bool Return,
-                                   bool Params)
-      : DeclReplacementTempl(D, nullptr, R), RewriteReturn(Return),
-        RewriteParams(Params) {
+                                   bool Params, bool Generic = false)
+      : DeclReplacementTempl(D, nullptr, R), RewriteGeneric(Generic),
+        RewriteReturn(Return), RewriteParams(Params) {
     assert("Doesn't make sense to rewrite nothing!" &&
-           (RewriteReturn || RewriteParams));
+           (RewriteGeneric || RewriteReturn || RewriteParams));
   }
 
   SourceRange getSourceRange(SourceManager &SM) const override;
 
 private:
   // This determines if the full declaration or the return will be replaced.
+  bool RewriteGeneric;
   bool RewriteReturn;
   bool RewriteParams;
 
+  SourceLocation getGenericBegin(SourceManager &SM) const;
   SourceLocation getDeclBegin(SourceManager &SM) const;
   SourceLocation getParamBegin(SourceManager &SM) const;
   SourceLocation getReturnEnd(SourceManager &SM) const;

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 
 class ConstraintVariable;
+class PointerVariableConstraint;
 class ProgramInfo;
 
 // Maps a Decl to the set of constraint variables for that Decl.
@@ -227,5 +228,8 @@ void getPrintfStringArgIndices(const clang::CallExpr *CE,
 // string literals (https://bugs.llvm.org/show_bug.cgi?id=49926).
 int64_t getStmtIdWorkaround(const clang::Stmt *St,
                             const clang::ASTContext &Context);
+
+//PointerVariableConstraint *findParamCV(clang::ASTContext &Context,
+//                          ProgramInfo &Info, clang::DeclRefExpr *D);
 
 #endif

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -166,8 +166,6 @@ clang::Expr *removeAuxillaryCasts(clang::Expr *SrcExpr);
 // OK to cast from Src to Dst?
 bool isCastSafe(clang::QualType DstType, clang::QualType SrcType);
 
-bool isCastAlloc(clang::CastExpr *CE);
-
   // Check if the provided file path belongs to the input project
 // and can be rewritten.
 //

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -166,7 +166,9 @@ clang::Expr *removeAuxillaryCasts(clang::Expr *SrcExpr);
 // OK to cast from Src to Dst?
 bool isCastSafe(clang::QualType DstType, clang::QualType SrcType);
 
-// Check if the provided file path belongs to the input project
+bool isCastAlloc(clang::CastExpr *CE);
+
+  // Check if the provided file path belongs to the input project
 // and can be rewritten.
 //
 // For accurate results, the path must be canonical. The file name of a

--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -57,7 +57,7 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
       if (FD && PIdx < FD->getNumParams()) {
         const int TyVarIdx = FV->getExternalParam(PIdx)->getGenericIndex();
         if (TypeVars.find(TyVarIdx) != TypeVars.end() &&
-            TypeVars[TyVarIdx] != nullptr)
+            TypeVars[TyVarIdx].first != nullptr)
           ArgExpr = ArgExpr->IgnoreImpCasts();
       }
 

--- a/clang/lib/3C/CheckedRegions.cpp
+++ b/clang/lib/3C/CheckedRegions.cpp
@@ -232,7 +232,7 @@ bool CheckedRegionFinder::VisitCallExpr(CallExpr *C) {
     if (FD) {
       if (Info.hasTypeParamBindings(C,Context))
         for (auto Entry : Info.getTypeParamBindings(C, Context))
-          Wild |= (Entry.second == nullptr);
+          Wild |= (Entry.second.first == nullptr);
       auto Type = FD->getReturnType();
       Wild |= (!(FD->hasPrototype() || FD->doesThisDeclarationHaveABody())) ||
               containsUncheckedPtr(Type);

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -171,7 +171,8 @@ public:
     // Is cast compatible with LHS type?
     QualType SrcT = C->getSubExpr()->getType();
     QualType DstT = C->getType();
-    if (!isCastSafe(DstT, SrcT) && !Info.hasPersistentConstraints(C, Context)) {
+    if (!isCastAlloc(C) && !isCastSafe(DstT, SrcT)
+      && !Info.hasPersistentConstraints(C, Context)) {
       auto CVs = CB.getExprConstraintVarsSet(C->getSubExpr());
       std::string Rsn = "Cast from " + SrcT.getAsString() +  " to " +
                         DstT.getAsString();

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -171,7 +171,7 @@ public:
     // Is cast compatible with LHS type?
     QualType SrcT = C->getSubExpr()->getType();
     QualType DstT = C->getType();
-    if (!isCastAlloc(C) && !isCastSafe(DstT, SrcT)
+    if (!CB.isCastofGeneric(C) && !isCastSafe(DstT, SrcT)
       && !Info.hasPersistentConstraints(C, Context)) {
       auto CVs = CB.getExprConstraintVarsSet(C->getSubExpr());
       std::string Rsn = "Cast from " + SrcT.getAsString() +  " to " +

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -237,7 +237,7 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
       // If the cast is NULL, it will otherwise seem invalid, but we want to
       // handle it as usual so the type in the cast can be rewritten.
       if (!isNULLExpression(ECE, *Context) && TypE->isPointerType() &&
-          !isCastSafe(TypE, TmpE->getType())) {
+          !isCastSafe(TypE, TmpE->getType()) && !isCastAlloc(ECE)) {
         CVarSet Vars = getExprConstraintVarsSet(TmpE);
         Ret = pairWithEmptyBkey(getInvalidCastPVCons(ECE));
         constrainConsVarGeq(Vars, Ret.first, CS, nullptr, Safe_to_Wild, false,

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -738,7 +738,7 @@ bool ConstraintResolver::isCastofGeneric(CastExpr *C) {
     // check for built-in allocators, in case the standard headers are not used
     if (auto *DD = dyn_cast_or_null<DeclaratorDecl>(CE->getCalleeDecl())) {
       std::string Name = DD->getNameAsString();
-      if (Name == "malloc" || Name == "calloc" || Name == "realloc")
+      if (isFunctionAllocator(Name))
         return true;
     }
     // check for a generic function call

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -521,7 +521,11 @@ PointerVariableConstraint::PointerVariableConstraint(
   // Get a string representing the type without pointer and array indirection.
   BaseType = extractBaseType(D, TSInfo, QT, Ty, C);
 
-  IsVoidPtr = isPtrOrArrayType(QT) && isTypeHasVoid(QT);
+  // check if the type is some depth of pointers to void
+  // TODO: is this what the field should mean? do we want to include other
+  // indirection options like arrays?
+  IsVoidPtr = QT->isPointerType() && isTypeHasVoid(QT);
+  // varargs are always wild, as are void pointers that are not generic
   bool IsWild = isVarArgType(BaseType) ||
       (!(PotentialGeneric || getIsGeneric()) && IsVoidPtr);
   if (IsWild) {

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -520,7 +520,7 @@ PointerVariableConstraint::PointerVariableConstraint(
   // Get a string representing the type without pointer and array indirection.
   BaseType = extractBaseType(D, TSInfo, QT, Ty, C);
 
-  IsVoidPtr = isTypeHasVoid(QT);
+  IsVoidPtr = isPtrOrArrayType(QT) && isTypeHasVoid(QT);
   bool IsWild = isVarArgType(BaseType) ||
       (!(PotentialGeneric || getIsGeneric()) && IsVoidPtr);
   if (IsWild) {

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1127,14 +1127,17 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
 
   // Locate the void* params for potential generic use
   std::vector<int> Voids;
-  if(ReturnVar.ExternalConstraint->isVoidPtr() &&
-      !ReturnVar.ExternalConstraint->getIsGeneric()) {
-    Voids.push_back(-1);
-  }
-  for(int i=0; i < ParamVars.size();i++) {
-    if(ParamVars[i].ExternalConstraint->isVoidPtr() &&
-        !ParamVars[i].ExternalConstraint->getIsGeneric()) {
-      Voids.push_back(i);
+  // but only in local definitions
+  if (hasBody()) {
+    if(ReturnVar.ExternalConstraint->isVoidPtr() &&
+       !ReturnVar.ExternalConstraint->getIsGeneric()) {
+      Voids.push_back(-1);
+    }
+    for(int i=0; i < ParamVars.size();i++) {
+      if(ParamVars[i].ExternalConstraint->isVoidPtr() &&
+         !ParamVars[i].ExternalConstraint->getIsGeneric()) {
+        Voids.push_back(i);
+      }
     }
   }
   // Strategy: If there's one void*, turn this into a generic function.

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -153,14 +153,15 @@ PointerVariableConstraint::PointerVariableConstraint(DeclaratorDecl *D,
                                                      ProgramInfo &I,
                                                      const ASTContext &C)
   : PointerVariableConstraint(D->getType(), D, std::string(D->getName()), I, C,
-                              nullptr, -1, false, D->getTypeSourceInfo()) {}
+                              nullptr, -1,
+                                false, false, D->getTypeSourceInfo()) {}
 
 PointerVariableConstraint::PointerVariableConstraint(TypedefDecl *D,
                                                      ProgramInfo &I,
                                                      const ASTContext &C)
   : PointerVariableConstraint(D->getUnderlyingType(), nullptr,
                               D->getNameAsString(), I, C, nullptr, -1,
-                              false, D->getTypeSourceInfo()) {}
+                              false, false, D->getTypeSourceInfo()) {}
 
 PointerVariableConstraint::PointerVariableConstraint(Expr *E, ProgramInfo &I,
                                                      const ASTContext &C)

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1134,7 +1134,7 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
        !ReturnVar.ExternalConstraint->getIsGeneric()) {
       Voids.push_back(-1);
     }
-    for(int i=0; i < ParamVars.size();i++) {
+    for(unsigned i=0; i < ParamVars.size();i++) {
       if(ParamVars[i].ExternalConstraint->isVoidPtr() &&
          !ParamVars[i].ExternalConstraint->getIsGeneric()) {
         Voids.push_back(i);

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -785,12 +785,13 @@ std::string PointerVariableConstraint::mkString(Constraints &CS,
     EmittedName = true;
   uint32_t TypeIdx = 0;
 
-  // If we're set a GenericIndex for void, it means we're converting it into
+  // If we've set a GenericIndex for void, it means we're converting it into
   // a generic function so give it the default generic type name.
   // Add more type names below if we expect to use a lot.
   std::string BaseName = BaseType;
   if (NewGenericIndex > -1 && BaseType == "void") {
-    assert(NewGenericIndex < 3 && "Trying to use unexpected type variable name");
+    assert(NewGenericIndex < 3
+           && "Trying to use an unexpected type variable name");
     BaseName = std::begin({"T","U","V"})[NewGenericIndex];
   }
 
@@ -819,9 +820,9 @@ std::string PointerVariableConstraint::mkString(Constraints &CS,
 
     Atom::AtomKind K = C->getKind();
 
-    // If this is not an itype
+    // If this is not an itype or generic
     // make this wild as it can hold any pointer type.
-    if (!ForItype && BaseType == "void")
+    if (!ForItype && NewGenericIndex == -1 && BaseType == "void")
       K = Atom::A_Wild;
 
     if (PrevArr && ArrSizes.at(TypeIdx).first != O_SizedArray && !EmittedName) {
@@ -2164,7 +2165,7 @@ FVComponentVariable::FVComponentVariable(const QualType &QT,
                                          bool PotentialGeneric,
                                          bool HasItype) {
   ExternalConstraint = new PVConstraint(QT, D, N, I, C, InFunc, -1,
-                                        PotentialGeneric ,HasItype, nullptr,
+                                        PotentialGeneric, HasItype, nullptr,
                                         ITypeT);
   InternalConstraint = new PVConstraint(QT, D, N, I, C, InFunc, -1,
                                         PotentialGeneric, HasItype,nullptr,

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -650,6 +650,13 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     RewriteReturn = true;
   }
 
+  // Mirrors the check above that sets RewriteGeneric to true.
+  // If we've decided against making this generic, remove the generic params
+  // so later rewrites (of typeparams) don't happen
+  if (!RewriteGeneric && FDConstraint->getGenericParams() > 0
+      && !FD->isGenericFunction() && !FD->isItypeGenericFunction())
+    FDConstraint->resetGenericParams();
+
 
   // Combine parameter and return variables rewritings into a single rewriting
   // for the entire function declaration.

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -559,8 +559,9 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     DeclIsTypedef = isa<TypedefType>(TS->getType());
   }
 
-  // If we've made this generic we need add "_Itype_for_any"
-  if (FDConstraint->getGenericParams() > 0 && !FD->isGenericFunction())
+  // If we've made this generic we need add "_For_any" or "_Itype_for_any"
+  if (FDConstraint->getGenericParams() > 0
+      && !FD->isGenericFunction() && !FD->isItypeGenericFunction())
     RewriteGeneric = true;
 
   // Get rewritten parameter variable declarations. Try to use

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -668,10 +668,6 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   if (RewriteReturn)
     NewSig += getStorageQualifierString(FD) + ReturnVar;
 
-  // remove an excess space
-  if (RewriteReturn && !RewriteParams)
-    NewSig.pop_back();
-
   if (RewriteReturn && RewriteParams)
     NewSig += FDConstraint->getName();
 

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -556,7 +556,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   }
 
   // If we've made this generic we need add "_Itype_for_any"
-  if (FDConstraint->getGenericParams() > 0 && !FD->isItypeGenericFunction())
+  if (FDConstraint->getGenericParams() > 0 && !FD->isGenericFunction())
     RewriteGeneric = true;
 
   // Get rewritten parameter variable declarations. Try to use

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -749,7 +749,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
 
   if(CV->getExternal()->isGenericChanged()) {
     Type = CV->getExternal()->mkString(Info.getConstraints());
-    if (BoundsStr != "")
+    if (BoundsStr.empty())
       IType = getExistingIType(CV->getExternal()) + BoundsStr;
     return;
   }

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -746,15 +746,17 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
                      RewriteParm, RewriteRet);
     return;
   }
+
+  // Don't add generics if one of the potential generic params is wild,
+  // even if it could have an itype
+  if (CV->getExternal()->isGenericChanged())
+    RewriteGen = false;
+
   if (CV->hasItypeSolution(Info.getConstraints())) {
     buildItypeDecl(CV->getExternal(), Decl, Type, IType,
                    RewriteParm, RewriteRet);
     return;
   }
-  // Don't add generics if one of the potential generic params is wild.
-  if (CV->getExternal()->isGenericChanged())
-    RewriteGen = false;
-
   // If the type of the pointer hasn't changed, then neither of the above
   // branches will be taken, but it's still possible for the bounds of an array
   // pointer to change.

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -763,6 +763,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
 
   if(CV->getExternal()->isGenericChanged()) {
     Type = CV->getExternal()->mkString(Info.getConstraints());
+    RewriteParm = true;
     if (BoundsStr.empty())
       IType = getExistingIType(CV->getExternal()) + BoundsStr;
     return;

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -747,6 +747,13 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
     ABRewriter.getBoundsString(CV->getExternal(), Decl,
                                !getExistingIType(CV->getExternal()).empty());
 
+  if(CV->getExternal()->isGenericChanged()) {
+    Type = CV->getExternal()->mkString(Info.getConstraints());
+    if (BoundsStr != "")
+      IType = getExistingIType(CV->getExternal()) + BoundsStr;
+    return;
+  }
+
   // Variables that do not need to be rewritten fall through to here.
   // Try to use the source.
   ParmVarDecl *PVD = dyn_cast_or_null<ParmVarDecl>(Decl);

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -575,7 +575,6 @@ ProgramInfo::insertNewFVConstraint(FunctionDecl *FD, FVConstraint *NewC,
 
 void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
   // Special-case for va_list, constrain to wild.
-  bool IsGeneric = false;
   PVConstraint *PVC = nullptr;
 
   CVarOption CVOpt = getVariable(D, Context);
@@ -584,17 +583,11 @@ void ProgramInfo::specialCaseVarIntros(ValueDecl *D, ASTContext *Context) {
     PVC = dyn_cast<PVConstraint>(&CV);
   }
 
-  if (isa<ParmVarDecl>(D))
-    IsGeneric = PVC && PVC->getIsGeneric();
-  if (isVarArgType(D->getType().getAsString()) ||
-      (hasVoidType(D) && !IsGeneric)) {
+  if (PVC != nullptr && isVarArgType(D->getType().getAsString())) {
     // Set the reason for making this variable WILD.
-    std::string Rsn = "Variable type void.";
     PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(D, *Context);
-    if (!D->getType()->isVoidType())
-      Rsn = "Variable type is va_list.";
-    if (PVC != nullptr)
-      PVC->constrainToWild(CS, Rsn, &PL);
+    std::string Rsn = "Variable type is va_list.";
+    PVC->constrainToWild(CS, Rsn, &PL);
   }
 }
 

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -1128,16 +1128,18 @@ void ProgramInfo::computePtrLevelStats() {
 }
 
 void ProgramInfo::setTypeParamBinding(CallExpr *CE, unsigned int TypeVarIdx,
-                                      ConstraintVariable *CV, ASTContext *C) {
+                                      ConstraintVariable *CV,
+                                      ConstraintVariable *Ident,
+                                      ASTContext *C) {
 
   auto PSL = PersistentSourceLoc::mkPSL(CE, *C);
   auto CallMap = TypeParamBindings[PSL];
   if (CallMap.find(TypeVarIdx) == CallMap.end()) {
-    TypeParamBindings[PSL][TypeVarIdx] = CV;
+    TypeParamBindings[PSL][TypeVarIdx] = std::make_pair(CV,Ident);
   } else {
     // If this CE/idx is at the same location, it's in a macro,
     // so mark it as inconsistent.
-    TypeParamBindings[PSL][TypeVarIdx] = nullptr;
+    TypeParamBindings[PSL][TypeVarIdx] = std::make_pair(nullptr,nullptr);
   }
 }
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -491,12 +491,18 @@ private:
 };
 
 SourceRange FunctionDeclReplacement::getSourceRange(SourceManager &SM) const {
-  SourceLocation Begin = RewriteReturn ? getDeclBegin(SM) : getParamBegin(SM);
+  SourceLocation Begin = RewriteGeneric ? getGenericBegin(SM) :
+                      (RewriteReturn ? getDeclBegin(SM) : getParamBegin(SM));
   SourceLocation End = RewriteParams ? getDeclEnd(SM) : getReturnEnd(SM);
   // Begin can be equal to End if the SourceRange only contains one token.
   assert("Invalid FunctionDeclReplacement SourceRange!" &&
          (Begin == End || SM.isBeforeInTranslationUnit(Begin, End)));
   return SourceRange(Begin, End);
+}
+
+SourceLocation FunctionDeclReplacement::getGenericBegin(SourceManager &SM) const {
+  SourceLocation Begin = Decl->getSourceRange().getBegin();
+  return Begin;
 }
 
 SourceLocation FunctionDeclReplacement::getDeclBegin(SourceManager &SM) const {

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -449,10 +449,17 @@ public:
         std::string TypeParamString;
         bool AllInconsistent = true;
         for (auto Entry : Info.getTypeParamBindings(CE, Context))
-          if (Entry.second != nullptr) {
+          if (Entry.second.first != nullptr) {
             AllInconsistent = false;
-            std::string TyStr = Entry.second->mkString(
-                Info.getConstraints(), false, false, true);
+            std::string TyStr;
+            PVConstraint *CheckVoid = dyn_cast<PVConstraint>(Entry.second.first);
+            if (Entry.second.second != nullptr && CheckVoid->isVoidPtr()) {
+              std::string TyStr = Entry.second.second->mkString(
+                  Info.getConstraints(), false, false, true);
+            } else {
+              std::string TyStr = Entry.second.first->mkString(
+                  Info.getConstraints(), false, false, true);
+            }
             if (TyStr.back() == ' ')
               TyStr.pop_back();
             TypeParamString += TyStr + ",";

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -446,8 +446,7 @@ public:
       // If the function is not generic, we have nothing to do.
       // This could happen even if it has type param binding if we
       // reset generics because of wildness
-      auto temp = Info.getFuncConstraint(FD,Context);
-      if (temp->getGenericParams() == 0 &&
+      if (Info.getFuncConstraint(FD,Context)->getGenericParams() == 0 &&
           !FD->isItypeGenericFunction())
         return true;
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -454,10 +454,10 @@ public:
             std::string TyStr;
             PVConstraint *CheckVoid = dyn_cast<PVConstraint>(Entry.second.first);
             if (Entry.second.second != nullptr && CheckVoid->isVoidPtr()) {
-              std::string TyStr = Entry.second.second->mkString(
+              TyStr = Entry.second.second->mkString(
                   Info.getConstraints(), false, false, true);
             } else {
-              std::string TyStr = Entry.second.first->mkString(
+              TyStr = Entry.second.first->mkString(
                   Info.getConstraints(), false, false, true);
             }
             if (TyStr.back() == ' ')

--- a/clang/lib/3C/TypeVariableAnalysis.cpp
+++ b/clang/lib/3C/TypeVariableAnalysis.cpp
@@ -126,7 +126,7 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
             FD->getNameAsString() + "_tyarg_" + std::to_string(TVEntry.first);
         PVConstraint *P =
             new PVConstraint(TVEntry.second.getType(), nullptr, Name, Info,
-                             *Context, nullptr, TVEntry.first);
+                             *Context, nullptr);
 
         // Constrain this variable GEQ the function arguments using the type
         // variable so if any of them are wild, the type argument will also be

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -387,19 +387,6 @@ bool isCastSafe(clang::QualType DstType, clang::QualType SrcType) {
   return castCheck(DstType, SrcType);
 }
 
-bool isCastAlloc(CastExpr *CE) {
-  Expr *SE = CE->getSubExpr();
-  if (CHKCBindTemporaryExpr *CE = dyn_cast<CHKCBindTemporaryExpr>(SE))
-    SE = CE->getSubExpr();
-  if (auto *CE = dyn_cast_or_null<CallExpr>(SE)) {
-    if (auto *DD = dyn_cast_or_null<DeclaratorDecl>(CE->getCalleeDecl())) {
-      std::string Name = DD->getNameAsString();
-      return Name == "malloc" || Name == "calloc" || Name == "realloc";
-    }
-  }
-  return false;
-}
-
 bool canWrite(const std::string &FilePath) {
   // Was this file explicitly provided on the command line?
   if (FilePaths.count(FilePath) > 0)

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -325,8 +325,7 @@ bool hasVoidType(clang::ValueDecl *D) { return isTypeHasVoid(D->getType()); }
 //  return D->isPointerType() == S->isPointerType();
 //}
 
-static bool castCheck(clang::QualType DstType, clang::QualType SrcType,
-                      bool AllowVoidCast) {
+static bool castCheck(clang::QualType DstType, clang::QualType SrcType) {
 
   // Check if both types are same.
   if (SrcType == DstType)
@@ -342,9 +341,8 @@ static bool castCheck(clang::QualType DstType, clang::QualType SrcType,
 
   // Both are pointers? check their pointee
   if (SrcPtrTypePtr && DstPtrTypePtr) {
-    return (AllowVoidCast && SrcPtrTypePtr->isVoidPointerType()) ||
-      castCheck(DstPtrTypePtr->getPointeeType(),
-                SrcPtrTypePtr->getPointeeType(), AllowVoidCast);
+    return castCheck(DstPtrTypePtr->getPointeeType(),
+                SrcPtrTypePtr->getPointeeType());
   }
 
   if (SrcPtrTypePtr || DstPtrTypePtr)
@@ -359,11 +357,10 @@ static bool castCheck(clang::QualType DstType, clang::QualType SrcType,
 
     for (unsigned I = 0; I < SrcFnType->getNumParams(); I++)
       if (!castCheck(SrcFnType->getParamType(I),
-                     DstFnType->getParamType(I), false))
+                     DstFnType->getParamType(I)))
         return false;
 
-    return castCheck(SrcFnType->getReturnType(), DstFnType->getReturnType(),
-                     false);
+    return castCheck(SrcFnType->getReturnType(), DstFnType->getReturnType());
   }
 
   // If both are not scalar types? Then the types must be exactly same.
@@ -387,7 +384,7 @@ bool isCastSafe(clang::QualType DstType, clang::QualType SrcType) {
       dyn_cast<clang::PointerType>(DstTypePtr);
   if (!DstPtrTypePtr) // Safe to cast to a non-pointer.
     return true;
-  return castCheck(DstType, SrcType, false);
+  return castCheck(DstType, SrcType);
 }
 
 bool isCastAlloc(CastExpr *CE) {

--- a/clang/test/3C/cast.c
+++ b/clang/test/3C/cast.c
@@ -26,8 +26,8 @@ void bar(void) {
 // malloc and generics are exceptions to our policy of unsafe void* casts
 #include<stdlib.h>
 _Itype_for_any(T)
-void *gen_fun(void *i : itype(_Ptr<T>))
-: itype(_Ptr<T>);
+void *ident(void *i : itype(_Ptr<T>))
+: itype(_Ptr<T>) { return i;};
 void test_generic_casts(void) {
   int *ptr_cast = (int*)malloc(3 * sizeof(int));
   // CHECK_ALL: _Ptr<int> ptr_cast = (_Ptr<int>)malloc<int>(3 * sizeof(int));
@@ -35,8 +35,8 @@ void test_generic_casts(void) {
   // CHECK_ALL: _Ptr<int> ptr_nocast = malloc<int>(3 * sizeof(int));
   char *ptr_badcast = (int *)malloc(3 * sizeof(int));
   // CHECK_ALL: char *ptr_badcast = (int *)malloc<int>(3 * sizeof(int));
-  int *ptr_custom = (int*)gen_fun<int>(ptr_cast);
-  // CHECK_ALL: _Ptr<int> ptr_custom = (_Ptr<int>)gen_fun<int>(ptr_cast);
+  int *ptr_custom = (int*)ident<int>(ptr_cast);
+  // CHECK_ALL: _Ptr<int> ptr_custom = (_Ptr<int>)ident<int>(ptr_cast);
 
   int *ptr_cast_c = (int*)calloc(3, sizeof(int));
   // CHECK_ALL: _Ptr<int> ptr_cast_c = (_Ptr<int>)calloc<int>(3, sizeof(int));

--- a/clang/test/3C/cast.c
+++ b/clang/test/3C/cast.c
@@ -22,3 +22,20 @@ void bar(void) {
   //CHECK: int *d = (int *)5;
   /*int *e = (int *)(a+5);*/
 }
+
+// malloc etc. are exceptions to our policy of unsafe void* casts
+#include<stdlib.h>
+void test_alloc(void) {
+  int *ptr_cast = (int*)malloc(3 * sizeof(int));
+  // CHECK_ALL: _Ptr<int> ptr_cast = (_Ptr<int>)malloc<int>(3 * sizeof(int));
+  int *ptr_nocast = malloc(3 * sizeof(int));
+  // CHECK_ALL: _Ptr<int> ptr_nocast = malloc<int>(3 * sizeof(int));
+  char *ptr_badcast = (int *)malloc(3 * sizeof(int));
+  // CHECK_ALL: char *ptr_badcast = (int *)malloc<int>(3 * sizeof(int));
+
+  int *ptr_cast_c = (int*)calloc(3, sizeof(int));
+  // CHECK_ALL: _Ptr<int> ptr_cast_c = (_Ptr<int>)calloc<int>(3, sizeof(int));
+  int *ptr_cast_r = (int*)realloc(ptr_cast_c, 3 * sizeof(int));
+  // CHECK_ALL: _Ptr<int> ptr_cast_r = (_Ptr<int>)realloc<int>(ptr_cast_c, 3 * sizeof(int));
+
+}

--- a/clang/test/3C/cast.c
+++ b/clang/test/3C/cast.c
@@ -23,15 +23,20 @@ void bar(void) {
   /*int *e = (int *)(a+5);*/
 }
 
-// malloc etc. are exceptions to our policy of unsafe void* casts
+// malloc and generics are exceptions to our policy of unsafe void* casts
 #include<stdlib.h>
-void test_alloc(void) {
+_Itype_for_any(T)
+void *gen_fun(void *i : itype(_Ptr<T>))
+: itype(_Ptr<T>);
+void test_generic_casts(void) {
   int *ptr_cast = (int*)malloc(3 * sizeof(int));
   // CHECK_ALL: _Ptr<int> ptr_cast = (_Ptr<int>)malloc<int>(3 * sizeof(int));
   int *ptr_nocast = malloc(3 * sizeof(int));
   // CHECK_ALL: _Ptr<int> ptr_nocast = malloc<int>(3 * sizeof(int));
   char *ptr_badcast = (int *)malloc(3 * sizeof(int));
   // CHECK_ALL: char *ptr_badcast = (int *)malloc<int>(3 * sizeof(int));
+  int *ptr_custom = (int*)gen_fun<int>(ptr_cast);
+  // CHECK_ALL: _Ptr<int> ptr_custom = (_Ptr<int>)gen_fun<int>(ptr_cast);
 
   int *ptr_cast_c = (int*)calloc(3, sizeof(int));
   // CHECK_ALL: _Ptr<int> ptr_cast_c = (_Ptr<int>)calloc<int>(3, sizeof(int));

--- a/clang/test/3C/fptr_array.c
+++ b/clang/test/3C/fptr_array.c
@@ -23,8 +23,8 @@ void (*g)(int *) = g_impl;
 
 void (*hs[2])(void *);
 void (*h)(void *);
-//CHECK_NOALL: void (*hs[2])(void *);
-//CHECK_NOALL: void (*h)(void *);
+//CHECK_NOALL: void (* hs[2])(void *) = {((void *)0)};
+//CHECK_NOALL: void (*h)(void *) = ((void *)0);
 //CHECK_ALL: _Ptr<void (void *)> hs _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<void (void *)> h = ((void *)0);
 

--- a/clang/test/3C/fptr_array.c
+++ b/clang/test/3C/fptr_array.c
@@ -23,8 +23,8 @@ void (*g)(int *) = g_impl;
 
 void (*hs[2])(void *);
 void (*h)(void *);
-//CHECK_NOALL: void (* hs[2])(void *) = {((void *)0)};
-//CHECK_NOALL: void (*h)(void *) = ((void *)0);
+//CHECK_NOALL: void (*hs[2])(void *);
+//CHECK_NOALL: void (*h)(void *);
 //CHECK_ALL: _Ptr<void (void *)> hs _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<void (void *)> h = ((void *)0);
 

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -22,10 +22,10 @@ void viewer_update(void *i) {
 void *getNull() { return 0; }
 // CHECK: _For_any(T) _Ptr<T> getNull(void) { return 0; }
 void *getOne() { return 1; }
-// CHECK: void *getOne() { return 1; }
+// CHECK: void *getOne(void) { return 1; }
 extern void *glob = 0;
 void *getGlobal() { return glob; }
-// CHECK: void *getGlobal() { return glob; }
+// CHECK: void *getGlobal(void) { return glob; }
 
 // check type parameters
 void call_from_fn() {

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/generalize.c -- | diff %t.checked/generalize.c -
+
+// Test the code that adds generics to replace void*
+
+// Basic functionality
+void viewer(void *i) { return; }
+// CHECK: _For_any(T) void viewer(_Ptr<T> i) { return; }
+void viewer_badnum(void *i, int *j : itype(_Ptr<int>)) {
+// CHECK: _Itype_for_any(T) void viewer_badnum(_Ptr<T> i, int *j : itype(_Ptr<int>)) {
+j = (int*)3;
+return;
+}
+void *getNull() { return 0; }
+// CHECK: _For_any(T) _Ptr<T> getNull(void) { return 0; }
+

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -17,6 +17,16 @@ void viewer_badnum(void *i, int *j) {
 void *getNull() { return 0; }
 // CHECK: _For_any(T) _Ptr<T> getNull(void) { return 0; }
 
+// check type parameters
+void call_from_fn() {
+  int *i;
+  viewer(i);
+  // CHECK: viewer<int>(i);
+}
+void call_from_gen_fn(void *i) {
+  viewer(i);
+  // CHECK: viewer<T>(i);
+}
 
 
 

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -14,8 +14,18 @@ void viewer_badnum(void *i, int *j) {
   j = (int*)3;
   return;
 }
+void viewer_update(void *i) {
+// CHECK: void viewer_update(void *i) {
+  i = 2;
+  return;
+}
 void *getNull() { return 0; }
 // CHECK: _For_any(T) _Ptr<T> getNull(void) { return 0; }
+void *getOne() { return 1; }
+// CHECK: void *getOne() { return 1; }
+extern void *glob = 0;
+void *getGlobal() { return glob; }
+// CHECK: void *getGlobal() { return glob; }
 
 // check type parameters
 void call_from_fn() {

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -17,3 +17,62 @@ return;
 void *getNull() { return 0; }
 // CHECK: _For_any(T) _Ptr<T> getNull(void) { return 0; }
 
+
+
+
+// Code from vsftpd
+#include <stdlib.h>
+#include <limits.h>
+extern void bug(char*);
+extern void die(char*);
+void*
+vsf_sysutil_malloc(unsigned int size)
+{
+  void* p_ret;
+  /* Paranoia - what if we got an integer overflow/underflow? */
+  if (size == 0 || size > INT_MAX)
+  {
+    bug("zero or big size in vsf_sysutil_malloc");
+  }
+  p_ret = malloc(size);
+  if (p_ret == NULL)
+  {
+    die("malloc");
+  }
+  return p_ret;
+}
+
+void*
+vsf_sysutil_realloc(void* p_ptr, unsigned int size)
+{
+  void* p_ret;
+  if (size == 0 || size > INT_MAX)
+  {
+    bug("zero or big size in vsf_sysutil_realloc");
+  }
+  p_ret = realloc(p_ptr, size);
+  if (p_ret == NULL)
+  {
+    die("realloc");
+  }
+  return p_ret;
+}
+
+void
+vsf_sysutil_free(void* p_ptr)
+{
+  if (p_ptr == NULL)
+  {
+    bug("vsf_sysutil_free got a null pointer");
+  }
+  free(p_ptr);
+}
+
+void run_vsf_sysutil (void) {
+  typedef struct {char a; char b;} char_node;
+  char_node *node1;
+  node1 = vsf_sysutil_malloc(sizeof(*node1));
+  node1 = vsf_sysutil_realloc(node1, sizeof(*node1));
+  vsf_sysutil_free(node1);
+}
+

--- a/clang/test/3C/liberal_itypes_ptr.c
+++ b/clang/test/3C/liberal_itypes_ptr.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_ptr.c -- | diff %t.checked/liberal_itypes_ptr.c -
+// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked %t.checked/liberal_itypes_ptr.c -- | diff %t.checked/liberal_itypes_ptr.c -
 
 void foo(int *a) {}
 // CHECK: void foo(_Ptr<int> a) _Checked {}
@@ -116,7 +116,8 @@ void bounds_fn(void *b : byte_count(1));
 // CHECK: void bounds_fn(void *b : byte_count(1));
 
 void bounds_call(void *p) {
-  // CHECK: void bounds_call(void *p) {
+  // CHECK_NOALL: void bounds_call(void *p) {
+  // CHECK_ALL: _For_any(T) void bounds_call(_Array_ptr<T> p) {
   bounds_fn(p);
   // CHECK: bounds_fn(p);
 }


### PR DESCRIPTION
The code now adds `_For_any(T)` to appropriate function. However, there is a need to propagate the `T` internally within the functions. See [below](#issuecomment-864225769) for the description.


Outdated:
I'm at the debugging stage and getting a wide range of errors most of which have little to do with generic functions.~

I'd appreciate if anyone can suggest where my changes might be leaking out. Some tests I've looked at:
- fp.c: fp parameter not written, not generic (_Ptr<int (int*)> vs _Ptr<int (int*p)>)
- add_bounds.c: count(1) not written, not generic
- addrof_crash.c: function marked as checked rather than itype, not generic
- compound_literal.c" second run checked more pointers, not generic
- generated tests: make "unwritable" changes to libio.h, some potential generic functions have whitespace differences

