### PR TITLE
Make the wild constraint variable used for unsafe mallocs generic

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -54,7 +54,7 @@ PointerVariableConstraint *PointerVariableConstraint::getWildPVConstraint(
   WildPVC->Vars.push_back(VA);
   WildPVC->SrcVars.push_back(CS.getWild());
 
-  // Mark this constraint variable is generic. This is done because we do not
+  // Mark this constraint variable as generic. This is done because we do not
   // know the type of the constraint, and therefore we also don't know the
   // number of atoms it needs to have. Fortunately, it's already WILD, so any
   // constraint made with it will force the other constraint to WILD, safely

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -54,6 +54,13 @@ PointerVariableConstraint *PointerVariableConstraint::getWildPVConstraint(
   WildPVC->Vars.push_back(VA);
   WildPVC->SrcVars.push_back(CS.getWild());
 
+  // Mark this constraint variable is generic. This is done because we do not
+  // know the type of the constraint, and therefore we also don't know the
+  // number of atoms it needs to have. Fortunately, it's already WILD, so any
+  // constraint made with it will force the other constraint to WILD, safely
+  // handling assignment between incompatible pointer depths.
+  WildPVC->GenericIndex = 0;
+
   return WildPVC;
 }
 

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -34,6 +34,7 @@ void test1() {
   c++; // expected-warning {{1 unchecked pointer: Pointer arithmetic performed on a function pointer}}
 
   int *d = malloc(1); // expected-warning {{1 unchecked pointer: Unsafe call to allocator function}}
+  int **e = malloc(1); // expected-warning {{1 unchecked pointer: Unsafe call to allocator function}}
 }
 
 // expected-warning@+1 {{1 unchecked pointer: External global variable glob has no definition}}


### PR DESCRIPTION
This fixes issue correctcomputation/checkedc-clang#673 by making the wild constraint variable used for unsafe allocator calls a generic variable. This allows it to be used in constraints with other variables of arbitrary pointer depth without triggering incompatible pointer type constraints.