### PR TITLE
3c no longer crashes when encountering intrinsics 

### DIFF
--- a/clang/include/clang/3C/ConstraintResolver.h
+++ b/clang/include/clang/3C/ConstraintResolver.h
@@ -78,6 +78,10 @@ private:
   CVarSet getBaseVarPVConstraint(DeclRefExpr *Decl);
 
   PVConstraint *getRewritablePVConstraint(Expr *E);
+
+
+  bool isNonPtrType(QualType &TE);
+
 };
 
 #endif // LLVM_CLANG_3C_CONSTRAINTRESOLVER_H

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -164,7 +164,7 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
     E = E->IgnoreParens();
 
     // Non-pointer (int, char, etc.) types have a special base PVConstraint.
-    if (TypE->isRecordType() || TypE->isArithmeticType()) {
+    if (TypE->isRecordType() || TypE->isArithmeticType() || TypE->isVectorType()) {
       if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
         // If we have a DeclRef, the PVC can get a meaningful name
         return pairWithEmptyBkey(getBaseVarPVConstraint(DRE));
@@ -552,6 +552,7 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
         // In particular, structure initialization should not reach here,
         // as that caught by the non-pointer check at the top of this
         // method.
+        ILE->getType()->dump();
         assert("InitlistExpr of type other than array or pointer in "
                "getExprConstraintVars" &&
                ILE->getType()->isPointerType());
@@ -694,7 +695,7 @@ CVarSet ConstraintResolver::pvConstraintFromType(QualType TypE) {
   assert("Pointer type CVs should be obtained through getExprConstraintVars." &&
          !TypE->isPointerType());
   CVarSet Ret;
-  if (TypE->isRecordType() || TypE->isArithmeticType())
+  if (TypE->isRecordType() || TypE->isArithmeticType() || TypE->isVectorType())
     Ret.insert(PVConstraint::getNonPtrPVConstraint(Info.getConstraints()));
   else
     llvm::errs() << "Warning: Returning non-base, non-wild type";
@@ -706,7 +707,8 @@ CVarSet ConstraintResolver::getBaseVarPVConstraint(DeclRefExpr *Decl) {
     return Info.getPersistentConstraintsSet(Decl, Context);
 
   assert(Decl->getType()->isRecordType() ||
-         Decl->getType()->isArithmeticType());
+         Decl->getType()->isArithmeticType() ||
+         Decl->getType()->isVectorType());
 
   CVarSet Ret;
   auto DN = Decl->getDecl()->getName();

--- a/clang/test/3C/simd1.c
+++ b/clang/test/3C/simd1.c
@@ -1,0 +1,13 @@
+// Simple SIMD program that involves no pointers, we just want this to not crash
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s 
+
+typedef int v4si __attribute__ ((vector_size(16))); 
+
+int main(void) { 
+	v4si x = {1,2,3,4}; 
+	v4si y = {1,2,3,4}; 
+	v4si z = x + y; 
+
+	return (z[0] + z[1] + z[3] + z[4]);
+}

--- a/clang/test/3C/simd2.c
+++ b/clang/test/3C/simd2.c
@@ -1,12 +1,12 @@
-// Simple SIMD program that involves no pointers, we just want this to not crash
+// Simple SIMD program that derefs and involves no pointers, we just want this to not crash, 
 // RUN: rm -rf %t*
 // RUN: 3c -base-dir=%S -alltypes -addcr %s 
-
 typedef int v4si __attribute__ ((vector_size(16))); 
 
-void main(void) { 
+int main(void) { 
 	v4si x = {1,2,3,4}; 
 	v4si y = {1,2,3,4}; 
 	v4si z = x + y; 
 
+	return (z[0] + z[1] + z[3] + z[4]);
 }

--- a/clang/test/3C/simd3.c
+++ b/clang/test/3C/simd3.c
@@ -1,0 +1,7 @@
+// Original minimized failing simd program
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr %s 
+
+__attribute__((__vector_size__(2 * sizeof(long)))) int a() {
+  return (__attribute__((__vector_size__(2 * sizeof(long))))int){};
+}


### PR DESCRIPTION
Previously 3c would crash if it found any use of intrinsic types: (ex: `int __attribute__ ((vector_size(16))) x`) 
Now, 3c correctly identifies these as base type. 

Since intrinsic vectors cannot contain pointers, we do not need to generate constraints around them. 
(ie: `int* __attribute__ ((vector_size(16)))` is an invalid type). 

As far as rewriting, if the instrinsics are behind a typedef, then rewriting works fine. However if they are used as raw types rewriting will fail as currently rewriting drops attributes. This is potentially addressed in #466. 

This fixes issues: #632, #381, and #284 

