### PR TITLE
Fix escaping bugs that currently affect the JSON formatting test on Windows.

### DIFF
--- a/clang/include/clang/3C/PersistentSourceLoc.h
+++ b/clang/include/clang/3C/PersistentSourceLoc.h
@@ -56,9 +56,12 @@ public:
       return FileName < O.FileName;
   }
 
-  void print(llvm::raw_ostream &O) const {
-    O << FileName << ":" << LineNo << ":" << ColNoS << ":" << ColNoE;
+  std::string toString() const {
+    return FileName + ":" + std::to_string(LineNo) + ":" +
+           std::to_string(ColNoS) + ":" + std::to_string(ColNoE);
   }
+
+  void print(llvm::raw_ostream &O) const { O << toString(); }
 
   void dump() const { print(llvm::errs()); }
 

--- a/clang/lib/3C/3CInteractiveData.cpp
+++ b/clang/lib/3C/3CInteractiveData.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/3CInteractiveData.h"
+#include "llvm/Support/JSON.h"
 
 void ConstraintsInfo::clear() {
   RootWildAtomsWithReason.clear();
@@ -116,11 +117,9 @@ void ConstraintsInfo::printConstraintStats(llvm::raw_ostream &O,
   O << "\"InSrc\":" << (InSrcWildAtoms.find(Cause) != InSrcWildAtoms.end()) << ", ";
   O << "\"Location\":";
   const PersistentSourceLoc &PSL = PtrInfo.getLocation();
-  if (PSL.valid()) {
-    O << "\"";
-    PSL.print(O);
-    O << "\"";
-  } else
+  if (PSL.valid())
+    O << llvm::json::Value(PSL.toString());
+  else
     O << "null";
   O << ", ";
 

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -13,6 +13,7 @@
 #include "clang/3C/ConstraintsGraph.h"
 #include "clang/3C/MappingVisitor.h"
 #include "clang/3C/Utils.h"
+#include "llvm/Support/JSON.h"
 #include <sstream>
 
 using namespace clang;
@@ -66,7 +67,10 @@ void dumpStaticFuncMapJson(const ProgramInfo::StaticFunctionMapType &EMap,
     if (AddComma) {
       O << ",\n";
     }
-    O << "{\"FuncName\":\"" << DefM.first << "\", \"Constraints\":[";
+    // The `FuncName` and `FileName` field names are backwards: this is actually
+    // the file name, hence the need to defend against special characters.
+    O << "{\"FuncName\":" << llvm::json::Value(DefM.first)
+      << ", \"Constraints\":[";
     bool AddComma1 = false;
     for (const auto &J : DefM.second) {
       if (AddComma1) {
@@ -113,9 +117,9 @@ void ProgramInfo::dumpJson(llvm::raw_ostream &O) const {
     }
     PersistentSourceLoc L = I.first;
 
-    O << "{\"line\":\"";
-    L.print(O);
-    O << "\",\"Variables\":[";
+    O << "{\"line\":";
+    O << llvm::json::Value(L.toString());
+    O << ",\"Variables\":[";
     I.second->dumpJson(O);
     O << "]}";
     AddComma = true;
@@ -315,7 +319,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
         if (AddComma) {
           O << ",\n";
         }
-        O << "{\"" << I.first << "\":{";
+        O << "{" << llvm::json::Value(I.first) << ":{";
         O << "\"constraints\":" << V << ",";
         O << "\"ptr\":" << P << ",";
         O << "\"ntarr\":" << Nt << ",";

--- a/clang/test/3C/json_formatting.c
+++ b/clang/test/3C/json_formatting.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
 // RUN: mkdir %t.alltypes && cd %t.alltypes
-// RUN: 3c -base-dir=%S -alltypes -dump-stats -dump-intermediate -debug-solver %s
+// RUN: 3c -base-dir=%S -alltypes -dump-stats -dump-intermediate -debug-solver %s --
 // RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
 // RUN: mkdir %t.noalltypes && cd %t.noalltypes
-// RUN: 3c -base-dir=%S -dump-stats -dump-intermediate -debug-solver %s
+// RUN: 3c -base-dir=%S -dump-stats -dump-intermediate -debug-solver %s --
 // RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
 
 // Testing that json files output for statistics logging are well formed

--- a/clang/test/3C/json_formatting_backslash.c
+++ b/clang/test/3C/json_formatting_backslash.c
@@ -1,0 +1,36 @@
+// Regression test for a bug in which 3C didn't escape backslashes in file paths
+// in its JSON output
+// (https://github.com/correctcomputation/checkedc-clang/issues/619). On
+// Windows, file paths contain backslashes as the directory separator, so the
+// main json_formatting.c test would catch the bug. This test catches the bug on
+// Linux and Mac OS X by manually creating a file with a backslash in the name
+// (which is an ordinary filename character on these OSes).
+
+// UNSUPPORTED: system-windows
+
+// We reuse json_formatting.c to ensure that we test all the same code
+// constructs, but we `#include` it instead of running 3c on it directly because
+// some code used by 3c seems to be messing with backslashes in file names on
+// the command line. The `#include` seems to preserve the backslash. (This is an
+// unusual case, so it wouldn't be surprising if 3c's behavior changes at some
+// point and this test breaks and we have to redesign it.)
+
+// RUN: rm -rf %t*
+
+// RUN: mkdir %t.alltypes && cd %t.alltypes
+// RUN: cp %s .
+// RUN: cp %S/json_formatting.c 'json\_formatting.h'
+// RUN: 3c -alltypes -dump-stats -dump-intermediate -debug-solver -output-dir=out.checked json_formatting_backslash.c --
+// RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
+
+// RUN: mkdir %t.noalltypes && cd %t.noalltypes
+// RUN: cp %s .
+// RUN: cp %S/json_formatting.c 'json\_formatting.h'
+// RUN: 3c -dump-stats -dump-intermediate -debug-solver -output-dir=out.checked json_formatting_backslash.c --
+// RUN: python -c "import json, glob; [json.load(open(f)) for f in glob.glob('*.json')]"
+
+// Even though this looks like a double-quoted string, the Checked C compiler
+// seems to require the backslash to _not_ be escaped. We choose `\_` because it
+// is not a valid escape sequence in a JSON string literal (see
+// https://www.json.org/).
+#include "json\_formatting.h"


### PR DESCRIPTION
Other escaping bugs may remain; #620 is to fix all of them.
    
Fixes #619.

This PR depends on #624 since it adds a second test of the JSON files and if we let both tests write JSON files directly in `build/tools/clang/test/3C`, the tests could interfere if they are run in parallel.  I've set the target branch for review purposes; I'll change it to `main` after #624 is merged.