### PR TITLE
Merge from Microsoft 2021-08-25

### DIFF
--- a/clang/docs/checkedc/LLVM-Upgrade-Notes.md
+++ b/clang/docs/checkedc/LLVM-Upgrade-Notes.md
@@ -1,0 +1,38 @@
+# Notes on LLVM/Clang Upgrades
+
+This file gives details about the commit hashes up to which the `baseline` and
+`master` branches of the `checkedc-clang` repository have been upgraded with
+respect to the upstream LLVM/Clang repository.
+
+
+# Upgrade to LLVM/Clang 11.x
+
+The commit hash on the `main` branch of the upstream LLVM/Clang repository
+up to which the `baseline` and the `master` branches of the `checkedc-clang`
+repository have been upgraded:
+&lt;branch-point-of-11-on-main&gt; : 2e10b7a39b930ef8d9c4362509d8835b221fbc0a
+
+Cherry-picked commits (on `master` of `checkedc-clang`) from the upstream
+LLVM/Clang repository:
+Details not available.
+
+The branch `release_11.x` of the `checkedc-clang` repository is upgraded to
+&lt;llvm-11.1.0-commit-hash&gt; : 1fdec59bffc11ae37eb51a1b9869f0696bfd5312
+
+
+# Upgrade to LLVM/Clang 12.x
+
+The commit hash on the `main` branch of the upstream LLVM/Clang repository
+up to which the `baseline` and the `master` branches of the `checkedc-clang`
+repository have been upgraded:
+&lt;branch-point-of-12-on-main&gt; : 8e464dd76befbc4a39a1d21968a3d5f543e29312 
+
+Cherry-picked commits (on `master` of `checkedc-clang`) from the upstream
+LLVM/Clang repository:
+
+  - Commit hash 0024efc69ea6cd0b630cd11cef5991b7edb73ffc on the `main` branch
+    of the upstream LLVM/Clang repo (See LLVM/Clang bug
+    [#48920](https://bugs.llvm.org/show_bug.cgi?id=48920) for details.)
+
+The branch `release_12.x` of the `checkedc-clang` repository is upgraded to
+&lt;llvm-12.0.1-commit-hash&gt; : fed41342a82f5a3a9201819a82bf7a48313e296b

--- a/clang/docs/checkedc/Update-to-latest-LLVM-sources.md
+++ b/clang/docs/checkedc/Update-to-latest-LLVM-sources.md
@@ -1,81 +1,251 @@
 # Instructions for updating to the latest LLVM/Clang sources
 
-We are staying in sync with the LLVM/Clang mainline sources.   The baseline branch is a pristine copy of
-LLVM/Clang sources.  We periodically update the baseline branch and then push the changes to other branches.
+We are staying in sync with the upstream LLVM/Clang repository. The `baseline`
+branch of the `checkedc-clang` repository is a pristine copy of LLVM/Clang
+sources, and the `master` branch contains LLVM/Clang sources plus the support
+for Checked C language extensions. We periodically upgrade the `baseline` branch
+and the `master` branch to the sources of the most recent releases from the
+upstream LLVM/Clang repository.
 
-The first step is to create updated baseline branches:
-1. Create new branches of your local baseline branches (we suggest creating new
-branches so that you can run automated testing. You'll need new branches
-that you can push to GitHub).
-2. Update those branches to the latest sources.
-3. Run testing on those branches to make sure things are stable.
+The branching and merging policies of the `checkedc-clang` repository are
+aligned with the versioning and branching of upstream LLVM/Clang repository in
+order to closely follow the LLVM/Clang releases. LLVM/Clang releases are
+versioned as &lt;major-version&gt;.&lt;minor-version&gt;.&lt;patch-version&gt;.
+The LLVM/Clang repository has a branch called `main`, and several release
+branches (created off `main`) called `release/<major-version>.x`, each
+corresponding to the major version number of a release. New features go on the
+`main` branch. At an appropriate commit on the `main` branch, a release branch
+is created. Bug fixes go on the release branch and only some of these bug fixes
+get merged back into the `main` branch. Typically, LLVM/Clang makes two final
+releases for each major version.
 
-The second step is to create updated master branches:
-  1. Create branches of your updated baseline branches.
-  2. Merge changes from the Checked C master branches into those branches.
-  3. Fix merge conflicts and run testing.  You will likely need to fix some issues
-     and re-run testing until all issues are fixed.
+Now we describe our approach for upgrading the `checkedc-clang` repository to
+LLVM/Clang sources corresponding to the two releases for each major version,
+for example, 12.0.0 and 12.0.1. The upgrade is performed in two phases as
+described below. This description is followed by detailed instructions for each
+phase.
 
-The third step is to merge your changes back into your baseline and master branches.
+**Phase 1**: We upgrade the `master` branch of the `checkedc-clang` repository
+up to the commit hash on the `main` branch of the LLVM/Clang repository at which
+the branch `release/12.x` is created - we shall refer to this commit hash as
+&lt;branch-point-of-12-on-main&gt;. We get this commit hash by executing the
+command `git merge-base main release/12.x` in a clone of the LLVM/Clang
+repository. Note that &lt;branch-point-of-12-on-main&gt;
+needs to be the full commit hash and not just the 7-digit abbreviation. This
+phase constitutes the major portion of the developer effort towards the merge.
 
-## Create updated branches of your baseline branches
+**Phase 2**: We create a branch called `release_12.x` off the `master` branch in
+the `checkedc-clang` repository. Then there are two sub-phases:
+   - When we wish to make a Checked C compiler release based on the 12.0.0
+   release of LLVM/Clang:
+      - We first upgrade the `release_12.x` branch (of the `checkedc-clang`
+      repository) to the sources corresponding to the 12.0.0 release on the
+      `release/12.x` branch of the LLVM/Clang repository.
+      - Next, we merge Checked C features and bug fixes from the `master` branch
+      to the `release_12.x` branch.
+      - The release of the Checked C compiler happens from the `release_12.x`
+      branch.
+   - When we wish to make a Checked C compiler release based on the 12.0.1
+   release of LLVM/Clang:
+      - We upgrade the same `release_12.x` branch (of the `checkedc-clang`
+      repository) to the sources corresponding to the 12.0.1 release on the
+      `release/12.x` branch of the LLVM/Clang repository.
+      - Next, we merge Checked C features and bug fixes from the `master` branch
+      to the `release_12.x` branch.
+      - The release of the Checked C compiler happens from the `release_12.x`
+      branch.
+      
 
-First create remote to the mirrored GitHub repo that contains the updated sources
-for LLVM/Clang. Go to your LLVM/Clang repo and do:
+We do not expect substantial developer effort to be expended in Phase 2 as it is
+highly unlikely that the bug fixes on the release branches of the LLVM/Clang
+repository will break Checked C build and tests. 
 
-    git remote add mirror https://github.com/llvm-mirror/llvm-project
+Note that Phase 1 and the sub-phases of Phase 2 may not be executed one after
+another in one continuous stretch. They may be spread over several weeks and may
+be interspersed with Checked C development on the `master` branch.
 
-Then branch your baseline branch and merge changes into it:
+## Detailed Instructions - Phase 1
 
+1. Create a new branch off the `baseline` branch in the `checkedc-clang`
+repository. Let us call this new branch `updated_baseline`.
+```        
+    git checkout -b updated_baseline baseline
+```     
+2. Upgrade the branch `updated_baseline` to &lt;branch-point-of-12-on-main&gt;
+commit hash on the `main` branch of the LLVM/Clang repository. Record the commit
+hash &lt;branch-point-of-12-on-main&gt; in the document LLVM-Upgrade-Notes.md.
+```
+    git remote add upstream https://github.com/llvm/llvm-project.git 
+    git pull upstream <branch-point-of-12-on-main>
+```
+3. Execute LLVM/Clang tests on the branch `updated_baseline` on your local
+machine to make sure that the upgrade is stable.
+
+4. Merge the `updated_baseline` branch back to the `baseline` branch. We expect
+branch `updated_baseline` to be a descendant of branch `baseline`.
+```
     git checkout baseline
-    git checkout -b updated-baseline
-    git pull mirror master
+    git merge --ff-only updated_baseline
+```
+5. Create a new branch, say, `updated_baseline_master_12` from the `baseline`
+branch.
+```
+    git checkout -b updated_baseline_master_12 baseline
+```
+6. Merge the `master` branch of the checkedc-clang repository into the
+`updated_baseline_master_12` branch. This merge may cause several merge
+conflicts and test case failures. After the merge command, git may suggest to
+you to set `merge.renamelimit` to a specific value. It is a good idea to set it
+as suggested and re-run the merge. The last section in this document gives
+guidelines on fixing the merge conflicts and test failures.
+```
+    git checkout updated_baseline_master_12
+    git merge master > merge_conflict_list.txt
+``` 
+7. The resolution of test failures may require you to cherry-pick commits from
+the upstream LLVM/Clang repository. Record the cherry-picked commits in the
+document LLVM-Upgrade-Notes.md. Let &lt;commit-to-cherry-pick&gt; be one
+such commit hash on branch &lt;cherry-pick-branch&gt; of the LLVM/Clang
+repository. 
+```
+    git fetch upstream <cherry-pick-branch>
+    git cherry-pick -x <commit-to-cherry-pick>
+```
+8. While the merge conflicts and test failures are being fixed, it is possible
+that the `master` branch has had several commits. Merge the `master` branch into
+`updated_baseline_master_12` branch, and resolve the new conflicts and failures
+if necessary.
+```
+    git merge master >> merge_conflict_list.txt
+```
+9. After all the merge conflicts and test failures on the local machine are
+fixed, push the `baseline` and `updated_baseline_master_12` branches to the
+remote repository and execute the ADO tests on branch 
+`updated_baseline_master_12`. Commits to the `master` branch should be held off
+during the final execution of these tests, i.e. just prior to executing step 10
+below. 
+```
+    git push origin baseline
+    git push origin updated_baseline_master_12
+```
+10. After the ADO tests are successful, merge the `updated_baseline_master_12`
+branch into `master` and push to the remote repository. If all the changes on
+the `master` branch have been merged into the `updated_baseline_master_12`
+branch in step 8, then it should be possible to do a fast-forward merge of
+branch `updated_baseline_master_12` into the `master` branch.
+```
+    git checkout master
+    git merge --ff-only updated_baseline_master_12
+    git push origin master
+```
 
-## Run testing on your branched baseline branches.
+## Detailed Instructions - Phase 2
+We give the instructions for the first sub-phase of Phase 2. Similar steps
+have to be followed for the other sub-phase.
 
-You can run testing locally or push your branched baseline branches to GitHub
-and use automated testing.  This will show you whether there are any unexpected
-failures in your baseline branch.
-
-If you use automated testing, make sure to clean the build directory first.
-Enough changes will likely have accumulated that things may go wrong without doing
-that first.
-
-## Branch your new baseline branches and merge master changes
-
-You can now branch your baseline branches to create a new master branch:
-
-    git checkout -b updated-master
+1. Create a new branch, called `release_12.x`, from the `master` branch in the
+`checkedc-clang` repository. If the branch already exists, then merge the
+`master` branch into it. Resolve merge conflicts and test failures if any.
+```        
+    git checkout -b release_12.x master
+    OR
+    git checkout release_12.x
     git merge master
+```     
+2. Upgrade the branch `release_12.x` to the LLVM/Clang sources corresponding to
+the 12.0.0 release. The commit hash associated with the 12.0.0 release is given
+by the LLVM/Clang tag `llvmorg-12.0.0`. Resolve merge conflicts and test
+failures if any. Record the fact that the `release_12.x` branch has been
+upgraded upto the commit hash given by the `llvmorg-12.0.0` tag, in the document
+LLVM-Upgrade-Notes.md.
+```
+    git remote add upstream https://github.com/llvm/llvm-project.git
+    git pull upstream llvmorg-12.0.0
+```
+3. Push the branch `release_12.x` to the remote repository, run ADO tests
+on it and fix test failures to make sure that the branch is stable.
+```
+    git push origin release_12.x
+```
+## Practical Tips
 
-You will very likely have merge conflicts and some test failures.  The test
-failures usually stem from incorrect merges or Checked C-specific data not being
-initialized by new or changed constructor methods.
+1. If you use automated testing, make sure to clean the build directory first.
+Enough changes will likely have accumulated that things may go wrong without
+doing that first.
 
-You may also need to pick up changes from LLVM/Clang for fixes to any unexpected
-baseline failures.
+2. The test failures usually stem from incorrect merges or Checked C-specific data
+not being initialized by new or changed constructor methods.
 
-You can push your updated master branches up to GitHub for automated
-testing.  If you haven't cleaned the build directory as described earlier,
-make sure you do that.
-
-You'll want to run automated tests on Linux and Windows x86/x64, as well as
+3. You'll want to run automated tests on Linux and Windows x86/x64, as well as
 Linux LNT tests.  You may find in some cases that tests need to be updated
 based on new warnings or slightly different compiler behavior.
 
-## Merge your branched baseline and master branches
-
-Once all testing is passing, you can merge your branches back into
-your baseline and master branches.
-
-
-    git checkout baseline
-    git merge updated-baseline
-    git checkout master
-    git merge updated-master
-
-## Push the updated branches to GitHub
-
-The changes will be extensive enough that you don't want to do a pull request
+4. The changes will be extensive enough that you don't want to do a pull request
 on GitHub.  Just push the branches up to GitHub.
 
+
+## Handling Merge Conflicts and Test Failures
+
+1. When `merge.renamelimit` is set to a large value, the output of the
+`git merge` command may have several lines like:
+    - CONFLICT (rename/delete): ... in master renamed to ... in HEAD. Version
+    HEAD ... left in tree.
+    - CONFLICT (rename/delete): ... in master renamed to ... in HEAD. Version
+    master ... left in tree.
+
+    If the version in HEAD is left in tree, it is very likely a valid change -
+    the file may have been moved. If the version in `master` is left in tree,
+    the files may be valid files that have been added as part of Checked C
+    support:
+    - `llvm/projects/checkedc-wrapper/lit.site.cfg.py`
+    - `llvm/projects/checkedc-wrapper/lit.cfg.py`
+
+    Others may need more investigation. For example, in the LLVM/Clang 11 to 12
+    merge, two files which were reported by git as "Version master ... left in
+    tree" were old versions lying around that needed to be deleted:
+    - `clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTAPI.h`
+    - `clang/include/clang/AST/TypeNodes.def`
+
+2. While resolving merge conflicts, it is a good idea to have three reference
+code snapshots to perform diffs of individual files to help distinguish between
+checkedc-specific changes and llvm-11-to-12 changes:
+    - The `master` branch of the `checkedc-clang` repository at the commit hash
+  which was merged into `updated_baseline_master_12`.
+    - The pristine LLVM/Clang source at &lt;branch-point-of-11-on-main&gt;
+    - The pristine LLVM/Clang source at &lt;branch-point-of-12-on-main&gt;
+
+    The description of the three snapshots above holds only for the initial 
+    merge from LLVM 11 to 12 in phase 1 step 6. For a merge of additional
+    Checked C feature development in phase 1 step 8, here are the relevant
+    snapshots and their commit hashes, which we get from the in-progress merge:
+    - A snapshot of branch `updated_baseline_master_12` after phase 1 step 7, or
+    an earlier iteration of step 8. The commit hash that corresponds to this
+    snapshot is `HEAD` - use command `git rev-parse HEAD` to dump the commit
+    hash.
+    - A snapshot of the `master` branch that participated in the previous merge
+    that produced the above snapshot. The commit hash that corresponds to this
+    snapshot is the common ancestor - use command
+    `git merge-base HEAD MERGE_HEAD` to dump the commit hash.
+    - A snapshot of the current `master` branch. The commit hash that
+    corresponds to this is `MERGE_HEAD` - use command `git rev-parse MERGE_HEAD`
+    to dump the commit hash.
+
+    Here are some alternatives to the above approach of using source snapshots
+    to manually perform diffs of the relevant files:
+    - Run `git mergetool` - you may need to have a merge tool that is suitable
+    for your environment (Linux/Windows) installed and configured
+    (ex.: `kdiff3`).
+    - Set `git config merge.conflictstyle diff3` before running `git merge` so
+    that the conflict markup written to the file shows all three versions rather
+    than just two.
+    - Run
+    `git show :1:clang/path/to/some/File.cpp > clang/path/to/some/File.1.cpp`
+    (and similarly with 2 or 3 in place of 1) to write out the three versions
+    for inspection with other tools.
+
+3. When bitfields are modified (or need modification to accommodate changes
+related to Checked C) in files like `clang/include/clang/AST/Stmt.h` (see
+commit hash af12895f631), and `clang/include/clang/AST/DeclBase.h` (see the diff
+between commits bc556e5 and e08e3f6 - this change was required for a previous
+merge), more manual investigation may be needed to check the correctness of the
+changes.

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -102,8 +102,10 @@ protected:
 
     /// The statement class.
     unsigned sClass : 8;
+    /// The checked scope specifier for the statement.
+    unsigned CSS : 2;
   };
-  enum { NumStmtBits = 8 };
+  enum { NumStmtBits = 10 };
 
   class NullStmtBitfields {
     friend class ASTStmtReader;
@@ -1206,6 +1208,14 @@ public:
   }
 
   const char *getStmtClassName() const;
+
+  CheckedScopeSpecifier getCheckedScopeSpecifier() const {
+    return static_cast<CheckedScopeSpecifier>(StmtBits.CSS);
+  }
+
+  void setCheckedScopeSpecifier(CheckedScopeSpecifier CSS) {
+    StmtBits.CSS = CSS;
+  }
 
   /// SourceLocation tokens are not useful in isolation - they are low level
   /// value objects created/interpreted by SourceManager. We assume AST

--- a/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
+++ b/clang/include/clang/Sema/CheckedCAnalysesPrepass.h
@@ -38,9 +38,6 @@ namespace clang {
   // of F in whose declared bounds expressions F occurs.
   using BoundsSiblingFieldsTy = llvm::DenseMap<const FieldDecl *, FieldSetTy>;
 
-  // CheckedScopeMapTy maps a statement to its checked scope specifier.
-  using CheckedScopeMapTy = llvm::DenseMap<const Stmt *, CheckedScopeSpecifier>;
-
   struct PrepassInfo {
     // VarUses maps each VarDecl V in a function to the DeclRefExpr (if any)
     // that is the first use of V, if V fulfills the following conditions:
@@ -85,10 +82,6 @@ namespace clang {
     // a deterministic iteration order we must remember to sort the keys as
     // well as the values.
     BoundsSiblingFieldsTy BoundsSiblingFields;
-
-    // A map of statements to their checked scope specifiers. An entry in this
-    // map is made only when the checked scope specifier changes.
-    CheckedScopeMapTy CheckedScopeMap;
   };
 } // end namespace clang
 #endif

--- a/clang/lib/AST/ExprUtils.cpp
+++ b/clang/lib/AST/ExprUtils.cpp
@@ -469,7 +469,7 @@ void ExprUtil::EnsureEqualBitWidths(llvm::APSInt &A, llvm::APSInt &B) {
 }
 
 bool InverseUtil::IsInvertible(Sema &S, Expr *LValue, Expr *E) {
-  if (!E)
+  if (!E || E->containsErrors())
     return false;
 
   E = E->IgnoreParens();
@@ -628,7 +628,10 @@ bool InverseUtil::IsCastExprInvertible(Sema &S, Expr *LValue, CastExpr *E) {
 }
 
 Expr *InverseUtil::Inverse(Sema &S, Expr *LValue, Expr *F, Expr *E) {
-  if (!F)
+  if (!F || F->containsErrors())
+    return nullptr;
+
+  if (!E || E->containsErrors())
     return nullptr;
 
   E = E->IgnoreParens();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14201,6 +14201,15 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
 
   CheckAddressOfPackedMember(op);
 
+  // For Checked C, &e1[e2] should be a pointer to T if e1 or e2 is a pointer
+  // to T, regardless of checked scope. This avoids the unexpected result of
+  // &e1[e2] having a different type than e1 or e2, which could otherwise
+  // happen in an unchecked scope if e1 or e2 is a checked pointer.
+  if (getLangOpts().CheckedC) {
+    if (ArraySubscriptExpr *arrSubscript = dyn_cast<ArraySubscriptExpr>(op))
+      return arrSubscript->getBase()->getType();
+  }
+
   // Checked scopes change the types of the address-of(&) operator.
   // In a checked scope, the operator produces an array_ptr<T> except for
   // function type. For address-of function type, it produces ptr not array_ptr.

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -436,8 +436,19 @@ StmtResult Sema::ActOnCompoundStmt(SourceLocation L, SourceLocation R,
       DiagnoseEmptyLoopBody(Elts[i], Elts[i + 1]);
   }
 
+  // Set the checked scope specifiers for all statements that are part of this
+  // compound statement.
+  CheckedScopeSpecifier InferredCSS = GetCheckedScopeInfo();
+  for (Stmt *S : Elts) {
+    if (!S)
+      continue;
+    if (auto *L = dyn_cast<LabelStmt>(S))
+      S = L->getSubStmt();
+    S->setCheckedScopeSpecifier(InferredCSS);
+  }
+
   return CompoundStmt::Create(Context, Elts, L, R, WrittenCSS,
-                              GetCheckedScopeInfo(), CSSLoc, CSMLoc);
+                              InferredCSS, CSSLoc, CSMLoc);
 }
 
 ExprResult

--- a/clang/test/CheckedC/inferred-bounds/basic.c
+++ b/clang/test/CheckedC/inferred-bounds/basic.c
@@ -431,8 +431,7 @@ void f42(void) {
 // CHECK: VarDecl {{0x[0-9a-f]+}} {{.*}} r '_Array_ptr<int>' cinit
 // CHECK: |-CountBoundsExpr {{0x[0-9a-f]+}} {{.*}} 'NULL TYPE' Element
 // CHECK: | `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 1
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK:     `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK: | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
@@ -521,8 +520,7 @@ void f43(void) {
 
 // CHECK: BinaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' '='
 // CHECK: |-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'r' '_Array_ptr<int>'
-// CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <BitCast>
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK: `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK: |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK:       | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue Var {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'

--- a/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
+++ b/clang/test/CheckedC/inferred-bounds/equiv-expr-sets.c
@@ -1027,27 +1027,25 @@ void original_value11(array_ptr<int> p, array_ptr<int> q) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Original value of p in (_Array_ptr<int>&p[2]): (int *)p - 2
-  // Updated EquivExprs: { { (int *)p - 2 + 1, q } }
+  // Original value of p in &p[2]: p - 2
+  // Updated EquivExprs: { { p - 2 + 1, q } }
   p = &p[2];
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
-  // CHECK-NEXT:     UnaryOperator {{.*}} 'int *' prefix '&'
-  // CHECK-NEXT:       ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:         ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:           DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:     ArraySubscriptExpr {{.*}} 'int'
+  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'int *' <BitCast>
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:       IntegerLiteral {{.*}} 2
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     IntegerLiteral {{.*}} 2
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'q'
@@ -1127,28 +1125,26 @@ void original_value13(array_ptr<int> p, array_ptr<int> q) {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
-  // Original value of p in (_Array_ptr<int>)&0[&*p]: (int *)p - 0
-  // Updated EquivExprs: { { (int *)p - 0 + 1, q } }
+  // Original value of p in &0[&*p]: p - 0
+  // Updated EquivExprs: { { p - 0 + 1, q } }
   p = &0[&*p];
   // CHECK: Statement S:
   // CHECK-NEXT: BinaryOperator {{.*}} '='
   // CHECK-NEXT:   DeclRefExpr {{.*}} 'p'
-  // CHECK-NEXT:   ImplicitCastExpr {{.*}} '_Array_ptr<int>' <BitCast>
-  // CHECK-NEXT:     UnaryOperator {{.*}} 'int *' prefix '&'
-  // CHECK-NEXT:       ArraySubscriptExpr {{.*}} 'int'
-  // CHECK-NEXT:         IntegerLiteral {{.*}} 0
-  // CHECK-NEXT:         UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
-  // CHECK-NEXT:           UnaryOperator {{.*}} '*'
-  // CHECK-NEXT:             ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:               DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:   UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:     ArraySubscriptExpr {{.*}} 'int'
+  // CHECK-NEXT:       IntegerLiteral {{.*}} 0
+  // CHECK-NEXT:       UnaryOperator {{.*}} '_Array_ptr<int>' prefix '&'
+  // CHECK-NEXT:         UnaryOperator {{.*}} '*'
+  // CHECK-NEXT:           ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:             DeclRefExpr {{.*}} 'p'
   // CHECK: Sets of equivalent expressions after checking S:
   // CHECK-NEXT: {
   // CHECK-NEXT: {
   // CHECK-NEXT: BinaryOperator {{.*}} '+'
   // CHECK-NEXT:   BinaryOperator {{.*}} '-'
-  // CHECK-NEXT:     ImplicitCastExpr {{.*}} 'int *' <BitCast>
-  // CHECK-NEXT:       ImplicitCastExpr {{.*}} <LValueToRValue>
-  // CHECK-NEXT:         DeclRefExpr {{.*}} 'p'
+  // CHECK-NEXT:     ImplicitCastExpr {{.*}} <LValueToRValue>
+  // CHECK-NEXT:       DeclRefExpr {{.*}} 'p'
   // CHECK-NEXT:     IntegerLiteral {{.*}} 0
   // CHECK-NEXT:   IntegerLiteral {{.*}} 1
   // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>

--- a/clang/test/CheckedC/inferred-bounds/ptr-cast.c
+++ b/clang/test/CheckedC/inferred-bounds/ptr-cast.c
@@ -71,7 +71,7 @@ void f2(_Array_ptr<int> p : count(5)) {
 // CHECK: |     |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK: |     | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'
 // CHECK: |     `-IntegerLiteral {{0x[0-9a-f]+}} {{.*}} 'int' 5
-// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} 'int *' prefix '&'
+// CHECK: `-UnaryOperator {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' prefix '&'
 // CHECK:   `-ArraySubscriptExpr {{0x[0-9a-f]+}} {{.*}} 'int' lvalue
 // CHECK:     |-ImplicitCastExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' <LValueToRValue>
 // CHECK:     | `-DeclRefExpr {{0x[0-9a-f]+}} {{.*}} '_Array_ptr<int>' lvalue ParmVar {{0x[0-9a-f]+}} 'p' '_Array_ptr<int>'

--- a/clang/test/CheckedC/inferred-bounds/widened-bounds-complex-conditionals.c
+++ b/clang/test/CheckedC/inferred-bounds/widened-bounds-complex-conditionals.c
@@ -1,0 +1,666 @@
+// Tests for datafow analysis for bounds widening of null-terminated arrays in
+// presence of complex conditionals.
+//
+// RUN: %clang_cc1 -fdump-widened-bounds -verify \
+// RUN: -verify-ignore-unexpected=note -verify-ignore-unexpected=warning %s \
+// RUN: | FileCheck %s
+
+// expected-no-diagnostics
+
+#include <limits.h>
+#include <stdint.h>
+
+int a;
+
+void f1(_Nt_array_ptr<char> p : count(0)) {
+
+  if (*p) {
+    a = 1;
+  } else {
+    a = 2;
+  }
+
+// CHECK: Function: f1
+// CHECK: Block: B7 (Entry), Pred: Succ: B6
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+
+  if (!*p) {
+    a = 3;
+  } else {
+    a = 4;
+  }
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: !*p
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B2, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+
+// CHECK: Block: B1, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+}
+
+void f2(_Nt_array_ptr<char> p : count(i), int i) {
+
+  if (*(p + i) == 0) {
+    a = 1;
+  } else {
+    a = 2;
+  }
+
+// CHECK: Function: f2
+// CHECK: Block: B13 (Entry), Pred: Succ: B12
+
+// CHECK: Block: B12, Pred: B13, Succ: B11, B10
+// CHECK:   Widened bounds before stmt: *(p + i) == 0
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B11, Pred: B12, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B10, Pred: B12, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + i + 1)
+
+  if (*(i + p) != 0) {
+    a = 3;
+  } else {
+    a = 4;
+  }
+
+// CHECK: Block: B9, Pred: B10, B11, Succ: B8, B7
+// CHECK:   Widened bounds before stmt: *(i + p) != 0
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B8, Pred: B9, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, i + p + 1)
+
+// CHECK: Block: B7, Pred: B9, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + i)
+
+  if ('a' == *(p + i)) {
+    a = 5;
+  } else {
+    a = 6;
+  }
+
+// CHECK: Block: B6, Pred: B7, B8, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: 'a' == *(p + i)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B5, Pred: B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + i + 1)
+
+// CHECK: Block: B4, Pred: B6, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + i)
+
+  if ('a' != *(i + p)) {
+    a = 7;
+  } else {
+    a = 8;
+  }
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: 'a' != *(i + p)
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B2, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + i)
+
+// CHECK: Block: B1, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, i + p + 1)
+}
+
+void f3(_Nt_array_ptr<char> p : bounds(p, p)) {
+
+  if (*p) {
+    a = 1;
+  } else if (*p == 'a') {
+    a = 2;
+  } else {
+    a = 3;
+  }
+
+// CHECK: Function: f3
+// CHECK: Block: B16 (Entry), Pred: Succ: B15
+
+// CHECK: Block: B15, Pred: B16, Succ: B14, B13
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B14, Pred: B15, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B13, Pred: B15, Succ: B12, B11
+// CHECK:   Widened bounds before stmt: *p == 'a'
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B12, Pred: B13, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B11, Pred: B13, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p)
+
+  if (!*p) {
+    a = 4;
+  } else if (!*p) {
+    a = 5;
+  } else {
+    a = 6;
+  }
+
+// CHECK: Block: B10, Pred: B11, B12, B14, Succ: B9, B8
+// CHECK:   Widened bounds before stmt: !*p
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B9, Pred: B10, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B8, Pred: B10, Succ: B7, B6
+// CHECK:   Widened bounds before stmt: !*p
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B7, Pred: B8, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B8, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 1)
+
+  if (!*p) {
+    a = 7;
+  } else if (*(p + 1) != '\0') {
+    a = 8;
+  } else {
+    a = 9;
+  }
+
+// CHECK: Block: B5, Pred: B6, B7, B9, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: !*p
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B4, Pred: B5, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: *(p + 1) != '\x00'
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 8
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+// CHECK: Block: B1, Pred: B3, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 9
+// CHECK:     p: bounds(p, p + 1)
+}
+
+void f4(_Nt_array_ptr<char> p : bounds(p, p)) {
+  if (!!*p) {
+    a = 1;
+  }
+
+// CHECK: Function: f4
+// CHECK: Block: B13 (Entry), Pred: Succ: B12
+
+// CHECK: Block: B12, Pred: B13, Succ: B11, B10
+// CHECK:   Widened bounds before stmt: !!*p
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B11, Pred: B12, Succ: B10
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1)
+
+  if (!!!*p) {
+    a = 2;
+  }
+
+// CHECK: Block: B10, Pred: B11, B12, Succ: B9, B8
+// CHECK:   Widened bounds before stmt: !!!*p
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p)
+
+  if (!(*p == 0)) {
+    a = 3;
+  }
+
+// CHECK: Block: B8, Pred: B9, B10, Succ: B7, B6
+// CHECK:   Widened bounds before stmt: !(*p == 0)
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+
+  if (!(*p != 0)) {
+    a = 4;
+  }
+
+// CHECK: Block: B6, Pred: B7, B8, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: !(*p != 0)
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p)
+
+  if (!!(*p != 0)) {
+    a = 5;
+  }
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: !!(*p != 0)
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 1)
+
+  if (!!!(!*p == 0)) {
+    a = 6;
+  }
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: !!!(!*p == 0)
+// CHECK:     p: bounds(p, p)
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p)
+}
+
+void f5(_Nt_array_ptr<char> p : bounds(p, p + 1)) {
+  char c;
+
+  if ((c = *(p + 1)) == 'a') {
+    a = 1;
+  }
+
+// CHECK: Function: f5
+// CHECK: Block: B10 (Entry), Pred: Succ: B9
+
+// CHECK: Block: B9, Pred: B10, Succ: B8, B7
+// CHECK:   Widened bounds before stmt: char c;
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK:   Widened bounds before stmt: (c = *(p + 1)) == 'a'
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B7
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+  if (0 != (c = *(p + 1))) {
+    a = 2;
+  }
+
+// CHECK: Block: B7, Pred: B8, B9, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: 0 != (c = *(p + 1))
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+  if ((c = *(p + 1))) {
+    a = 3;
+  }
+
+// CHECK: Block: B5, Pred: B6, B7, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: c = *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B3
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1 + 1)
+
+  if ((c = !*(p + 1))) {
+    a = 4;
+  }
+
+// CHECK: Block: B3, Pred: B4, B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: c = !*(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+}
+
+void f6(_Nt_array_ptr<char> p : count(0),
+        _Nt_array_ptr<char> q : count(0)) {
+
+  if (*p == a) {
+    a = 1;
+  }
+
+// CHECK: Function: f6
+// CHECK: Block: B22 (Entry), Pred: Succ: B21
+
+// CHECK: Block: B21, Pred: B22, Succ: B20, B19
+// CHECK:   Widened bounds before stmt: *p == a
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B20, Pred: B21, Succ: B19
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+  if (*p == *q) {
+    a = 2;
+  }
+
+// CHECK: Block: B19, Pred: B20, B21, Succ: B18, B17
+// CHECK:   Widened bounds before stmt: *p == *q
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B18, Pred: B19, Succ: B17
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+  if ((*p == 'a') && (*q != 'b')) {
+    a = 3;
+  }
+
+// CHECK: Block: B17, Pred: B18, B19, Succ: B16, B14
+// CHECK:   Widened bounds before stmt: *p == 'a'
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B16, Pred: B17, Succ: B15, B14
+// CHECK:   Widened bounds before stmt: *q != 'b'
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B15, Pred: B16, Succ: B14
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+  if (*p && !*q) {
+    a = 4;
+  } else if (!*p && *q) {
+    a = 5;
+  }
+
+// CHECK: Block: B14, Pred: B15, B16, B17, Succ: B13, B11
+// CHECK:   Widened bounds before stmt: *p
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B13, Pred: B14, Succ: B12, B11
+// CHECK:   Widened bounds before stmt: !*q
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B12, Pred: B13, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B11, Pred: B13, B14, Succ: B10, B8
+// CHECK:   Widened bounds before stmt: !*p
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9, B8
+// CHECK:   Widened bounds before stmt: *q
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B9, Pred: B10, Succ: B8
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+  if (*p != 0 && *(p + 1) && 'a' == *(p + 2)) {
+    a = 6;
+  }
+
+// CHECK: Block: B8, Pred: B9, B10, B11, B12, Succ: B7, B4
+// CHECK:   Widened bounds before stmt: *p != 0
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6, B4
+// CHECK:   Widened bounds before stmt: *(p + 1)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B6, Pred: B7, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: 'a' == *(p + 2)
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 2 + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+  char c, d;
+  if (((c = *p) != 0) && 'a' == (d = *q)) {
+    a = 7;
+  }
+
+// CHECK: Block: B4, Pred: B5, B6, B7, B8, Succ: B3, B1
+// CHECK:   Widened bounds before stmt: char c;
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: char d;
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK:   Widened bounds before stmt: (c = *p) != 0
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: 'a' == (d = *q)
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 0)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 7
+// CHECK:     p: bounds(p, p + 1)
+// CHECK:     q: bounds(q, q + 1)
+}
+
+void f7(char p _Nt_checked[1], char q _Nt_checked[2]) {
+  if (p[0] != '\0' && 'a' == 1[q] && p[1] == 'b') {
+    a = 1;
+  }
+
+// CHECK: Function: f7
+// CHECK: Block: B17 (Entry), Pred: Succ: B16
+
+// CHECK: Block: B16, Pred: B17, Succ: B15, B12
+// CHECK:   Widened bounds before stmt: p[0] != '\x00'
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B15, Pred: B16, Succ: B14, B12
+// CHECK:   Widened bounds before stmt: 'a' == 1[q]
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B14, Pred: B15, Succ: B13, B12
+// CHECK:   Widened bounds before stmt: p[1] == 'b'
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B13, Pred: B14, Succ: B12
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 1 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+  char c;
+  if ((c = q[0]) && (c = q[1])) {
+    a = 2;
+  }
+
+// CHECK: Block: B12, Pred: B13, B14, B15, B16, Succ: B11, B9
+// CHECK:   Widened bounds before stmt: char c;
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK:   Widened bounds before stmt: (c = q[0])
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B11, Pred: B12, Succ: B10, B9
+// CHECK:   Widened bounds before stmt: (c = q[1])
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B10, Pred: B11, Succ: B9
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+  if (!p[0]) {
+    a = 3;
+  } else if (!q[1]) {
+    a = 4;
+  } else if (p[0]) {
+    a = 5;
+  } else if (q[1]) {
+    a = 6;
+  }
+
+// CHECK: Block: B9, Pred: B10, B11, B12, Succ: B8, B7
+// CHECK:   Widened bounds before stmt: !p[0]
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B8, Pred: B9, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B7, Pred: B9, Succ: B6, B5
+// CHECK:   Widened bounds before stmt: !q[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B6, Pred: B7, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1)
+
+// CHECK: Block: B5, Pred: B7, Succ: B4, B3
+// CHECK:   Widened bounds before stmt: p[0]
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B4, Pred: B5, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 5
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B3, Pred: B5, Succ: B2, B1
+// CHECK:   Widened bounds before stmt: q[1]
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+
+// CHECK: Block: B2, Pred: B3, Succ: B1
+// CHECK:   Widened bounds before stmt: a = 6
+// CHECK:     p: bounds(p, p + 0 + 1)
+// CHECK:     q: bounds(q, q + 1 + 1)
+}
+
+void f8(_Nt_array_ptr<_Ptr<char>> p : count(0),
+        _Nt_array_ptr<_Ptr<char>> q : bounds(*q, *q)) {
+
+  if (**p) {
+    a = 1;
+  }
+
+// CHECK: Function: f8
+// CHECK: Block: B9 (Entry), Pred: Succ: B8
+
+// CHECK: Block: B8, Pred: B9, Succ: B7, B6
+// CHECK:   Widened bounds before stmt: **p
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+// CHECK: Block: B7, Pred: B8, Succ: B6
+// CHECK:   Widened bounds before stmt: a = 1
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+  if (!**p) {
+    a = 2;
+  }
+
+// CHECK: Block: B6, Pred: B7, B8, Succ: B5, B4
+// CHECK:   Widened bounds before stmt: !**p
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+// CHECK: Block: B5, Pred: B6, Succ: B4
+// CHECK:   Widened bounds before stmt: a = 2
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+  if (**q) {
+    a = 3;
+  }
+
+// CHECK: Block: B4, Pred: B5, B6, Succ: B3, B2
+// CHECK:   Widened bounds before stmt: **q
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+// CHECK: Block: B3, Pred: B4, Succ: B2
+// CHECK:   Widened bounds before stmt: a = 3
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q + 1)
+
+  if (!**q) {
+    a = 4;
+  }
+
+// CHECK: Block: B2, Pred: B3, B4, Succ: B1, B0
+// CHECK:   Widened bounds before stmt: !**q
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+
+// CHECK: Block: B1, Pred: B2, Succ: B0
+// CHECK:   Widened bounds before stmt: a = 4
+// CHECK:     p: bounds(p, p + 0)
+// CHECK:     q: bounds(*q, *q)
+}


### PR DESCRIPTION
The main motivation for merging now is the `&str[i]` fix (microsoft/checkedc-clang#1148), which benefits the tiny-bignum-c tutorial, but we can hold off on the merge if it would be too disruptive to other work.

The 3C regression tests pass.  Would people like me to run additional tests, or do you want to run your own tests (e.g., your own ports)?