### PR TITLE
Introduce a code pattern for functions with named optional parameters.

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -26,6 +26,7 @@
 #define LLVM_CLANG_3C_CONSTRAINTVARIABLES_H
 
 #include "clang/3C/Constraints.h"
+#include "clang/3C/OptionalParams.h"
 #include "clang/3C/ProgramVar.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Lex/Lexer.h"
@@ -40,6 +41,16 @@ class ProgramInfo;
 typedef std::set<ConstraintKey> CVars;
 // Holds Atoms, one for each of the pointer (*) declared in the program.
 typedef std::vector<Atom *> CAtoms;
+
+struct MkStringOpts {
+  bool EmitName = true;
+  bool ForItype = false;
+  bool EmitPointee = false;
+  bool UnmaskTypedef = false;
+  std::string UseName = "";
+  bool ForItypeBase = false;
+};
+#define MKSTRING_OPTS(...) PACK_OPTS(MkStringOpts, __VA_ARGS__)
 
 // Base class for ConstraintVariables. A ConstraintVariable can either be a
 // PointerVariableConstraint or a FunctionVariableConstraint. The difference
@@ -84,11 +95,8 @@ public:
   // the name of the variable, false for just the type.
   // The 'forIType' parameter is true when the generated string is expected
   // to be used inside an itype.
-  virtual std::string mkString(Constraints &CS, bool EmitName = true,
-                               bool ForItype = false, bool EmitPointee = false,
-                               bool UnmaskTypedef = false,
-                               std::string UseName = "",
-                               bool ForItypeBase = false) const = 0;
+  virtual std::string mkString(Constraints &CS,
+                               const MkStringOpts &Opts = {}) const = 0;
 
   // Debug printing of the constraint variable.
   virtual void print(llvm::raw_ostream &O) const = 0;
@@ -442,11 +450,8 @@ public:
 
   std::string gatherQualStrings(void) const;
 
-  std::string mkString(Constraints &CS, bool EmitName = true,
-                       bool ForItype = false, bool EmitPointee = false,
-                       bool UnmaskTypedef = false,
-                       std::string UseName = "",
-                       bool ForItypeBase = false) const override;
+  std::string mkString(Constraints &CS,
+                       const MkStringOpts &Opts = {}) const override;
 
   FunctionVariableConstraint *getFV() const { return FV; }
 
@@ -635,11 +640,8 @@ public:
   bool solutionEqualTo(Constraints &CS, const ConstraintVariable *CV,
                        bool ComparePtyp = true) const override;
 
-  std::string mkString(Constraints &CS, bool EmitName = true,
-                       bool ForItype = false, bool EmitPointee = false,
-                       bool UnmaskTypedef = false,
-                       std::string UseName = "",
-                       bool ForItypeBase = false) const override;
+  std::string mkString(Constraints &CS,
+                       const MkStringOpts &Opts = {}) const override;
   void print(llvm::raw_ostream &O) const override;
   void dump() const override { print(llvm::errs()); }
   void dumpJson(llvm::raw_ostream &O) const override;

--- a/clang/include/clang/3C/OptionalParams.h
+++ b/clang/include/clang/3C/OptionalParams.h
@@ -1,0 +1,213 @@
+//=--3C.h---------------------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions supporting a code pattern for functions that take _named_
+// optional parameters. For functions with multiple optional parameters, this
+// pattern tends to be better than C++'s default arguments, which are positional
+// and have the limitation that if a call site specifies a value for one
+// argument, it must also specify values for all previous arguments.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_3C_OPTIONALPARAMS_H
+#define LLVM_CLANG_3C_OPTIONALPARAMS_H
+
+// The basic ideas of the code pattern, for a function `foo`:
+//
+// 1. Define a struct `FooOpts` to hold the optional "parameters", and use
+//    default member initializers to specify the desired default values.
+// 2. Declare `foo` to take a final parameter `const FooOpts &Opts = {}`. (The
+//    default argument `{}` corresponds to a `FooOpts` with all the default
+//    values.)
+// 3. In the body of `foo`, use the `UNPACK_OPTS` macro to copy the fields of
+//    `Opts` to local variables for convenient access.
+// 4. At call sites, use a macro to generate an immediately invoked lambda that
+//    generates a `FooOpts` instance with the desired values. We could
+//    alternatively use designated initializers if they were supported in our
+//    target C++ standard.
+//
+// In two places in the current pattern, optional parameters are simply copied
+// by value, which gives rise to several limitations: we have to use pointers
+// (`T *`) instead of references (`T &`), and there may be a performance cost to
+// the copying. We may be able to overcome these limitations in the future with
+// additional tricks such as using wrapper objects with an overloaded `=`
+// operator for the members of `FooOpts`, but it doesn't seem worth it yet (as
+// of 2021-07-09).
+//
+// Further design discussion:
+// https://github.com/correctcomputation/checkedc-clang/issues/621
+// https://github.com/correctcomputation/checkedc-clang/pull/638
+//
+// A simple example is included at the bottom of this file, after the
+// implementation. That way, you can explore it in your IDE by changing the `#if
+// 0` to `#if 1`, at the cost of having to scroll down to reach it. For an
+// example of an actual use, see ConstraintVariable::mkString.
+
+// IMPLEMENTATION:
+
+// This currently supports up to 6 optional parameters for a given function. It
+// should be clear how to extend the pattern of macros to increase the limit.
+
+// Our internal macro names are prefixed with `_OP_` (for "optional parameters")
+// in an attempt to avoid accidental collisions with anything else in the LLVM
+// monorepo.
+
+// Helpers:
+
+// Workaround for an MSVC bug where if a macro body passes __VA_ARGS__ to
+// another macro (called M in this discussion), M receives a single argument
+// containing commas instead of a variable number of arguments. For reasons we
+// haven't researched, placing this wrapper around the entire macro body seems
+// to avoid the problem.
+//
+// _OP_MSVC_VA_ARGS_WORKAROUND is needed only when M declares individual
+// parameters and we need the arguments to be matched up with those parameters.
+// If M just declares `...` and passes it on to another macro with __VA_ARGS__,
+// it's generally harmless to let M receive a single argument containing commas;
+// the argument will be correctly split up by _OP_MSVC_VA_ARGS_WORKAROUND later.
+//
+// We should be able to remove this workaround when the 3C Windows build moves
+// to the "new" MSVC preprocessor. See
+// https://developercommunity.visualstudio.com/t/-va-args-seems-to-be-trated-as-a-single-parameter/460154.
+#define _OP_MSVC_VA_ARGS_WORKAROUND(_x) _x
+
+#define _OP_GET_ARG7(_1, _2, _3, _4, _5, _6, _7, ...) _7
+// Precondition: The number of arguments is between 1 and 6 inclusive.
+//
+// The `_dummy` is because according to the C++ standard, at least one argument
+// must be passed to a `...` parameter
+// (https://en.cppreference.com/w/cpp/preprocessor/replace).
+#define _OP_COUNT_ARGS(...)                                                    \
+  _OP_MSVC_VA_ARGS_WORKAROUND(                                                 \
+      _OP_GET_ARG7(__VA_ARGS__, 6, 5, 4, 3, 2, 1, _dummy))
+
+// Each _i argument is expected to be of the form `field = expr`, so we generate
+// a statement of the form `_s.field = expr;` to set the struct field.
+#define _OP_ASSIGN_FIELDS_1(_i1) _s._i1;
+#define _OP_ASSIGN_FIELDS_2(_i1, _i2)                                          \
+  _s._i1;                                                                      \
+  _s._i2;
+#define _OP_ASSIGN_FIELDS_3(_i1, _i2, _i3)                                     \
+  _s._i1;                                                                      \
+  _s._i2;                                                                      \
+  _s._i3;
+#define _OP_ASSIGN_FIELDS_4(_i1, _i2, _i3, _i4)                                \
+  _s._i1;                                                                      \
+  _s._i2;                                                                      \
+  _s._i3;                                                                      \
+  _s._i4;
+#define _OP_ASSIGN_FIELDS_5(_i1, _i2, _i3, _i4, _i5)                           \
+  _s._i1;                                                                      \
+  _s._i2;                                                                      \
+  _s._i3;                                                                      \
+  _s._i4;                                                                      \
+  _s._i5;
+#define _OP_ASSIGN_FIELDS_6(_i1, _i2, _i3, _i4, _i5, _i6)                      \
+  _s._i1;                                                                      \
+  _s._i2;                                                                      \
+  _s._i3;                                                                      \
+  _s._i4;                                                                      \
+  _s._i5;                                                                      \
+  _s._i6;
+#define _OP_ASSIGN_FIELDS(_count, ...)                                         \
+  _OP_MSVC_VA_ARGS_WORKAROUND(_OP_ASSIGN_FIELDS_##_count(__VA_ARGS__))
+// In _OP_ASSIGN_FIELDS, ## takes precedence over the expansion of the _count
+// argument, so if we let PACK_OPTS call `_OP_ASSIGN_FIELDS(_OP_COUNT_ARGS(foo),
+// bar)` directly, we'd end up with `_OP_ASSIGN_FIELDS__COUNT_ARGS(foo)(bar)`.
+// _OP_ASSIGN_FIELDS_WRAP expands its _count argument before calling
+// _OP_ASSIGN_FIELDS, working around the problem. See the second example on
+// https://gcc.gnu.org/onlinedocs/cpp/Argument-Prescan.html.
+#define _OP_ASSIGN_FIELDS_WRAP(_count, ...)                                    \
+  _OP_ASSIGN_FIELDS(_count, __VA_ARGS__)
+
+// PACK_OPTS currently doesn't support passing an empty list of fields to the
+// `...`, because in the current usage for optional parameters, we expect the
+// whole struct to be omitted if no optional parameters need to be passed.
+#define PACK_OPTS(_type, ...)                                                  \
+  ([&] {                                                                       \
+    _type _s;                                                                  \
+    _OP_ASSIGN_FIELDS_WRAP(_OP_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)           \
+    return _s;                                                                 \
+  })()
+
+// `(void)_f` suppresses "unused variable" warnings: see the comment on
+// LLVM_ATTRIBUTE_UNUSED in llvm/include/llvm/Support/Compiler.h.
+#define _OP_UNPACK_OPT(_f)                                                     \
+  auto _f = Opts._f;                                                           \
+  (void)_f;
+#define _OP_UNPACK_OPTS_1(_f1) _OP_UNPACK_OPT(_f1)
+#define _OP_UNPACK_OPTS_2(_f1, _f2) _OP_UNPACK_OPT(_f1) _OP_UNPACK_OPT(_f2)
+#define _OP_UNPACK_OPTS_3(_f1, _f2, _f3)                                       \
+  _OP_UNPACK_OPT(_f1) _OP_UNPACK_OPT(_f2) _OP_UNPACK_OPT(_f3)
+#define _OP_UNPACK_OPTS_4(_f1, _f2, _f3, _f4)                                  \
+  _OP_UNPACK_OPT(_f1)                                                          \
+  _OP_UNPACK_OPT(_f2) _OP_UNPACK_OPT(_f3) _OP_UNPACK_OPT(_f4)
+#define _OP_UNPACK_OPTS_5(_f1, _f2, _f3, _f4, _f5)                             \
+  _OP_UNPACK_OPT(_f1)                                                          \
+  _OP_UNPACK_OPT(_f2)                                                          \
+  _OP_UNPACK_OPT(_f3) _OP_UNPACK_OPT(_f4) _OP_UNPACK_OPT(_f5)
+#define _OP_UNPACK_OPTS_6(_f1, _f2, _f3, _f4, _f5, _f6)                        \
+  _OP_UNPACK_OPT(_f1)                                                          \
+  _OP_UNPACK_OPT(_f2)                                                          \
+  _OP_UNPACK_OPT(_f3)                                                          \
+  _OP_UNPACK_OPT(_f4) _OP_UNPACK_OPT(_f5) _OP_UNPACK_OPT(_f6)
+#define _OP_UNPACK_OPTS_IMPL(_count, ...)                                      \
+  _OP_MSVC_VA_ARGS_WORKAROUND(_OP_UNPACK_OPTS_##_count(__VA_ARGS__))
+// Ditto the comment on _OP_ASSIGN_FIELDS_WRAP.
+#define _OP_UNPACK_OPTS_WRAP(_count, ...)                                      \
+  _OP_UNPACK_OPTS_IMPL(_count, __VA_ARGS__)
+// UNPACK_OPTS doesn't support an empty list of parameters: the UNPACK_OPTS call
+// should just be omitted in that case.
+#define UNPACK_OPTS(...)                                                       \
+  _OP_UNPACK_OPTS_WRAP(_OP_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+// EXAMPLE (change `#if 0` to `#if 1` to explore it in your IDE):
+
+#if 0
+
+struct FooOpts {
+  std::string B = "hello";
+  bool C = false;
+};
+
+#define FOO_OPTS(...) PACK_OPTS(FooOpts, __VA_ARGS__)
+
+void foo(int A, const FooOpts &Opts = {}) {
+  UNPACK_OPTS(B, C);
+#if 0 // Avoid "duplicate local variable" errors in this illustration.
+  // Expansion:
+  auto B = Opts.B;
+  // Suppresses an "unused variable" warning if FooOpts is shared by several
+  // functions that take the same optional parameters (e.g., virtual overrides)
+  // and some of those functions don't actually read all the parameters.
+  (void)B;
+  auto C = Opts.C;
+  (void)C;
+#endif
+
+  llvm::errs() << "A is " << A << ", B is " << B << ", C is " << C << "\n";
+}
+
+void test() {
+  foo(1);
+  foo(2, FOO_OPTS(B = "goodbye"));
+  // Expansion (notice how we conveniently concatenated `_s.` and the argument
+  // `B = "goodbye"`):
+  foo(2, ([&] {
+        FooOpts _s;
+        _s.B = "goodbye";
+        return _s;
+      })());
+
+  foo(3, FOO_OPTS(C = true));
+  foo(4, FOO_OPTS(B = "goodbye", C = true));
+}
+
+#endif // example
+
+#endif // LLVM_CLANG_3C_OPTIONALPARAMS_H

--- a/clang/lib/3C/CastPlacement.cpp
+++ b/clang/lib/3C/CastPlacement.cpp
@@ -154,8 +154,11 @@ CastPlacementVisitor::getCastString(ConstraintVariable *Dst,
                                     CastNeeded CastKind) {
   switch (CastKind) {
   case CAST_NT_ARRAY:
-    return std::make_pair(
-        "((" + Dst->mkString(Info.getConstraints(), false) + ")", ")");
+    return std::make_pair("((" +
+                              Dst->mkString(Info.getConstraints(),
+                                            MKSTRING_OPTS(EmitName = false)) +
+                              ")",
+                          ")");
   case CAST_TO_WILD:
     return std::make_pair("((" + Dst->getRewritableOriginalTy() + ")", ")");
   case CAST_TO_CHECKED: {
@@ -182,7 +185,8 @@ CastPlacementVisitor::getCastString(ConstraintVariable *Dst,
       }
     }
     return std::make_pair("_Assume_bounds_cast<" +
-                              Dst->mkString(Info.getConstraints(), false) +
+                              Dst->mkString(Info.getConstraints(),
+                                            MKSTRING_OPTS(EmitName = false)) +
                               ">(",
                           Suffix);
   }

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -721,11 +721,11 @@ std::string PointerVariableConstraint::gatherQualStrings(void) const {
   return S.str();
 }
 
-std::string PointerVariableConstraint::mkString(Constraints &CS, bool EmitName,
-                                                bool ForItype, bool EmitPointee,
-                                                bool UnmaskTypedef,
-                                                std::string UseName,
-                                                bool ForItypeBase) const {
+std::string
+PointerVariableConstraint::mkString(Constraints &CS,
+                                    const MkStringOpts &Opts) const {
+  UNPACK_OPTS(EmitName, ForItype, EmitPointee, UnmaskTypedef, UseName,
+              ForItypeBase);
 
   // The name field encodes if this variable is the return type for a function.
   // TODO: store this information in a separate field.
@@ -905,10 +905,11 @@ std::string PointerVariableConstraint::mkString(Constraints &CS, bool EmitName,
       }
       bool EmitFVName = !FptrInner.str().empty();
       if (EmitFVName)
-        Ss << FV->mkString(CS, true, false, false, false, FptrInner.str(),
-                           ForItypeBase);
+        Ss << FV->mkString(CS, MKSTRING_OPTS(UseName = FptrInner.str(),
+                                             ForItypeBase = ForItypeBase));
       else
-        Ss << FV->mkString(CS, false, false, false, false, "", ForItypeBase);
+        Ss << FV->mkString(
+            CS, MKSTRING_OPTS(EmitName = false, ForItypeBase = ForItypeBase));
     } else if (TypedefLevelInfo.HasTypedef) {
       std::ostringstream Buf;
       getQualString(TypedefLevelInfo.TypedefLevel, Buf);
@@ -1532,12 +1533,11 @@ bool FunctionVariableConstraint::solutionEqualTo(Constraints &CS,
   return Ret;
 }
 
-std::string FunctionVariableConstraint::mkString(Constraints &CS, bool EmitName,
-                                                 bool ForItype,
-                                                 bool EmitPointee,
-                                                 bool UnmaskTypedef,
-                                                 std::string UseName,
-                                                 bool ForItypeBase) const {
+std::string
+FunctionVariableConstraint::mkString(Constraints &CS,
+                                     const MkStringOpts &Opts) const {
+  UNPACK_OPTS(EmitName, ForItype, EmitPointee, UnmaskTypedef, UseName,
+              ForItypeBase);
   if (UseName.empty())
     UseName = Name;
   std::string Ret = ReturnVar.mkTypeStr(CS, false, "", ForItypeBase);
@@ -2058,8 +2058,9 @@ std::string FVComponentVariable::mkTypeStr(Constraints &CS, bool EmitName,
   // variable. Because the call is passed ForItypeBase, it will emit an
   // unchecked type instead of the solved type.
   if (ForItypeBase || hasCheckedSolution(CS) || (EmitName && !UseName.empty())) {
-    Ret = ExternalConstraint->mkString(CS, EmitName, false, false, false,
-                                       UseName, ForItypeBase);
+    Ret = ExternalConstraint->mkString(
+        CS, MKSTRING_OPTS(EmitName = EmitName, UseName = UseName,
+                          ForItypeBase = ForItypeBase));
   } else {
     // if no need to generate type, try to use source
     if (!SourceDeclaration.empty())
@@ -2085,7 +2086,10 @@ std::string FVComponentVariable::mkTypeStr(Constraints &CS, bool EmitName,
 std::string
 FVComponentVariable::mkItypeStr(Constraints &CS, bool ForItypeBase) const {
   if (!ForItypeBase && hasItypeSolution(CS))
-    return " : itype(" + ExternalConstraint->mkString(CS, false, true) + ")";
+    return " : itype(" +
+           ExternalConstraint->mkString(
+               CS, MKSTRING_OPTS(EmitName = false, ForItype = true)) +
+           ")";
   return "";
 }
 

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -42,8 +42,8 @@ void DeclRewriter::buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
     // unchecked type from the PVConstraint. The last argument of this call
     // tells mkString to generate a string using unchecked types instead of
     // checked types.
-    Type = Defn->mkString(Info.getConstraints(), true, false, false, false, "",
-                          true);
+    Type = Defn->mkString(Info.getConstraints(),
+                          MKSTRING_OPTS(ForItypeBase = true));
   } else {
     Type = Defn->getRewritableOriginalTy();
     if (isa_and_nonnull<ParmVarDecl>(Decl)) {
@@ -68,9 +68,12 @@ void DeclRewriter::buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
     // type to the declaration so that it can be used in checked code.
     // TODO: This could potentially be applied to typedef types even when the
     //       flag is not passed to limit spread of wildness through typedefs.
-    IType += Defn->mkString(Info.getConstraints(), false, true, false, true);
+    IType += Defn->mkString(Info.getConstraints(),
+                            MKSTRING_OPTS(EmitName = false, ForItype = true,
+                                          UnmaskTypedef = true));
   } else {
-    IType += Defn->mkString(Info.getConstraints(), false, true);
+    IType += Defn->mkString(Info.getConstraints(),
+                            MKSTRING_OPTS(EmitName = false, ForItype = true));
   }
   IType += ")" + ABR.getBoundsString(Defn, Decl, true);
 }
@@ -113,7 +116,8 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
           if (Var.anyChanges(Env)) {
             std::string NewTy =
                 getStorageQualifierString(D) +
-                Var.mkString(Info.getConstraints(), true, false, false, true);
+                Var.mkString(Info.getConstraints(),
+                             MKSTRING_OPTS(UnmaskTypedef = true));
             RewriteThese.insert(new TypedefDeclReplacement(TD, nullptr, NewTy));
           }
         }
@@ -737,7 +741,7 @@ void FunctionDeclBuilder::buildCheckedDecl(
     std::string &IType, std::string UseName, bool &RewriteParm,
     bool &RewriteRet) {
   Type =
-      Defn->mkString(Info.getConstraints(), true, false, false, false, UseName);
+      Defn->mkString(Info.getConstraints(), MKSTRING_OPTS(UseName = UseName));
   //IType = getExistingIType(Defn);
   IType = ABRewriter.getBoundsString(Defn, Decl, !IType.empty());
   RewriteParm |= getExistingIType(Defn).empty() != IType.empty() ||

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -422,7 +422,8 @@ private:
       // Replace the original type with this new one if the type has changed.
       if (CV->anyChanges(Vars)) {
         rewriteSourceRange(Writer, Range,
-                           CV->mkString(Info.getConstraints(), false));
+                           CV->mkString(Info.getConstraints(),
+                                        MKSTRING_OPTS(EmitName = false)));
         PState.incrementNumFixedCasts();
       }
   }
@@ -451,8 +452,9 @@ public:
         for (auto Entry : Info.getTypeParamBindings(CE, Context))
           if (Entry.second != nullptr) {
             AllInconsistent = false;
-            std::string TyStr = Entry.second->mkString(Info.getConstraints(),
-                                                       false, false, true);
+            std::string TyStr = Entry.second->mkString(
+                Info.getConstraints(),
+                MKSTRING_OPTS(EmitName = false, EmitPointee = true));
             if (TyStr.back() == ' ')
               TyStr.pop_back();
             TypeParamString += TyStr + ",";


### PR DESCRIPTION
I'm submitting this proof-of-concept PR so we can decide whether we think this change is an improvement on the status quo before I put more work into polishing it.

I used approach (6) from #621, which is the one I would recommend since it has relatively low boilerplate and the generated code is relatively easy to understand.  This approach has some potential limitations (there are copy operations that I'm not sure will be optimized out, and if we wanted to pass a `T &`, we would have to pass a `T *` instead); none of them seriously affect `mkString`, but we should consider them before committing to the approach for the future.