### PR TITLE
Fortify source workaround

### DIFF
--- a/clang/test/3C/tree.c
+++ b/clang/test/3C/tree.c
@@ -1,6 +1,6 @@
-// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 #include <stdlib.h>
 #include <string.h>

--- a/clang/test/3C/tree.c
+++ b/clang/test/3C/tree.c
@@ -1,6 +1,7 @@
-// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c --extra-arg="-D_FORTIFY_SOURCE=0" -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// Manually passing fortify source to avoid issues surrounding the way compiler builtins are handled. (See issue #630)
+// RUN: 3c -base-dir=%S -alltypes %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- -D_FORTIFY_SOURCE=0 | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 #include <stdlib.h>
 #include <string.h>

--- a/clang/test/3C/type_params.c
+++ b/clang/test/3C/type_params.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unused -
+// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unused -
 
 // General demonstration
 _Itype_for_any(T) void *test_single(void *a

--- a/clang/test/3C/type_params.c
+++ b/clang/test/3C/type_params.c
@@ -1,7 +1,8 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S --extra-arg="-D_FORTIFY_SOURCE=0" -addcr %s -- | %clang -c -fcheckedc-extension -x c -o %t1.unused -
+// Manually passing fortify source to avoid issues surrounding the way compiler builtins are handled. (See issue #630)
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 | %clang -c -fcheckedc-extension -x c -o %t1.unused -
 
 // General demonstration
 _Itype_for_any(T) void *test_single(void *a


### PR DESCRIPTION
Add `-D_FORITFY_SOURCE=0` to certain tests as a workaround to issues with Fortify and other compiler builtins. 
(For a long term solution, see: #630 )