### PR TITLE
Add a flag to always add itypes on function prototypes

### DIFF
--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -72,6 +72,8 @@ struct _3COptions {
   bool AllowUnwritableChanges;
 
   bool AllowRewriteFailures;
+
+  bool ItypesForExtern;
 };
 
 // The main interface exposed by the 3C to interact with the tool.

--- a/clang/include/clang/3C/3CGlobalOptions.h
+++ b/clang/include/clang/3C/3CGlobalOptions.h
@@ -33,6 +33,7 @@ extern bool WarnAllRootCause;
 extern bool DumpUnwritableChanges;
 extern bool AllowUnwritableChanges;
 extern bool AllowRewriteFailures;
+extern bool ItypesForExtern;
 
 #ifdef FIVE_C
 extern bool RemoveItypes;

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -104,7 +104,7 @@ protected:
   virtual void buildDeclVar(const FVComponentVariable *CV, DeclaratorDecl *Decl,
                             std::string &Type, std::string &IType,
                             std::string UseName, bool &RewriteParm,
-                            bool &RewriteRet);
+                            bool &RewriteRet, bool StaticFunc);
   void buildCheckedDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
                         std::string &Type, std::string &IType,
                         std::string UseName, bool &RewriteParm,

--- a/clang/include/clang/3C/DeclRewriter.h
+++ b/clang/include/clang/3C/DeclRewriter.h
@@ -35,6 +35,11 @@ public:
   // Info parameter are rewritten.
   static void rewriteDecls(ASTContext &Context, ProgramInfo &Info, Rewriter &R);
 
+  static void
+  buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl, std::string &Type,
+                 std::string &IType, ProgramInfo &Info,
+                 ArrayBoundsRewriter &ABR);
+
 private:
   static RecordDecl *LastRecordDecl;
   static std::map<Decl *, Decl *> VDToRDMap;

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -59,6 +59,7 @@ std::set<std::string> FilePaths;
 bool DumpUnwritableChanges;
 bool AllowUnwritableChanges;
 bool AllowRewriteFailures;
+bool ItypesForExtern;
 
 #ifdef FIVE_C
 bool RemoveItypes;
@@ -354,6 +355,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   DumpUnwritableChanges = CCopt.DumpUnwritableChanges;
   AllowUnwritableChanges = CCopt.AllowUnwritableChanges;
   AllowRewriteFailures = CCopt.AllowRewriteFailures;
+  ItypesForExtern = CCopt.ItypesForExtern;
 
 #ifdef FIVE_C
   RemoveItypes = CCopt.RemoveItypes;

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -27,6 +27,54 @@
 using namespace llvm;
 using namespace clang;
 
+// Generate a new declaration for the PVConstraint using an itype where the
+// unchecked portion of the type is the original type, and the checked portion
+// is the taken from the constraint graph solution. The unchecked portion is
+// assigned to string reference Type and the checked (itype) portion is assigned
+// to the string reference Itype.
+void DeclRewriter::buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
+                                  std::string &Type, std::string &IType,
+                                  ProgramInfo &Info, ArrayBoundsRewriter &ABR) {
+  if (Defn->getFV()) {
+    // This declaration is for a function pointer. Writing itypes on function
+    // pointers is a little bit harder since the original type string will not
+    // work for the unchecked portion of the itype. We need to generate the
+    // unchecked type from the PVConstraint. The last argument of this call
+    // tells mkString to generate a string using unchecked types instead of
+    // checked types.
+    Type = Defn->mkString(Info.getConstraints(), true, false, false, false, "",
+                          true);
+  } else {
+    Type = Defn->getRewritableOriginalTy();
+    if (isa_and_nonnull<ParmVarDecl>(Decl)) {
+      if (Decl->getName().empty())
+        Type += Defn->getName();
+      else
+        Type += Decl->getNameAsString();
+    } else {
+      std::string Name = Defn->getName();
+      if (Name != RETVAR)
+        Type += Name;
+    }
+  }
+
+  IType = " : itype(";
+  if (ItypesForExtern && Defn->isTypedef()) {
+    // In -itypes-for-extern mode we do not rewrite typedefs to checked types.
+    // They are given a checked itype instead. The unchecked portion of the
+    // itype continues to use the original typedef, but the typedef in the
+    // checked portion is expanded and rewritten to use a checked type. This
+    // lets the typedef be used in unchecked code while still giving a checked
+    // type to the declaration so that it can be used in checked code.
+    // TODO: This could potentially be applied to typedef types even when the
+    //       flag is not passed to limit spread of wildness through typedefs.
+    IType += Defn->mkString(Info.getConstraints(), false, true, false, true);
+  } else {
+    IType += Defn->mkString(Info.getConstraints(), false, true);
+  }
+  IType += ")" + ABR.getBoundsString(Defn, Decl, true);
+}
+
 // This function is the public entry point for declaration rewriting.
 void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
                                 Rewriter &R) {
@@ -123,24 +171,21 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
           isa<VarDecl>(D) &&
           cast<VarDecl>(D)->getFormalLinkage() == Linkage::ExternalLinkage;
         if (ItypesForExtern && (isa<FieldDecl>(D) || IsExternGlobalVar)) {
-          // Give record fields typedefs when using -itypes-for-extern. Note
-          // that we haven't properly implemented itypes for structures yet.
-          // This just rewrites to an itype instead of a fully checked type when
-          // a checked type could have been used.
-          // TODO: This is duplicating some logic from buildItypeDecl.
-          if (PV->getFV()) {
-            // The result of getFV() is not nullptr, so the declaration is for a
-            // function pointer. This makes rewriting with an itype a bit harder.
-            NewTy += PV->mkString(Info.getConstraints(), true, false, false,
-                                  false, "", /* UseUnchecked = */ true);
-          } else {
-            NewTy += PV->getRewritableOriginalTy() +
-                     cast<DeclaratorDecl>(D)->getNameAsString();
-          }
-          NewTy += " : itype(" +
-                   PV->mkString(Info.getConstraints(), /* EmitName = */ false,
-                                /* ForItype = */ true) + ")" +
-                   ABRewriter.getBoundsString(PV, D, /* IsItype = */ true);
+          // Give record fields and global variables itypes when using
+          // -itypes-for-extern. Note that we haven't properly implemented
+          // itypes for structures and globals. This just rewrites to an itype
+          // instead of a fully checked type when a checked type could have been
+          // used. This does provide most of the rewriting infrastructure that
+          // would be required to support these itypes if constraint generation
+          // is updated to handle structure/global itypes.
+          std::string Type, IType;
+          // VarDecl and FieldDecl subclass DeclaratorDecl, so the cast will
+          // always succeed. In fact, ParmVarDecl is also a subclass of
+          // DeclaratorDecl, so it should be possible to make the values in
+          // PSLMap DeclaratorDecls and avoid this cast altogether.
+          DeclRewriter::buildItypeDecl(PV, cast<DeclaratorDecl>(D), Type, IType,
+                                       Info, ABRewriter);
+          NewTy += Type + IType;
         } else {
           NewTy += PV->mkString(Info.getConstraints()) +
                    ABRewriter.getBoundsString(PV, D);
@@ -700,39 +745,13 @@ void FunctionDeclBuilder::buildCheckedDecl(
   RewriteRet |= isa_and_nonnull<FunctionDecl>(Decl);
 }
 
+
 void FunctionDeclBuilder::buildItypeDecl(PVConstraint *Defn,
                                          DeclaratorDecl *Decl,
                                          std::string &Type, std::string &IType,
                                          bool &RewriteParm, bool &RewriteRet) {
   Info.getPerfStats().incrementNumITypes();
-  if (Defn->getFV()) {
-    // The result of getFV() is not nullptr, so the declaration is for a
-    // function pointer. This makes rewriting with an itype a bit harder.
-    Type = Defn->mkString(Info.getConstraints(), true, false, false, false, "",
-                          true);
-  } else {
-    Type = Defn->getRewritableOriginalTy();
-    if (isa_and_nonnull<ParmVarDecl>(Decl)) {
-      if (Decl->getName().empty())
-        Type += Defn->getName();
-      else
-        Type += Decl->getQualifiedNameAsString();
-    } else {
-      std::string Name = Defn->getName();
-      if (Name != RETVAR)
-        Type += Name;
-    }
-  }
-
-  IType = " : itype(";
-  if (ItypesForExtern && Defn->isTypedef()) {
-    // In -itypes-for-extern mode we do not rewrite typedefs to checked types.
-    // They are given a checked itype instead.
-    IType += Defn->mkString(Info.getConstraints(), false, true, false, true);
-  } else {
-    IType += Defn->mkString(Info.getConstraints(), false, true);
-  }
-  IType += ")" + ABRewriter.getBoundsString(Defn, Decl, true);
+  DeclRewriter::buildItypeDecl(Defn, Decl, Type, IType, Info, ABRewriter);
   RewriteParm = true;
   RewriteRet |= isa_and_nonnull<FunctionDecl>(Decl);
 }
@@ -749,10 +768,6 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
 
   bool CheckedSolution = CV->hasCheckedSolution(Info.getConstraints());
   bool ItypeSolution = CV->hasItypeSolution(Info.getConstraints());
-  // FIXME: ItypesForExtern won't apply to function pointers. This more or less
-  //        fine for porting vsftpd, but I want to keep the logic for adding
-  //        itypes consistent between these two cases since a discrepancy there
-  //        was the source of an earlier bug.
   if (ItypeSolution || (CheckedSolution && ItypesForExtern && !StaticFunc)) {
     buildItypeDecl(CV->getExternal(), Decl, Type, IType, RewriteParm,
                    RewriteRet);

--- a/clang/test/3C/itypes_for_extern.c
+++ b/clang/test/3C/itypes_for_extern.c
@@ -5,7 +5,7 @@
 // RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -itypes-for-extern -alltypes %t.checked/itypes_for_extern.c -- | diff %t.checked/itypes_for_extern.c -
 
-// Simplest test case: a would normaly get a checked type, but is given an
+// Simplest test case: a would normally get a checked type, but is given an
 // itype because of the flag.
 void foo(int *a) {}
 //CHECK: void foo(int *a : itype(_Ptr<int>)) _Checked {}
@@ -15,7 +15,7 @@ void foo(int *a) {}
 static void static_foo(int *a) {}
 //CHECK: static void static_foo(_Ptr<int> a) _Checked {}
 
-// Don't give a funciton an itype if it wouldn't normally be checked
+// Don't give a function an itype if it wouldn't normally be checked
 void undef_foo(int *a);
 //CHECK: void undef_foo(int *a);
 
@@ -81,3 +81,14 @@ struct typedef_struct {
 };
 //CHECK: int_star a : itype(_Ptr<int>);
 //CHECK: fn f : itype(_Ptr<void (_Ptr<int>)>);
+
+// Testing some cases where the itypes already exist. Earlier we made a change
+// that lets itypes re-solve to checked types. That shouldn't happen with this
+// flag. This is also covered by the idempotence check, but I wanted to make it
+// explicit.
+
+void has_itype0(int *a : itype(_Ptr<int>)) { a = 1; }
+//CHECK: void has_itype0(int *a : itype(_Ptr<int>)) { a = 1; }
+
+void has_itype1(int *a : itype(_Ptr<int>)) { a = 0; }
+//CHECK: void has_itype1(int *a : itype(_Ptr<int>)) _Checked { a = 0; }

--- a/clang/test/3C/itypes_for_extern.c
+++ b/clang/test/3C/itypes_for_extern.c
@@ -1,0 +1,83 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked %s --
+// RUN: 3c -base-dir=%t.checked -itypes-for-extern -alltypes %t.checked/itypes_for_extern.c -- | diff %t.checked/itypes_for_extern.c -
+
+// Simplest test case: a would normaly get a checked type, but is given an
+// itype because of the flag.
+void foo(int *a) {}
+//CHECK: void foo(int *a : itype(_Ptr<int>)) _Checked {}
+
+// Since static function can't be included in other translation units, these
+// can stay fully checked.
+static void static_foo(int *a) {}
+//CHECK: static void static_foo(_Ptr<int> a) _Checked {}
+
+// Don't give a funciton an itype if it wouldn't normally be checked
+void undef_foo(int *a);
+//CHECK: void undef_foo(int *a);
+
+int *bar() { return 0; }
+//CHECK: int *bar(void) : itype(_Ptr<int>) _Checked { return 0; }
+
+int *baz(int *a, int len, int *b) {
+//CHECK_ALL: int *baz(int *a : itype(_Array_ptr<int>) count(len), int len, int *b : itype(_Ptr<int>)) : itype(_Array_ptr<int>) count(len) _Checked {
+//CHECK_NOALL: int *baz(int *a : itype(_Ptr<int>), int len, int *b : itype(_Ptr<int>)) : itype(_Ptr<int>) {
+  for (int i = 0; i < len; i++)
+    a[i];
+  return a;
+}
+
+// FIXME: The space between after the first star is needed for the idempotence
+//        test to pass. If there isn't a space there, 3c will add one when
+//        re-run on its original output. This should be fixed ideally in two
+//        ways.  First, the space shouldn't be added when not present in the
+//        original source, and second, the second conversion should not rewrite
+//        the declaration.
+void buz(int * (*f)(int *, int *)) {}
+//CHECK: void buz(int * ((*f)(int *, int *)) : itype(_Ptr<_Ptr<int> (_Ptr<int>, _Ptr<int>)>)) _Checked {}
+
+typedef int * int_star;
+void typedef_test(int_star p) {}
+//CHECK: typedef int * int_star;
+//CHECK: void typedef_test(int_star p : itype(_Ptr<int>)) _Checked {}
+
+typedef void (*fn)(int *);
+void fn_typedef_test(fn f) {}
+//CHECK: typedef void (*fn)(int *);
+//CHECK: void fn_typedef_test(fn f : itype(_Ptr<void (_Ptr<int>)>)) _Checked {}
+
+struct foo {
+  int *a;
+  void (*fn)(int *);
+};
+//CHECK: int *a : itype(_Ptr<int>);
+//CHECK: void ((*fn)(int *)) : itype(_Ptr<void (_Ptr<int>)>);
+
+int *glob = 0;
+extern int *extern_glob = 0;
+static int *static_glob = 0;
+//CHECK: int *glob : itype(_Ptr<int>) = 0;
+//CHECK: extern int *extern_glob : itype(_Ptr<int>) = 0;
+//CHECK: static _Ptr<int> static_glob = 0;
+
+void (*glob_fn)(int *) = 0;
+extern void (*extern_glob_fn)(int *) = 0;
+static void (*static_glob_fn)(int *) = 0;
+//CHECK: void ((*glob_fn)(int *)) : itype(_Ptr<void (_Ptr<int>)>) = 0;
+//CHECK: extern void ((*extern_glob_fn)(int *)) : itype(_Ptr<void (_Ptr<int>)>) = 0;
+//CHECK: static _Ptr<void (_Ptr<int>)> static_glob_fn = 0;
+
+int_star typedef_glob = 0;
+fn typedef_fn_glob = 0;
+//CHECK: int_star typedef_glob : itype(_Ptr<int>) = 0;
+//CHECK: fn typedef_fn_glob : itype(_Ptr<void (_Ptr<int>)>) = 0;
+
+struct typedef_struct {
+  int_star a;
+  fn f;
+};
+//CHECK: int_star a : itype(_Ptr<int>);
+//CHECK: fn f : itype(_Ptr<void (_Ptr<int>)>);

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -227,6 +227,14 @@ static cl::opt<bool> OptAllowRewriteFailures(
              "affect common use cases."),
     cl::init(false), cl::cat(_3CCategory));
 
+static cl::opt<bool> OptItypesForExtern(
+  "itypes-for-extern",
+  cl::desc("All functions with external linkage will be rewritten to use itypes"
+           "instead checked types. This does not apply to static functions which"
+           "continue to have itypes only when the function is internally"
+           "unsafe."),
+  cl::init(false), cl::cat(_3CCategory));
+
 #ifdef FIVE_C
 static cl::opt<bool> OptRemoveItypes(
     "remove-itypes",
@@ -292,6 +300,7 @@ int main(int argc, const char **argv) {
   CcOptions.DumpUnwritableChanges = OptDumpUnwritableChanges;
   CcOptions.AllowUnwritableChanges = OptAllowUnwritableChanges;
   CcOptions.AllowRewriteFailures = OptAllowRewriteFailures;
+  CcOptions.ItypesForExtern = OptItypesForExtern;
 
 #ifdef FIVE_C
   CcOptions.RemoveItypes = OptRemoveItypes;


### PR DESCRIPTION
This is the implementation of the `-itypes-for-externs` flag used in the vsftpd tutorial. It is based on PR #636 which fixes the syntax for function pointer itypes.