### PR TITLE
Change test7 in functionDeclEnd.c to infer a valid bound

### DIFF
--- a/clang/test/3C/functionDeclEnd.c
+++ b/clang/test/3C/functionDeclEnd.c
@@ -126,7 +126,7 @@ void test6(int *a)
 int *test7(int *a)
     : count(10)
 //CHECK_NOALL: int *test7(int *a : itype(_Ptr<int>)) : count(10)
-//CHECK_ALL: _Array_ptr<int> test7(_Array_ptr<int> a) : count(10)
+//CHECK_ALL: _Array_ptr<int> test7(_Array_ptr<int> a : count(10)) : count(10)
 #else
 int *test7(int *a)
     : count(10)
@@ -139,8 +139,10 @@ int *test7(int *a)
 //CHECK: ;
 
 int *test7(int *a) : count(10) {
-  //CHECK_ALL: _Array_ptr<int> test7(_Array_ptr<int> a) : count(10) _Checked {
+  //CHECK_ALL: _Array_ptr<int> test7(_Array_ptr<int> a : count(10)) : count(10) _Checked {
   //CHECK_NOALL: int *test7(int *a : itype(_Ptr<int>)) : count(10) {
+  for (int i = 0; i < 10; i++)
+    a[i];
   return a;
 }
 


### PR DESCRIPTION
Fixes #682.

The purpose of this function was to test function declaration rewriting
for itype array pointers declared with bounds but without an explicit
itype. This is equally well tested when a correct bound is inferred for
the parameter array.

This could probably be done a few other ways. What's important though
is that there is still a bound on the return without an itype expression,
and that that the function declaration is rewritten with and without `-alltypes`.
