### PR TITLE
Emit itypes for function pointers

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -87,7 +87,8 @@ public:
   virtual std::string mkString(Constraints &CS, bool EmitName = true,
                                bool ForItype = false, bool EmitPointee = false,
                                bool UnmaskTypedef = false,
-                               std::string UseName = "") const = 0;
+                               std::string UseName = "",
+                               bool ForItypeBase = false) const = 0;
 
   // Debug printing of the constraint variable.
   virtual void print(llvm::raw_ostream &O) const = 0;
@@ -444,7 +445,8 @@ public:
   std::string mkString(Constraints &CS, bool EmitName = true,
                        bool ForItype = false, bool EmitPointee = false,
                        bool UnmaskTypedef = false,
-                       std::string UseName = "") const override;
+                       std::string UseName = "",
+                       bool ForItypeBase = false) const override;
 
   FunctionVariableConstraint *getFV() const { return FV; }
 
@@ -523,10 +525,12 @@ public:
 
   void mergeDeclaration(FVComponentVariable *From, ProgramInfo &I,
                         std::string &ReasonFailed);
-  std::string mkItypeStr(Constraints &CS) const;
+  std::string mkItypeStr(Constraints &CS, bool ForItypeBase = false) const;
   std::string mkTypeStr(Constraints &CS, bool EmitName,
-                        std::string UseName = "") const;
-  std::string mkString(Constraints &CS, bool EmitName = true) const;
+                        std::string UseName = "",
+                        bool ForItypeBase = false) const;
+  std::string mkString(Constraints &CS, bool EmitName = true,
+                       bool ForItypeBase = false) const;
 
   bool hasItypeSolution(Constraints &CS) const;
   bool hasCheckedSolution(Constraints &CS) const;
@@ -634,7 +638,8 @@ public:
   std::string mkString(Constraints &CS, bool EmitName = true,
                        bool ForItype = false, bool EmitPointee = false,
                        bool UnmaskTypedef = false,
-                       std::string UseName = "") const override;
+                       std::string UseName = "",
+                       bool ForItypeBase = false) const override;
   void print(llvm::raw_ostream &O) const override;
   void dump() const override { print(llvm::errs()); }
   void dumpJson(llvm::raw_ostream &O) const override;

--- a/clang/test/3C/extstructfields.c
+++ b/clang/test/3C/extstructfields.c
@@ -13,7 +13,7 @@
 #include <signal.h>
 
 void vsf_sysutil_set_sighandler(int sig, void (*p_handlefunc)(int))
-//CHECK: void vsf_sysutil_set_sighandler(int sig, void (*p_handlefunc)(int))
+//CHECK: void vsf_sysutil_set_sighandler(int sig, void ((*p_handlefunc)(int)) : itype(_Ptr<void (int)>))
 {
   int retval;
   struct sigaction sigact;

--- a/clang/test/3C/generated_tests/safefptrargboth.c
+++ b/clang/test/3C/generated_tests/safefptrargboth.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -121,11 +121,11 @@ int *sus(int (*x)(int), int (*y)(int)) {
 }
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -137,10 +137,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargbothmulti1.c
+++ b/clang/test/3C/generated_tests/safefptrargbothmulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -128,10 +128,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargbothmulti2.c
+++ b/clang/test/3C/generated_tests/safefptrargbothmulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargcallee.c
+++ b/clang/test/3C/generated_tests/safefptrargcallee.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -121,11 +121,11 @@ int *sus(int (*x)(int), int (*y)(int)) {
 }
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -136,11 +136,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargcalleemulti1.c
+++ b/clang/test/3C/generated_tests/safefptrargcalleemulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -127,11 +127,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargcalleemulti2.c
+++ b/clang/test/3C/generated_tests/safefptrargcalleemulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargcaller.c
+++ b/clang/test/3C/generated_tests/safefptrargcaller.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -120,11 +120,11 @@ int *sus(int (*x)(int), int (*y)(int)) {
 }
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -136,10 +136,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargcallermulti1.c
+++ b/clang/test/3C/generated_tests/safefptrargcallermulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -128,10 +128,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargcallermulti2.c
+++ b/clang/test/3C/generated_tests/safefptrargcallermulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargprotoboth.c
+++ b/clang/test/3C/generated_tests/safefptrargprotoboth.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -125,10 +125,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -140,8 +140,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargprotocallee.c
+++ b/clang/test/3C/generated_tests/safefptrargprotocallee.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -124,11 +124,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -139,8 +139,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargprotocaller.c
+++ b/clang/test/3C/generated_tests/safefptrargprotocaller.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -125,10 +125,10 @@ int *foo() {
 
 int *bar() {
   //CHECK_NOALL: int *bar(void) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) {
+  //CHECK_ALL: _Array_ptr<int> bar(void) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -140,8 +140,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargprotosafe.c
+++ b/clang/test/3C/generated_tests/safefptrargprotosafe.c
@@ -104,15 +104,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -123,11 +123,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -138,8 +138,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/safefptrargsafe.c
+++ b/clang/test/3C/generated_tests/safefptrargsafe.c
@@ -100,8 +100,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -119,11 +119,11 @@ int *sus(int (*x)(int), int (*y)(int)) {
 }
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -134,11 +134,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargsafemulti1.c
+++ b/clang/test/3C/generated_tests/safefptrargsafemulti1.c
@@ -107,15 +107,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
-  //CHECK_NOALL: _Ptr<int> foo(void) {
-  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> foo(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);
@@ -126,11 +126,11 @@ int *foo() {
 }
 
 int *bar() {
-  //CHECK_NOALL: _Ptr<int> bar(void) {
-  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
+  //CHECK_NOALL: _Ptr<int> bar(void) _Checked {
+  //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) _Checked {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = sub1;
   //CHECK: _Ptr<int (int)> y = sub1;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/safefptrargsafemulti2.c
+++ b/clang/test/3C/generated_tests/safefptrargsafemulti2.c
@@ -107,8 +107,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargboth.c
+++ b/clang/test/3C/generated_tests/unsafefptrargboth.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -125,7 +125,7 @@ int *foo() {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -140,7 +140,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargbothmulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargbothmulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -131,7 +131,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargbothmulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargbothmulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargcallee.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallee.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -125,7 +125,7 @@ int *foo() {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -140,7 +140,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargcalleemulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcalleemulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -131,7 +131,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargcalleemulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcalleemulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargcaller.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcaller.c
@@ -101,8 +101,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -124,7 +124,7 @@ int *foo() {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -139,7 +139,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargcallermulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallermulti1.c
@@ -108,15 +108,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -131,7 +131,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargcallermulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallermulti2.c
@@ -108,8 +108,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargprotoboth.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotoboth.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -128,7 +128,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -140,8 +140,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargprotocallee.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotocallee.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -128,7 +128,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -139,8 +139,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargprotocaller.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotocaller.c
@@ -105,15 +105,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -128,7 +128,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -140,8 +140,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargprotosafe.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotosafe.c
@@ -104,15 +104,15 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -127,7 +127,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -138,8 +138,8 @@ int *bar() {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/generated_tests/unsafefptrargsafe.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafe.c
@@ -100,8 +100,8 @@ int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;
@@ -123,7 +123,7 @@ int *foo() {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -138,7 +138,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargsafemulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafemulti1.c
@@ -107,15 +107,15 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*)(int), int (*)(int));
-//CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>);
-//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5);
+//CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>);
+//CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5);
 
 int *foo() {
   //CHECK_NOALL: _Ptr<int> foo(void) {
   //CHECK_ALL: _Array_ptr<int> foo(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);
@@ -130,7 +130,7 @@ int *bar() {
   //CHECK_ALL: _Array_ptr<int> bar(void) : count(5) {
 
   int (*x)(int) = add1;
-  //CHECK: int (*x)(int) = add1;
+  //CHECK: _Ptr<int (int)> x = add1;
   int (*y)(int) = mul2;
   //CHECK: int (*y)(int) = mul2;
   int *z = sus(x, y);

--- a/clang/test/3C/generated_tests/unsafefptrargsafemulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafemulti2.c
@@ -107,8 +107,8 @@ static int *mul2(int *x) {
 }
 
 int *sus(int (*x)(int), int (*y)(int)) {
-  //CHECK_NOALL: int *sus(int (*x)(int), _Ptr<int (int)> y) : itype(_Ptr<int>) {
-  //CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int)> y) : count(5) {
+  //CHECK_NOALL: int *sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : itype(_Ptr<int>) {
+  //CHECK_ALL: _Array_ptr<int> sus(int ((*x)(int)) : itype(_Ptr<int (int)>), _Ptr<int (int)> y) : count(5) {
 
   x = (int (*)(int))5;
   //CHECK: x = (int (*)(int))5;

--- a/clang/test/3C/liberal_itypes_fp.c
+++ b/clang/test/3C/liberal_itypes_fp.c
@@ -75,7 +75,7 @@ void fp_unsafe_return() {
 }
 
 void f_ptr_arg(int (*f)()) {
-  // CHECK: void f_ptr_arg(int (*f)()) {
+  // CHECK: void f_ptr_arg(int ((*f)(void)) : itype(_Ptr<int (void)>)) {
   f = 1;
 }
 
@@ -86,7 +86,7 @@ void fpnc1(void *p1) {}
 void fpnc2() { fpnc0(fpnc1); }
 // CHECK: void fpnc2() { fpnc0(fpnc1); }
 void fpnc3(void (*fptr)(void *)) { fptr = 1; }
-// CHECK: void fpnc3(void (*fptr)(void *)) { fptr = 1; }
+// CHECK: void fpnc3(void ((*fptr)(void *)) : itype(_Ptr<void (void *)>)) { fptr = 1; }
 void fpnc4(void *p1) {}
 // CHECK: void fpnc4(void *p1) {}
 void fpnc5() { fpnc3(fpnc4); }

--- a/clang/test/3C/mergebodies1.c
+++ b/clang/test/3C/mergebodies1.c
@@ -30,7 +30,7 @@ int *wildBody(int x) {
 };
 
 int *fnPtrParamUnsafe(int (*)(int,int), int(*)(int*));
-// CHECK: int *fnPtrParamUnsafe(int (*fn)(int, int), _Ptr<int (_Ptr<int>)>) : itype(_Ptr<int>);
+// CHECK: int *fnPtrParamUnsafe(int ((*fn)(int, int)) : itype(_Ptr<int (int, int)>), _Ptr<int (_Ptr<int>)>) : itype(_Ptr<int>);
 
 int *fnPtrParamSafe(int (*)(int,int));
 // CHECK: int *fnPtrParamSafe(_Ptr<int (int, int)> fn) : itype(_Ptr<int>);

--- a/clang/test/3C/mergebodies2.c
+++ b/clang/test/3C/mergebodies2.c
@@ -24,7 +24,7 @@ int *wildBody(int x, int *y, int **z);
 // CHECK: int *wildBody(int x, _Ptr<int> y, _Ptr<_Ptr<int>> z) : itype(_Ptr<int>);
 
 int *fnPtrParamUnsafe(int (*fn)(int,int)) {
-// CHECK: int *fnPtrParamUnsafe(int (*fn)(int,int)) : itype(_Ptr<int>) {
+// CHECK: int *fnPtrParamUnsafe(int ((*fn)(int, int)) : itype(_Ptr<int (int, int)>)) : itype(_Ptr<int>) {
   fn = (int (*)(int,int))5;
   return fn(1,3);
 }


### PR DESCRIPTION
Prior to implementing liberal itypes (PR #356), itypes emitted for function pointers were syntactically incorrect  (Issue #246). While working on liberal itypes I made it so that function pointers would never solve to itypes, avoiding this issue. This change enables solving for itypes on function pointers, and updates function declaration rewriting to emit syntactically correct itypes on function pointers. 