### PR TITLE
Command line options clean up

### DIFF
--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -22,59 +22,7 @@
 #include "clang/Tooling/CommonOptionsParser.h"
 #include <mutex>
 
-// Options used to initialize 3C tool.
-//
-// See clang/docs/checkedc/3C/clang-tidy.md#_3c-name-prefix
-// NOLINTNEXTLINE(readability-identifier-naming)
-struct _3COptions {
-  bool DumpIntermediate;
 
-  bool Verbose;
-
-  std::string OutputPostfix;
-  std::string OutputDir;
-
-  std::string ConstraintOutputJson;
-
-  bool DumpStats;
-
-  std::string StatsOutputJson;
-
-  std::string WildPtrInfoJson;
-
-  std::string PerPtrInfoJson;
-
-  std::vector<std::string> AllocatorFunctions;
-
-  bool HandleVARARGS;
-
-  bool EnablePropThruIType;
-
-  std::string BaseDir;
-  bool AllowSourcesOutsideBaseDir;
-
-  bool EnableAllTypes;
-
-  bool AddCheckedRegions;
-
-  bool EnableCCTypeChecker;
-
-  bool WarnRootCause;
-
-  bool WarnAllRootCause;
-
-#ifdef FIVE_C
-  bool RemoveItypes;
-  bool ForceItypes;
-#endif
-
-  bool DumpUnwritableChanges;
-  bool AllowUnwritableChanges;
-
-  bool AllowRewriteFailures;
-
-  bool ItypesForExtern;
-};
 
 // The main interface exposed by the 3C to interact with the tool.
 //

--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -22,8 +22,6 @@
 #include "clang/Tooling/CommonOptionsParser.h"
 #include <mutex>
 
-
-
 // The main interface exposed by the 3C to interact with the tool.
 //
 // See clang/docs/checkedc/3C/clang-tidy.md#_3c-name-prefix

--- a/clang/include/clang/3C/3CGlobalOptions.h
+++ b/clang/include/clang/3C/3CGlobalOptions.h
@@ -15,29 +15,61 @@
 
 #include "llvm/Support/CommandLine.h"
 
-extern bool Verbose;
-extern bool DumpIntermediate;
-extern std::string OutputPostfix;
-extern std::string OutputDir;
-extern bool HandleVARARGS;
-extern bool SeperateMultipleFuncDecls;
-extern bool EnablePropThruIType;
-extern bool ConsiderAllocUnsafe;
-extern bool AllTypes;
-extern bool NewSolver;
-extern std::string BaseDir;
-extern std::vector<std::string> AllocatorFunctions;
-extern bool AddCheckedRegions;
-extern bool WarnRootCause;
-extern bool WarnAllRootCause;
-extern bool DumpUnwritableChanges;
-extern bool AllowUnwritableChanges;
-extern bool AllowRewriteFailures;
-extern bool ItypesForExtern;
+// Options used to initialize 3C tool.
+//
+// See clang/docs/checkedc/3C/clang-tidy.md#_3c-name-prefix
+// NOLINTNEXTLINE(readability-identifier-naming)
+struct _3COptions {
+  bool DumpIntermediate;
+
+  bool Verbose;
+
+  std::string OutputPostfix;
+  std::string OutputDir;
+
+  std::string ConstraintOutputJson;
+
+  bool DumpStats;
+
+  std::string StatsOutputJson;
+
+  std::string WildPtrInfoJson;
+
+  std::string PerWildPtrInfoJson;
+
+  std::vector<std::string> AllocatorFunctions;
+
+  bool HandleVARARGS;
+
+  bool EnablePropThruIType;
+
+  std::string BaseDir;
+  bool AllowSourcesOutsideBaseDir;
+
+  bool AllTypes;
+
+  bool AddCheckedRegions;
+
+  bool EnableCCTypeChecker;
+
+  bool WarnRootCause;
+
+  bool WarnAllRootCause;
 
 #ifdef FIVE_C
-extern bool RemoveItypes;
-extern bool ForceItypes;
+  bool RemoveItypes;
+  bool ForceItypes;
 #endif
+
+  bool DumpUnwritableChanges;
+  bool AllowUnwritableChanges;
+
+  bool AllowRewriteFailures;
+
+  bool ItypesForExtern;
+};
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern struct _3COptions _3CGlobalOptions;
 
 #endif // LLVM_CLANG_3C_3CGLOBALOPTIONS_H

--- a/clang/include/clang/3C/3CGlobalOptions.h
+++ b/clang/include/clang/3C/3CGlobalOptions.h
@@ -70,6 +70,6 @@ struct _3COptions {
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-extern struct _3COptions _3CGlobalOptions;
+extern struct _3COptions _3COpts;
 
 #endif // LLVM_CLANG_3C_3CGLOBALOPTIONS_H

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -310,6 +310,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
                            CompilationDatabase *CompDB) {
 
   _3COpts = CCopt;
+  _3COpts.WarnRootCause |= _3COpts.WarnAllRootCause;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -259,8 +259,7 @@ public:
 void dumpConstraintOutputJson(const std::string &PostfixStr,
                               ProgramInfo &Info) {
   if (_3COpts.DumpIntermediate) {
-    std::string FilePath =
-      _3COpts.ConstraintOutputJson + PostfixStr + ".json";
+    std::string FilePath = _3COpts.ConstraintOutputJson + PostfixStr + ".json";
     errs() << "Writing json output to:" << FilePath << "\n";
     std::error_code Ec;
     llvm::raw_fd_ostream OutputJson(FilePath, Ec);
@@ -319,15 +318,14 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
 
   ConstraintsBuilt = false;
 
-  if (_3COpts.OutputPostfix != "-" &&
-      !_3COpts.OutputDir.empty()) {
+  if (_3COpts.OutputPostfix != "-" && !_3COpts.OutputDir.empty()) {
     errs() << "3C initialization error: Cannot use both -output-postfix and "
               "-output-dir\n";
     ConstructionFailed = true;
     return;
   }
-  if (_3COpts.OutputPostfix == "-" &&
-      _3COpts.OutputDir.empty() && SourceFileList.size() > 1) {
+  if (_3COpts.OutputPostfix == "-" && _3COpts.OutputDir.empty() &&
+      SourceFileList.size() > 1) {
     errs() << "3C initialization error: Cannot specify more than one input "
               "file when output is to stdout\n";
     ConstructionFailed = true;
@@ -346,8 +344,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   EC = tryGetCanonicalFilePath(_3COpts.BaseDir, TmpPath);
   if (EC) {
     errs() << "3C initialization error: Failed to canonicalize base directory "
-           << "\"" << _3COpts.BaseDir << "\": " << EC.message()
-           << "\n";
+           << "\"" << _3COpts.BaseDir << "\": " << EC.message() << "\n";
     ConstructionFailed = true;
     return;
   }
@@ -367,8 +364,8 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
     EC = tryGetCanonicalFilePath(_3COpts.OutputDir, TmpPath);
     if (EC) {
       errs() << "3C initialization error: Failed to canonicalize output "
-             << "directory \"" << _3COpts.OutputDir
-             << "\": " << EC.message() << "\n";
+             << "directory \"" << _3COpts.OutputDir << "\": " << EC.message()
+             << "\n";
       ConstructionFailed = true;
       return;
     }
@@ -391,8 +388,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
     if (!filePathStartsWith(AbsPath, _3COpts.BaseDir)) {
       errs()
           << "3C initialization "
-          << (_3COpts.OutputDir != "" ||
-              !_3COpts.AllowSourcesOutsideBaseDir
+          << (_3COpts.OutputDir != "" || !_3COpts.AllowSourcesOutsideBaseDir
                   ? "error"
                   : "warning")
           << ": File \"" << AbsPath
@@ -631,8 +627,7 @@ bool _3CInterface::dumpStats() {
       GlobalProgramInfo.printStats(FilePaths, OutputJson, false, true);
       OutputJson.close();
     }
-    std::string AggregateStats =
-      _3COpts.StatsOutputJson + ".aggregate.json";
+    std::string AggregateStats = _3COpts.StatsOutputJson + ".aggregate.json";
     llvm::raw_fd_ostream AggrJson(AggregateStats, Ec);
     if (!AggrJson.has_error()) {
       GlobalProgramInfo.printAggregateStats(FilePaths, AggrJson);
@@ -645,8 +640,7 @@ bool _3CInterface::dumpStats() {
       WildPtrInfo.close();
     }
 
-    llvm::raw_fd_ostream PerWildPtrInfo(_3COpts.PerWildPtrInfoJson,
-                                        Ec);
+    llvm::raw_fd_ostream PerWildPtrInfo(_3COpts.PerWildPtrInfoJson, Ec);
     if (!PerWildPtrInfo.has_error()) {
       GlobalProgramInfo.getInterimConstraintState().printRootCauseStats(
           PerWildPtrInfo, GlobalProgramInfo.getConstraints());

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -259,7 +259,8 @@ public:
 void dumpConstraintOutputJson(const std::string &PostfixStr,
                               ProgramInfo &Info) {
   if (_3CGlobalOptions.DumpIntermediate) {
-    std::string FilePath = _3CGlobalOptions.ConstraintOutputJson + PostfixStr + ".json";
+    std::string FilePath =
+        _3CGlobalOptions.ConstraintOutputJson + PostfixStr + ".json";
     errs() << "Writing json output to:" << FilePath << "\n";
     std::error_code Ec;
     llvm::raw_fd_ostream OutputJson(FilePath, Ec);
@@ -318,13 +319,15 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
 
   ConstraintsBuilt = false;
 
-  if (_3CGlobalOptions.OutputPostfix != "-" && !_3CGlobalOptions.OutputDir.empty()) {
+  if (_3CGlobalOptions.OutputPostfix != "-" &&
+      !_3CGlobalOptions.OutputDir.empty()) {
     errs() << "3C initialization error: Cannot use both -output-postfix and "
               "-output-dir\n";
     ConstructionFailed = true;
     return;
   }
-  if (_3CGlobalOptions.OutputPostfix == "-" && _3CGlobalOptions.OutputDir.empty() && SourceFileList.size() > 1) {
+  if (_3CGlobalOptions.OutputPostfix == "-" &&
+      _3CGlobalOptions.OutputDir.empty() && SourceFileList.size() > 1) {
     errs() << "3C initialization error: Cannot specify more than one input "
               "file when output is to stdout\n";
     ConstructionFailed = true;
@@ -343,7 +346,8 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   EC = tryGetCanonicalFilePath(_3CGlobalOptions.BaseDir, TmpPath);
   if (EC) {
     errs() << "3C initialization error: Failed to canonicalize base directory "
-           << "\"" << _3CGlobalOptions.BaseDir << "\": " << EC.message() << "\n";
+           << "\"" << _3CGlobalOptions.BaseDir << "\": " << EC.message()
+           << "\n";
     ConstructionFailed = true;
     return;
   }
@@ -363,7 +367,8 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
     EC = tryGetCanonicalFilePath(_3CGlobalOptions.OutputDir, TmpPath);
     if (EC) {
       errs() << "3C initialization error: Failed to canonicalize output "
-             << "directory \"" << _3CGlobalOptions.OutputDir << "\": " << EC.message() << "\n";
+             << "directory \"" << _3CGlobalOptions.OutputDir
+             << "\": " << EC.message() << "\n";
       ConstructionFailed = true;
       return;
     }
@@ -386,8 +391,10 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
     if (!filePathStartsWith(AbsPath, _3CGlobalOptions.BaseDir)) {
       errs()
           << "3C initialization "
-          << (_3CGlobalOptions.OutputDir != "" || !_3CGlobalOptions.AllowSourcesOutsideBaseDir ? "error"
-                                                                   : "warning")
+          << (_3CGlobalOptions.OutputDir != "" ||
+                      !_3CGlobalOptions.AllowSourcesOutsideBaseDir
+                  ? "error"
+                  : "warning")
           << ": File \"" << AbsPath
           << "\" specified on the command line is outside the base directory\n";
       SawInputOutsideBaseDir = true;
@@ -624,7 +631,8 @@ bool _3CInterface::dumpStats() {
       GlobalProgramInfo.printStats(FilePaths, OutputJson, false, true);
       OutputJson.close();
     }
-    std::string AggregateStats = _3CGlobalOptions.StatsOutputJson + ".aggregate.json";
+    std::string AggregateStats =
+        _3CGlobalOptions.StatsOutputJson + ".aggregate.json";
     llvm::raw_fd_ostream AggrJson(AggregateStats, Ec);
     if (!AggrJson.has_error()) {
       GlobalProgramInfo.printAggregateStats(FilePaths, AggrJson);
@@ -637,7 +645,8 @@ bool _3CInterface::dumpStats() {
       WildPtrInfo.close();
     }
 
-    llvm::raw_fd_ostream PerWildPtrInfo(_3CGlobalOptions.PerWildPtrInfoJson, Ec);
+    llvm::raw_fd_ostream PerWildPtrInfo(_3CGlobalOptions.PerWildPtrInfoJson,
+                                        Ec);
     if (!PerWildPtrInfo.has_error()) {
       GlobalProgramInfo.getInterimConstraintState().printRootCauseStats(
           PerWildPtrInfo, GlobalProgramInfo.getConstraints());

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/3C.h"
+#include "clang/3C/3CGlobalOptions.h"
 #include "clang/3C/ArrayBoundsInferenceConsumer.h"
 #include "clang/3C/ConstraintBuilder.h"
 #include "clang/3C/IntermediateToolHook.h"
@@ -36,35 +37,9 @@ static cl::opt<bool>
                    cl::desc("Dump array bounds inference graph"),
                    cl::init(false), cl::cat(ArrBoundsInferCat));
 
-bool DumpIntermediate;
-bool Verbose;
-std::string OutputPostfix;
-std::string OutputDir;
-std::string ConstraintOutputJson;
-std::vector<std::string> AllocatorFunctions;
-bool DumpStats;
-bool HandleVARARGS;
-bool EnablePropThruIType;
-bool ConsiderAllocUnsafe;
-std::string StatsOutputJson;
-std::string WildPtrInfoJson;
-std::string PerWildPtrInfoJson;
-bool AllTypes;
-std::string BaseDir;
-bool AddCheckedRegions;
-bool EnableCCTypeChecker;
-bool WarnRootCause;
-bool WarnAllRootCause;
 std::set<std::string> FilePaths;
-bool DumpUnwritableChanges;
-bool AllowUnwritableChanges;
-bool AllowRewriteFailures;
-bool ItypesForExtern;
 
-#ifdef FIVE_C
-bool RemoveItypes;
-bool ForceItypes;
-#endif
+struct _3COptions _3CGlobalOptions;
 
 static CompilationDatabase *CurrCompDB = nullptr;
 static tooling::CommandLineArguments SourceFiles;
@@ -194,7 +169,7 @@ public:
     // a LibTooling ArgumentsAdjuster, but we access the options in their parsed
     // data structure rather than as strings, so it is much more robust.
 
-    if (!EnableCCTypeChecker)
+    if (!_3CGlobalOptions.EnableCCTypeChecker)
       // Corresponds to the -f3c-tool compiler option.
       Invocation->LangOpts->_3C = true;
 
@@ -283,8 +258,8 @@ public:
 
 void dumpConstraintOutputJson(const std::string &PostfixStr,
                               ProgramInfo &Info) {
-  if (DumpIntermediate) {
-    std::string FilePath = ConstraintOutputJson + PostfixStr + ".json";
+  if (_3CGlobalOptions.DumpIntermediate) {
+    std::string FilePath = _3CGlobalOptions.ConstraintOutputJson + PostfixStr + ".json";
     errs() << "Writing json output to:" << FilePath << "\n";
     std::error_code Ec;
     llvm::raw_fd_ostream OutputJson(FilePath, Ec);
@@ -300,7 +275,7 @@ void dumpConstraintOutputJson(const std::string &PostfixStr,
 void runSolver(ProgramInfo &Info, std::set<std::string> &SourceFiles) {
   Constraints &CS = Info.getConstraints();
 
-  if (Verbose) {
+  if (_3CGlobalOptions.Verbose) {
     errs() << "Trying to capture Constraint Variables for all functions\n";
   }
 
@@ -311,7 +286,7 @@ void runSolver(ProgramInfo &Info, std::set<std::string> &SourceFiles) {
 
   clock_t StartTime = clock();
   CS.solve();
-  if (Verbose) {
+  if (_3CGlobalOptions.Verbose) {
     errs() << "Solver time:" << getTimeSpentInSeconds(StartTime) << "\n";
   }
 }
@@ -334,33 +309,7 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
                            const std::vector<std::string> &SourceFileList,
                            CompilationDatabase *CompDB) {
 
-  DumpIntermediate = CCopt.DumpIntermediate;
-  Verbose = CCopt.Verbose;
-  OutputPostfix = CCopt.OutputPostfix;
-  OutputDir = CCopt.OutputDir;
-  ConstraintOutputJson = CCopt.ConstraintOutputJson;
-  StatsOutputJson = CCopt.StatsOutputJson;
-  WildPtrInfoJson = CCopt.WildPtrInfoJson;
-  PerWildPtrInfoJson = CCopt.PerPtrInfoJson;
-  DumpStats = CCopt.DumpStats;
-  HandleVARARGS = CCopt.HandleVARARGS;
-  EnablePropThruIType = CCopt.EnablePropThruIType;
-  BaseDir = CCopt.BaseDir;
-  AllTypes = CCopt.EnableAllTypes;
-  AddCheckedRegions = CCopt.AddCheckedRegions;
-  EnableCCTypeChecker = CCopt.EnableCCTypeChecker;
-  AllocatorFunctions = CCopt.AllocatorFunctions;
-  WarnRootCause = CCopt.WarnRootCause || CCopt.WarnAllRootCause;
-  WarnAllRootCause = CCopt.WarnAllRootCause;
-  DumpUnwritableChanges = CCopt.DumpUnwritableChanges;
-  AllowUnwritableChanges = CCopt.AllowUnwritableChanges;
-  AllowRewriteFailures = CCopt.AllowRewriteFailures;
-  ItypesForExtern = CCopt.ItypesForExtern;
-
-#ifdef FIVE_C
-  RemoveItypes = CCopt.RemoveItypes;
-  ForceItypes = CCopt.ForceItypes;
-#endif
+  _3CGlobalOptions = CCopt;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -369,13 +318,13 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
 
   ConstraintsBuilt = false;
 
-  if (OutputPostfix != "-" && !OutputDir.empty()) {
+  if (_3CGlobalOptions.OutputPostfix != "-" && !_3CGlobalOptions.OutputDir.empty()) {
     errs() << "3C initialization error: Cannot use both -output-postfix and "
               "-output-dir\n";
     ConstructionFailed = true;
     return;
   }
-  if (OutputPostfix == "-" && OutputDir.empty() && SourceFileList.size() > 1) {
+  if (_3CGlobalOptions.OutputPostfix == "-" && _3CGlobalOptions.OutputDir.empty() && SourceFileList.size() > 1) {
     errs() << "3C initialization error: Cannot specify more than one input "
               "file when output is to stdout\n";
     ConstructionFailed = true;
@@ -385,40 +334,40 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
   std::string TmpPath;
   std::error_code EC;
 
-  if (BaseDir.empty()) {
-    BaseDir = ".";
+  if (_3CGlobalOptions.BaseDir.empty()) {
+    _3CGlobalOptions.BaseDir = ".";
   }
 
   // Get the canonical path of the base directory.
-  TmpPath = BaseDir;
-  EC = tryGetCanonicalFilePath(BaseDir, TmpPath);
+  TmpPath = _3CGlobalOptions.BaseDir;
+  EC = tryGetCanonicalFilePath(_3CGlobalOptions.BaseDir, TmpPath);
   if (EC) {
     errs() << "3C initialization error: Failed to canonicalize base directory "
-           << "\"" << BaseDir << "\": " << EC.message() << "\n";
+           << "\"" << _3CGlobalOptions.BaseDir << "\": " << EC.message() << "\n";
     ConstructionFailed = true;
     return;
   }
-  BaseDir = TmpPath;
+  _3CGlobalOptions.BaseDir = TmpPath;
 
-  if (!OutputDir.empty()) {
+  if (!_3CGlobalOptions.OutputDir.empty()) {
     // tryGetCanonicalFilePath will fail if the output dir doesn't exist yet, so
     // create it first.
-    EC = llvm::sys::fs::create_directories(OutputDir);
+    EC = llvm::sys::fs::create_directories(_3CGlobalOptions.OutputDir);
     if (EC) {
       errs() << "3C initialization error: Failed to create output directory \""
-             << OutputDir << "\": " << EC.message() << "\n";
+             << _3CGlobalOptions.OutputDir << "\": " << EC.message() << "\n";
       ConstructionFailed = true;
       return;
     }
-    TmpPath = OutputDir;
-    EC = tryGetCanonicalFilePath(OutputDir, TmpPath);
+    TmpPath = _3CGlobalOptions.OutputDir;
+    EC = tryGetCanonicalFilePath(_3CGlobalOptions.OutputDir, TmpPath);
     if (EC) {
       errs() << "3C initialization error: Failed to canonicalize output "
-             << "directory \"" << OutputDir << "\": " << EC.message() << "\n";
+             << "directory \"" << _3CGlobalOptions.OutputDir << "\": " << EC.message() << "\n";
       ConstructionFailed = true;
       return;
     }
-    OutputDir = TmpPath;
+    _3CGlobalOptions.OutputDir = TmpPath;
   }
 
   SourceFiles = SourceFileList;
@@ -434,10 +383,10 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
       continue;
     }
     FilePaths.insert(AbsPath);
-    if (!filePathStartsWith(AbsPath, BaseDir)) {
+    if (!filePathStartsWith(AbsPath, _3CGlobalOptions.BaseDir)) {
       errs()
           << "3C initialization "
-          << (OutputDir != "" || !CCopt.AllowSourcesOutsideBaseDir ? "error"
+          << (_3CGlobalOptions.OutputDir != "" || !_3CGlobalOptions.AllowSourcesOutsideBaseDir ? "error"
                                                                    : "warning")
           << ": File \"" << AbsPath
           << "\" specified on the command line is outside the base directory\n";
@@ -445,14 +394,14 @@ _3CInterface::_3CInterface(const struct _3COptions &CCopt,
     }
   }
   if (SawInputOutsideBaseDir) {
-    errs() << "The base directory is currently \"" << BaseDir
+    errs() << "The base directory is currently \"" << _3CGlobalOptions.BaseDir
            << "\" and can be changed with the -base-dir option.\n";
-    if (OutputDir != "") {
+    if (_3CGlobalOptions.OutputDir != "") {
       ConstructionFailed = true;
       errs() << "When using -output-dir, input files outside the base "
                 "directory cannot be handled because there is no way to "
                 "compute their output paths.\n";
-    } else if (!CCopt.AllowSourcesOutsideBaseDir) {
+    } else if (!_3CGlobalOptions.AllowSourcesOutsideBaseDir) {
       ConstructionFailed = true;
       errs() << "You can use the -allow-sources-outside-base-dir option to "
                 "temporarily downgrade this error to a warning.\n";
@@ -556,10 +505,10 @@ bool _3CInterface::solveConstraints() {
   assert(ConstraintsBuilt && "Constraints not yet built. We need to call "
                              "build constraint before trying to solve them.");
   // 3. Solve constraints.
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     errs() << "Solving constraints\n";
 
-  if (DumpIntermediate)
+  if (_3CGlobalOptions.DumpIntermediate)
     GlobalProgramInfo.dump();
 
   auto &PStats = GlobalProgramInfo.getPerfStats();
@@ -568,16 +517,16 @@ bool _3CInterface::solveConstraints() {
   runSolver(GlobalProgramInfo, FilePaths);
   PStats.endConstraintSolverTime();
 
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     errs() << "Constraints solved\n";
 
-  if (WarnRootCause)
+  if (_3CGlobalOptions.WarnRootCause)
     GlobalProgramInfo.computeInterimConstraintState(FilePaths);
 
-  if (DumpIntermediate)
+  if (_3CGlobalOptions.DumpIntermediate)
     dumpConstraintOutputJson(FINAL_OUTPUT_SUFFIX, GlobalProgramInfo);
 
-  if (AllTypes) {
+  if (_3CGlobalOptions.AllTypes) {
     if (DebugArrSolver)
       GlobalProgramInfo.getABoundsInfo().dumpAVarGraph(
           "arr_bounds_initial.dot");
@@ -606,7 +555,7 @@ bool _3CInterface::solveConstraints() {
   if (!isSuccessfulSoFar())
     return false;
 
-  if (AllTypes) {
+  if (_3CGlobalOptions.AllTypes) {
     // Propagate data-flow information for Array pointers.
     GlobalProgramInfo.getABoundsInfo().performFlowAnalysis(&GlobalProgramInfo);
 
@@ -662,33 +611,33 @@ bool _3CInterface::writeAllConvertedFilesToDisk() {
 }
 
 bool _3CInterface::dumpStats() {
-  if (AllTypes && DebugArrSolver) {
+  if (_3CGlobalOptions.AllTypes && DebugArrSolver) {
     GlobalProgramInfo.getABoundsInfo().dumpAVarGraph("arr_bounds_final.dot");
   }
 
-  if (DumpStats) {
+  if (_3CGlobalOptions.DumpStats) {
     GlobalProgramInfo.printStats(FilePaths, llvm::errs(), true);
     GlobalProgramInfo.computeInterimConstraintState(FilePaths);
     std::error_code Ec;
-    llvm::raw_fd_ostream OutputJson(StatsOutputJson, Ec);
+    llvm::raw_fd_ostream OutputJson(_3CGlobalOptions.StatsOutputJson, Ec);
     if (!OutputJson.has_error()) {
       GlobalProgramInfo.printStats(FilePaths, OutputJson, false, true);
       OutputJson.close();
     }
-    std::string AggregateStats = StatsOutputJson + ".aggregate.json";
+    std::string AggregateStats = _3CGlobalOptions.StatsOutputJson + ".aggregate.json";
     llvm::raw_fd_ostream AggrJson(AggregateStats, Ec);
     if (!AggrJson.has_error()) {
       GlobalProgramInfo.printAggregateStats(FilePaths, AggrJson);
       AggrJson.close();
     }
 
-    llvm::raw_fd_ostream WildPtrInfo(WildPtrInfoJson, Ec);
+    llvm::raw_fd_ostream WildPtrInfo(_3CGlobalOptions.WildPtrInfoJson, Ec);
     if (!WildPtrInfo.has_error()) {
       GlobalProgramInfo.getInterimConstraintState().printStats(WildPtrInfo);
       WildPtrInfo.close();
     }
 
-    llvm::raw_fd_ostream PerWildPtrInfo(PerWildPtrInfoJson, Ec);
+    llvm::raw_fd_ostream PerWildPtrInfo(_3CGlobalOptions.PerWildPtrInfoJson, Ec);
     if (!PerWildPtrInfo.has_error()) {
       GlobalProgramInfo.getInterimConstraintState().printRootCauseStats(
           PerWildPtrInfo, GlobalProgramInfo.getConstraints());

--- a/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
@@ -894,7 +894,7 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
 void handleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I,
                                          bool UseHeuristics) {
   // Run array bounds
-  for (auto FuncName : AllocatorFunctions) {
+  for (auto FuncName : _3CGlobalOptions.AllocatorFunctions) {
     AllocatorSizeAssoc[FuncName] = {0};
   }
   GlobalABVisitor GlobABV(C, I);

--- a/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/3C/ArrayBoundsInferenceConsumer.cpp
@@ -894,7 +894,7 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
 void handleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I,
                                          bool UseHeuristics) {
   // Run array bounds
-  for (auto FuncName : _3CGlobalOptions.AllocatorFunctions) {
+  for (auto FuncName : _3COpts.AllocatorFunctions) {
     AllocatorSizeAssoc[FuncName] = {0};
   }
   GlobalABVisitor GlobABV(C, I);

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -95,7 +95,7 @@ public:
       bool IsNamedInLineStruct =
           IsInLineStruct && LastRecordDecl->getNameAsString() != "";
       if (IsInLineStruct && !IsNamedInLineStruct) {
-        if (!_3CGlobalOptions.AllTypes) {
+        if (!_3COpts.AllTypes) {
           CVarOption CV = Info.getVariable(VD, Context);
           CB.constraintCVarToWild(CV, "Inline struct encountered.");
         } else {
@@ -269,7 +269,7 @@ public:
               constrainConsVarGeq(ParameterDC, ArgumentConstraints.first, CS,
                                   &PL, CA, false, &Info, false);
 
-              if (_3CGlobalOptions.AllTypes && TFD != nullptr &&
+              if (_3COpts.AllTypes && TFD != nullptr &&
                   I < TFD->getNumParams()) {
                 auto *PVD = TFD->getParamDecl(I);
                 auto &CSBI = Info.getABoundsInfo().getCtxSensBoundsHandler();
@@ -280,7 +280,7 @@ public:
               }
             } else {
               // The argument passed to a function ith varargs; make it wild
-              if (_3CGlobalOptions.HandleVARARGS) {
+              if (_3COpts.HandleVARARGS) {
                 CB.constraintAllCVarsToWild(ArgumentConstraints.first,
                                             "Passing argument to a function "
                                             "accepting var args.",
@@ -293,7 +293,7 @@ public:
                   // (https://github.com/correctcomputation/checkedc-clang/issues/549).
                   constrainVarsTo(ArgumentConstraints.first, CS.getNTArr());
                 }
-                if (_3CGlobalOptions.Verbose) {
+                if (_3COpts.Verbose) {
                   std::string FuncName = TargetFV->getName();
                   errs() << "Ignoring function as it contains varargs:"
                          << FuncName << "\n";
@@ -515,7 +515,7 @@ public:
   bool VisitFunctionDecl(FunctionDecl *D) {
     FullSourceLoc FL = Context->getFullLoc(D->getBeginLoc());
 
-    if (_3CGlobalOptions.Verbose)
+    if (_3COpts.Verbose)
       errs() << "Analyzing function " << D->getName() << "\n";
 
     if (FL.isValid()) { // TODO: When would this ever be false?
@@ -523,7 +523,7 @@ public:
         Stmt *Body = D->getBody();
         FunctionVisitor FV = FunctionVisitor(Context, Info, D);
         FV.TraverseStmt(Body);
-        if (_3CGlobalOptions.AllTypes) {
+        if (_3COpts.AllTypes) {
           // Only do this, if all types is enabled.
           LengthVarInference LVI(Info, Context, D);
           LVI.Visit(Body);
@@ -531,7 +531,7 @@ public:
       }
     }
 
-    if (_3CGlobalOptions.Verbose)
+    if (_3COpts.Verbose)
       errs() << "Done analyzing function\n";
 
     return true;
@@ -619,7 +619,7 @@ private:
 
 void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
   Info.enterCompilationUnit(C);
-  if (_3CGlobalOptions.Verbose) {
+  if (_3COpts.Verbose) {
     SourceManager &SM = C.getSourceManager();
     FileID MainFileId = SM.getMainFileID();
     const FileEntry *FE = SM.getFileEntryForID(MainFileId);
@@ -636,7 +636,7 @@ void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
     VAV.TraverseDecl(D);
   }
 
-  if (_3CGlobalOptions.Verbose)
+  if (_3COpts.Verbose)
     errs() << "Done analyzing\n";
 
   Info.exitCompilationUnit();
@@ -645,7 +645,7 @@ void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
 
 void ConstraintBuilderConsumer::HandleTranslationUnit(ASTContext &C) {
   Info.enterCompilationUnit(C);
-  if (_3CGlobalOptions.Verbose) {
+  if (_3COpts.Verbose) {
     SourceManager &SM = C.getSourceManager();
     FileID MainFileId = SM.getMainFileID();
     const FileEntry *FE = SM.getFileEntryForID(MainFileId);
@@ -685,7 +685,7 @@ void ConstraintBuilderConsumer::HandleTranslationUnit(ASTContext &C) {
     SR.TraverseDecl(D);
   }
 
-  if (_3CGlobalOptions.Verbose)
+  if (_3COpts.Verbose)
     errs() << "Done analyzing\n";
 
   PStats.endConstraintBuilderTime();

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -95,7 +95,7 @@ public:
       bool IsNamedInLineStruct =
           IsInLineStruct && LastRecordDecl->getNameAsString() != "";
       if (IsInLineStruct && !IsNamedInLineStruct) {
-        if (!AllTypes) {
+        if (!_3CGlobalOptions.AllTypes) {
           CVarOption CV = Info.getVariable(VD, Context);
           CB.constraintCVarToWild(CV, "Inline struct encountered.");
         } else {
@@ -269,7 +269,7 @@ public:
               constrainConsVarGeq(ParameterDC, ArgumentConstraints.first, CS,
                                   &PL, CA, false, &Info, false);
 
-              if (AllTypes && TFD != nullptr && I < TFD->getNumParams()) {
+              if (_3CGlobalOptions.AllTypes && TFD != nullptr && I < TFD->getNumParams()) {
                 auto *PVD = TFD->getParamDecl(I);
                 auto &CSBI = Info.getABoundsInfo().getCtxSensBoundsHandler();
                 // Here, we need to handle context-sensitive assignment.
@@ -279,7 +279,7 @@ public:
               }
             } else {
               // The argument passed to a function ith varargs; make it wild
-              if (HandleVARARGS) {
+              if (_3CGlobalOptions.HandleVARARGS) {
                 CB.constraintAllCVarsToWild(ArgumentConstraints.first,
                                             "Passing argument to a function "
                                             "accepting var args.",
@@ -292,7 +292,7 @@ public:
                   // (https://github.com/correctcomputation/checkedc-clang/issues/549).
                   constrainVarsTo(ArgumentConstraints.first, CS.getNTArr());
                 }
-                if (Verbose) {
+                if (_3CGlobalOptions.Verbose) {
                   std::string FuncName = TargetFV->getName();
                   errs() << "Ignoring function as it contains varargs:"
                          << FuncName << "\n";
@@ -514,7 +514,7 @@ public:
   bool VisitFunctionDecl(FunctionDecl *D) {
     FullSourceLoc FL = Context->getFullLoc(D->getBeginLoc());
 
-    if (Verbose)
+    if (_3CGlobalOptions.Verbose)
       errs() << "Analyzing function " << D->getName() << "\n";
 
     if (FL.isValid()) { // TODO: When would this ever be false?
@@ -522,7 +522,7 @@ public:
         Stmt *Body = D->getBody();
         FunctionVisitor FV = FunctionVisitor(Context, Info, D);
         FV.TraverseStmt(Body);
-        if (AllTypes) {
+        if (_3CGlobalOptions.AllTypes) {
           // Only do this, if all types is enabled.
           LengthVarInference LVI(Info, Context, D);
           LVI.Visit(Body);
@@ -530,7 +530,7 @@ public:
       }
     }
 
-    if (Verbose)
+    if (_3CGlobalOptions.Verbose)
       errs() << "Done analyzing function\n";
 
     return true;
@@ -618,7 +618,7 @@ private:
 
 void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
   Info.enterCompilationUnit(C);
-  if (Verbose) {
+  if (_3CGlobalOptions.Verbose) {
     SourceManager &SM = C.getSourceManager();
     FileID MainFileId = SM.getMainFileID();
     const FileEntry *FE = SM.getFileEntryForID(MainFileId);
@@ -635,7 +635,7 @@ void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
     VAV.TraverseDecl(D);
   }
 
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     errs() << "Done analyzing\n";
 
   Info.exitCompilationUnit();
@@ -644,7 +644,7 @@ void VariableAdderConsumer::HandleTranslationUnit(ASTContext &C) {
 
 void ConstraintBuilderConsumer::HandleTranslationUnit(ASTContext &C) {
   Info.enterCompilationUnit(C);
-  if (Verbose) {
+  if (_3CGlobalOptions.Verbose) {
     SourceManager &SM = C.getSourceManager();
     FileID MainFileId = SM.getMainFileID();
     const FileEntry *FE = SM.getFileEntryForID(MainFileId);
@@ -684,7 +684,7 @@ void ConstraintBuilderConsumer::HandleTranslationUnit(ASTContext &C) {
     SR.TraverseDecl(D);
   }
 
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     errs() << "Done analyzing\n";
 
   PStats.endConstraintBuilderTime();

--- a/clang/lib/3C/ConstraintBuilder.cpp
+++ b/clang/lib/3C/ConstraintBuilder.cpp
@@ -269,7 +269,8 @@ public:
               constrainConsVarGeq(ParameterDC, ArgumentConstraints.first, CS,
                                   &PL, CA, false, &Info, false);
 
-              if (_3CGlobalOptions.AllTypes && TFD != nullptr && I < TFD->getNumParams()) {
+              if (_3CGlobalOptions.AllTypes && TFD != nullptr &&
+                  I < TFD->getNumParams()) {
                 auto *PVD = TFD->getParamDecl(I);
                 auto &CSBI = Info.getABoundsInfo().getCtxSensBoundsHandler();
                 // Here, we need to handle context-sensitive assignment.

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -106,7 +106,8 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (std::find(_3CGlobalOptions.AllocatorFunctions.begin(), _3CGlobalOptions.AllocatorFunctions.end(),
+  if (std::find(_3CGlobalOptions.AllocatorFunctions.begin(),
+                _3CGlobalOptions.AllocatorFunctions.end(),
                 FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
       FuncName.compare("malloc") == 0)
     E = CE->getArg(0);

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -106,8 +106,8 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (std::find(AllocatorFunctions.begin(), AllocatorFunctions.end(),
-                FuncName) != AllocatorFunctions.end() ||
+  if (std::find(_3CGlobalOptions.AllocatorFunctions.begin(), _3CGlobalOptions.AllocatorFunctions.end(),
+                FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
       FuncName.compare("malloc") == 0)
     E = CE->getArg(0);
   else {
@@ -646,7 +646,7 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
       P->constrainToWild(Info.getConstraints(), Rsn, &PL);
       Ret = pairWithEmptyBkey({P});
     } else {
-      if (Verbose) {
+      if (_3CGlobalOptions.Verbose) {
         llvm::errs() << "WARNING! Initialization expression ignored: ";
         E->dump(llvm::errs(), *Context);
         llvm::errs() << "\n";
@@ -693,7 +693,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,
 
   // Only if all types are enabled and these are not pointers, then track
   // the assignment.
-  if (AllTypes) {
+  if (_3CGlobalOptions.AllTypes) {
     if ((!containsValidCons(L.first) && !containsValidCons(R.first)) ||
         !HandleBoundsKey) {
       ABI.handleAssignment(LHS, L.first, L.second, RHS, R.first, R.second,
@@ -718,7 +718,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
   if (V.hasValue())
     constrainConsVarGeq(&V.getValue(), RHSCons.first, Info.getConstraints(),
                         PLPtr, CAction, false, &Info, HandleBoundsKey);
-  if (AllTypes && !IgnoreBnds) {
+  if (_3CGlobalOptions.AllTypes && !IgnoreBnds) {
     if (!HandleBoundsKey || (!(V.hasValue() && isValidCons(&V.getValue())) &&
                              !containsValidCons(RHSCons.first))) {
       auto &ABI = Info.getABoundsInfo();

--- a/clang/lib/3C/ConstraintResolver.cpp
+++ b/clang/lib/3C/ConstraintResolver.cpp
@@ -106,9 +106,9 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (std::find(_3CGlobalOptions.AllocatorFunctions.begin(),
-                _3CGlobalOptions.AllocatorFunctions.end(),
-                FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
+  if (std::find(_3COpts.AllocatorFunctions.begin(),
+                _3COpts.AllocatorFunctions.end(),
+                FuncName) != _3COpts.AllocatorFunctions.end() ||
       FuncName.compare("malloc") == 0)
     E = CE->getArg(0);
   else {
@@ -647,7 +647,7 @@ CSetBkeyPair ConstraintResolver::getExprConstraintVars(Expr *E) {
       P->constrainToWild(Info.getConstraints(), Rsn, &PL);
       Ret = pairWithEmptyBkey({P});
     } else {
-      if (_3CGlobalOptions.Verbose) {
+      if (_3COpts.Verbose) {
         llvm::errs() << "WARNING! Initialization expression ignored: ";
         E->dump(llvm::errs(), *Context);
         llvm::errs() << "\n";
@@ -694,7 +694,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,
 
   // Only if all types are enabled and these are not pointers, then track
   // the assignment.
-  if (_3CGlobalOptions.AllTypes) {
+  if (_3COpts.AllTypes) {
     if ((!containsValidCons(L.first) && !containsValidCons(R.first)) ||
         !HandleBoundsKey) {
       ABI.handleAssignment(LHS, L.first, L.second, RHS, R.first, R.second,
@@ -719,7 +719,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
   if (V.hasValue())
     constrainConsVarGeq(&V.getValue(), RHSCons.first, Info.getConstraints(),
                         PLPtr, CAction, false, &Info, HandleBoundsKey);
-  if (_3CGlobalOptions.AllTypes && !IgnoreBnds) {
+  if (_3COpts.AllTypes && !IgnoreBnds) {
     if (!HandleBoundsKey || (!(V.hasValue() && isValidCons(&V.getValue())) &&
                              !containsValidCons(RHSCons.first))) {
       auto &ABI = Info.getABoundsInfo();

--- a/clang/lib/3C/Constraints.cpp
+++ b/clang/lib/3C/Constraints.cpp
@@ -64,7 +64,7 @@ bool Constraints::removeConstraint(Constraint *C) {
 // Check if we can add this constraint. This provides a global switch to
 // control what constraints we can add to our system.
 void Constraints::editConstraintHook(Constraint *C) {
-  if (!AllTypes) {
+  if (!_3CGlobalOptions.AllTypes) {
     // Invalidate any pointer-type constraints.
     if (Geq *E = dyn_cast<Geq>(C)) {
       if (!E->constraintIsChecked()) {
@@ -236,7 +236,7 @@ doSolve(ConstraintsGraph &CG,
           // new WILD-ness.
           Conflicts.insert(VA);
           // Failure case.
-          if (Verbose) {
+          if (_3CGlobalOptions.Verbose) {
             errs() << "Unsolvable constraints: ";
             VA->print(errs());
             errs() << "=";
@@ -352,7 +352,7 @@ bool Constraints::graphBasedSolve() {
   bool Res = doSolve(SolChkCG, Env, this, true, nullptr, Conflicts);
 
   // Now solve PtrType constraints
-  if (Res && AllTypes) {
+  if (Res && _3CGlobalOptions.AllTypes) {
     Env.doCheckedSolve(false);
     bool RegularSolve = !(OnlyGreatestSol || OnlyLeastSol);
 

--- a/clang/lib/3C/Constraints.cpp
+++ b/clang/lib/3C/Constraints.cpp
@@ -64,7 +64,7 @@ bool Constraints::removeConstraint(Constraint *C) {
 // Check if we can add this constraint. This provides a global switch to
 // control what constraints we can add to our system.
 void Constraints::editConstraintHook(Constraint *C) {
-  if (!_3CGlobalOptions.AllTypes) {
+  if (!_3COpts.AllTypes) {
     // Invalidate any pointer-type constraints.
     if (Geq *E = dyn_cast<Geq>(C)) {
       if (!E->constraintIsChecked()) {
@@ -236,7 +236,7 @@ doSolve(ConstraintsGraph &CG,
           // new WILD-ness.
           Conflicts.insert(VA);
           // Failure case.
-          if (_3CGlobalOptions.Verbose) {
+          if (_3COpts.Verbose) {
             errs() << "Unsolvable constraints: ";
             VA->print(errs());
             errs() << "=";
@@ -352,7 +352,7 @@ bool Constraints::graphBasedSolve() {
   bool Res = doSolve(SolChkCG, Env, this, true, nullptr, Conflicts);
 
   // Now solve PtrType constraints
-  if (Res && _3CGlobalOptions.AllTypes) {
+  if (Res && _3COpts.AllTypes) {
     Env.doCheckedSolve(false);
     bool RegularSolve = !(OnlyGreatestSol || OnlyLeastSol);
 

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -37,7 +37,7 @@ void DeclRewriter::buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
                                   ProgramInfo &Info, ArrayBoundsRewriter &ABR) {
   const EnvironmentMap &Env = Info.getConstraints().getVariables();
   bool IsTypedefVarUnchecked =
-    Defn->isTypedef() && (_3CGlobalOptions.ItypesForExtern ||
+    Defn->isTypedef() && (_3COpts.ItypesForExtern ||
                           !Defn->getTypedefVar()->isSolutionChecked(Env));
   if (Defn->getFV()) {
     // This declaration is for a function pointer. Writing itypes on function
@@ -122,7 +122,7 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
     // Don't convert typedefs when -itype-for-extern is passed. Typedefs will
     // keep their unchecked type but function using the typedef will be given a
     // checked itype.
-    if (!_3CGlobalOptions.ItypesForExtern && TD) {
+    if (!_3COpts.ItypesForExtern && TD) {
       auto PSL = PersistentSourceLoc::mkPSL(TD, Context);
       // Don't rewrite base types like int
       if (!TD->getUnderlyingType()->isBuiltinType()) {
@@ -195,7 +195,7 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
         bool IsExternGlobalVar =
           isa<VarDecl>(D) &&
           cast<VarDecl>(D)->getFormalLinkage() == Linkage::ExternalLinkage;
-        if (_3CGlobalOptions.ItypesForExtern &&
+        if (_3COpts.ItypesForExtern &&
             (isa<FieldDecl>(D) || IsExternGlobalVar)) {
           // Give record fields and global variables itypes when using
           // -itypes-for-extern. Note that we haven't properly implemented
@@ -248,7 +248,7 @@ void DeclRewriter::rewrite(RSet &ToRewrite) {
     DeclReplacement *N = Pair.second;
     assert(N->getDecl() != nullptr);
 
-    if (_3CGlobalOptions.Verbose) {
+    if (_3COpts.Verbose) {
       errs() << "Replacing type of decl:\n";
       N->getDecl()->dump();
       errs() << "with " << N->getReplacement() << "\n";
@@ -279,7 +279,7 @@ void DeclRewriter::rewriteTypedefDecl(TypedefDeclReplacement *TDR,
 // SourceLocations will be generated incorrectly if we rewrite it as a
 // normal multidecl.
 bool isInlineStruct(std::vector<Decl *> &InlineDecls) {
-  if (InlineDecls.size() >= 2 && _3CGlobalOptions.AllTypes)
+  if (InlineDecls.size() >= 2 && _3COpts.AllTypes)
     return isa<RecordDecl>(InlineDecls[0]) &&
            std::all_of(InlineDecls.begin() + 1, InlineDecls.end(),
                        [](Decl *D) { return isa<VarDecl>(D); });
@@ -800,7 +800,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
   bool CheckedSolution = CV->hasCheckedSolution(Info.getConstraints());
   bool ItypeSolution = CV->hasItypeSolution(Info.getConstraints());
   if (ItypeSolution ||
-      (CheckedSolution && _3CGlobalOptions.ItypesForExtern && !StaticFunc)) {
+      (CheckedSolution && _3COpts.ItypesForExtern && !StaticFunc)) {
     buildItypeDecl(CV->getExternal(), Decl, Type, IType, RewriteParm,
                    RewriteRet);
     return;

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -195,7 +195,8 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
         bool IsExternGlobalVar =
           isa<VarDecl>(D) &&
           cast<VarDecl>(D)->getFormalLinkage() == Linkage::ExternalLinkage;
-        if (_3CGlobalOptions.ItypesForExtern && (isa<FieldDecl>(D) || IsExternGlobalVar)) {
+        if (_3CGlobalOptions.ItypesForExtern &&
+            (isa<FieldDecl>(D) || IsExternGlobalVar)) {
           // Give record fields and global variables itypes when using
           // -itypes-for-extern. Note that we haven't properly implemented
           // itypes for structures and globals. This just rewrites to an itype
@@ -798,7 +799,8 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
 
   bool CheckedSolution = CV->hasCheckedSolution(Info.getConstraints());
   bool ItypeSolution = CV->hasItypeSolution(Info.getConstraints());
-  if (ItypeSolution || (CheckedSolution && _3CGlobalOptions.ItypesForExtern && !StaticFunc)) {
+  if (ItypeSolution ||
+      (CheckedSolution && _3CGlobalOptions.ItypesForExtern && !StaticFunc)) {
     buildItypeDecl(CV->getExternal(), Decl, Type, IType, RewriteParm,
                    RewriteRet);
     return;

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -37,7 +37,7 @@ void DeclRewriter::buildItypeDecl(PVConstraint *Defn, DeclaratorDecl *Decl,
                                   ProgramInfo &Info, ArrayBoundsRewriter &ABR) {
   const EnvironmentMap &Env = Info.getConstraints().getVariables();
   bool IsTypedefVarUnchecked =
-    Defn->isTypedef() && (ItypesForExtern ||
+    Defn->isTypedef() && (_3CGlobalOptions.ItypesForExtern ||
                           !Defn->getTypedefVar()->isSolutionChecked(Env));
   if (Defn->getFV()) {
     // This declaration is for a function pointer. Writing itypes on function
@@ -122,7 +122,7 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
     // Don't convert typedefs when -itype-for-extern is passed. Typedefs will
     // keep their unchecked type but function using the typedef will be given a
     // checked itype.
-    if (!ItypesForExtern && TD) {
+    if (!_3CGlobalOptions.ItypesForExtern && TD) {
       auto PSL = PersistentSourceLoc::mkPSL(TD, Context);
       // Don't rewrite base types like int
       if (!TD->getUnderlyingType()->isBuiltinType()) {
@@ -195,7 +195,7 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
         bool IsExternGlobalVar =
           isa<VarDecl>(D) &&
           cast<VarDecl>(D)->getFormalLinkage() == Linkage::ExternalLinkage;
-        if (ItypesForExtern && (isa<FieldDecl>(D) || IsExternGlobalVar)) {
+        if (_3CGlobalOptions.ItypesForExtern && (isa<FieldDecl>(D) || IsExternGlobalVar)) {
           // Give record fields and global variables itypes when using
           // -itypes-for-extern. Note that we haven't properly implemented
           // itypes for structures and globals. This just rewrites to an itype
@@ -247,7 +247,7 @@ void DeclRewriter::rewrite(RSet &ToRewrite) {
     DeclReplacement *N = Pair.second;
     assert(N->getDecl() != nullptr);
 
-    if (Verbose) {
+    if (_3CGlobalOptions.Verbose) {
       errs() << "Replacing type of decl:\n";
       N->getDecl()->dump();
       errs() << "with " << N->getReplacement() << "\n";
@@ -278,7 +278,7 @@ void DeclRewriter::rewriteTypedefDecl(TypedefDeclReplacement *TDR,
 // SourceLocations will be generated incorrectly if we rewrite it as a
 // normal multidecl.
 bool isInlineStruct(std::vector<Decl *> &InlineDecls) {
-  if (InlineDecls.size() >= 2 && AllTypes)
+  if (InlineDecls.size() >= 2 && _3CGlobalOptions.AllTypes)
     return isa<RecordDecl>(InlineDecls[0]) &&
            std::all_of(InlineDecls.begin() + 1, InlineDecls.end(),
                        [](Decl *D) { return isa<VarDecl>(D); });
@@ -798,7 +798,7 @@ void FunctionDeclBuilder::buildDeclVar(const FVComponentVariable *CV,
 
   bool CheckedSolution = CV->hasCheckedSolution(Info.getConstraints());
   bool ItypeSolution = CV->hasItypeSolution(Info.getConstraints());
-  if (ItypeSolution || (CheckedSolution && ItypesForExtern && !StaticFunc)) {
+  if (ItypeSolution || (CheckedSolution && _3CGlobalOptions.ItypesForExtern && !StaticFunc)) {
     buildItypeDecl(CV->getExternal(), Decl, Type, IType, RewriteParm,
                    RewriteRet);
     return;

--- a/clang/lib/3C/MappingVisitor.cpp
+++ b/clang/lib/3C/MappingVisitor.cpp
@@ -28,7 +28,7 @@ bool MappingVisitor::VisitDeclStmt(DeclStmt *S) {
       Decl *D = nullptr;
       Stmt *So = nullptr;
       std::tie<Stmt *, Decl *>(So, D) = PSLtoSDT[PSL];
-      if (So != nullptr && Verbose) {
+      if (So != nullptr && _3CGlobalOptions.Verbose) {
         llvm::errs() << "\nOverriding ";
         S->dump();
         llvm::errs() << "\n";
@@ -65,7 +65,7 @@ bool MappingVisitor::VisitDecl(Decl *D) {
       Decl *Do = nullptr;
       Stmt *S = nullptr;
       std::tie<Stmt *, Decl *>(S, Do) = PSLtoSDT[PSL];
-      if (Do != nullptr && Verbose) {
+      if (Do != nullptr && _3CGlobalOptions.Verbose) {
         llvm::errs() << "Overriding ";
         Do->dump();
         llvm::errs() << " with ";

--- a/clang/lib/3C/MappingVisitor.cpp
+++ b/clang/lib/3C/MappingVisitor.cpp
@@ -28,7 +28,7 @@ bool MappingVisitor::VisitDeclStmt(DeclStmt *S) {
       Decl *D = nullptr;
       Stmt *So = nullptr;
       std::tie<Stmt *, Decl *>(So, D) = PSLtoSDT[PSL];
-      if (So != nullptr && _3CGlobalOptions.Verbose) {
+      if (So != nullptr && _3COpts.Verbose) {
         llvm::errs() << "\nOverriding ";
         S->dump();
         llvm::errs() << "\n";
@@ -65,7 +65,7 @@ bool MappingVisitor::VisitDecl(Decl *D) {
       Decl *Do = nullptr;
       Stmt *S = nullptr;
       std::tie<Stmt *, Decl *>(S, Do) = PSLtoSDT[PSL];
-      if (Do != nullptr && _3CGlobalOptions.Verbose) {
+      if (Do != nullptr && _3COpts.Verbose) {
         llvm::errs() << "Overriding ";
         Do->dump();
         llvm::errs() << " with ";

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -169,7 +169,7 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
   for (auto &I : Variables) {
     ConstraintVariable *C = I.second;
     std::string FileName = I.first.getFileName();
-    if (F.count(FileName) || FileName.find(BaseDir) != std::string::npos) {
+    if (F.count(FileName) || FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
       if (C->isForValidDecl()) {
         FoundVars.clear();
         getVarsFromConstraint(C, FoundVars, Visited);
@@ -236,8 +236,8 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
 void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
                              bool OnlySummary, bool JsonFormat) {
   if (!OnlySummary && !JsonFormat) {
-    O << "Enable itype propagation:" << EnablePropThruIType << "\n";
-    O << "Sound handling of var args functions:" << HandleVARARGS << "\n";
+    O << "Enable itype propagation:" << _3CGlobalOptions.EnablePropThruIType << "\n";
+    O << "Sound handling of var args functions:" << _3CGlobalOptions.HandleVARARGS << "\n";
   }
   std::map<std::string, std::tuple<int, int, int, int, int>> FilesToVars;
   CVarSet InSrcCVars, Visited;
@@ -247,7 +247,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
   // First, build the map and perform the aggregation.
   for (auto &I : Variables) {
     std::string FileName = I.first.getFileName();
-    if (F.count(FileName) || FileName.find(BaseDir) != std::string::npos) {
+    if (F.count(FileName) || FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
       int VarC = 0;
       int PC = 0;
       int NtaC = 0;
@@ -352,7 +352,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
     O << "}},\n";
   }
 
-  if (AllTypes) {
+  if (_3CGlobalOptions.AllTypes) {
     if (JsonFormat) {
       O << "\"BoundsStats\":";
     }
@@ -375,7 +375,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
 bool ProgramInfo::link() {
   // For every global symbol in all the global symbols that we have found
   // go through and apply rules for whether they are functions or variables.
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     llvm::errs() << "Linking!\n";
 
   // Equate the constraints for all global variables.
@@ -387,7 +387,7 @@ bool ProgramInfo::link() {
       std::set<PVConstraint *>::iterator I = C.begin();
       std::set<PVConstraint *>::iterator J = C.begin();
       ++J;
-      if (Verbose)
+      if (_3CGlobalOptions.Verbose)
         llvm::errs() << "Global variables:" << V.first << "\n";
       while (J != C.end()) {
         constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, this);
@@ -662,7 +662,7 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
       // constrain to WILD even if we don't end up storing this in the map.
       constrainWildIfMacro(PVExternal, PVD->getLocation());
       // If this is "main", constrain its argv parameter to a nested arr
-      if (AllTypes && FuncName == "main" && FD->isGlobal() && I == 1) {
+      if (_3CGlobalOptions.AllTypes && FuncName == "main" && FD->isGlobal() && I == 1) {
         PVInternal->constrainOuterTo(CS, CS.getArr());
         PVInternal->constrainIdxTo(CS, CS.getNTArr(), 1);
       }
@@ -720,7 +720,7 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
 
 void ProgramInfo::ensureNtCorrect(const QualType &QT, const ASTContext &C,
                                   PointerVariableConstraint *PV) {
-  if (AllTypes && !canBeNtArray(QT)) {
+  if (_3CGlobalOptions.AllTypes && !canBeNtArray(QT)) {
     PV->constrainOuterTo(CS, CS.getArr(), true, true);
   }
 }

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -170,7 +170,7 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
     ConstraintVariable *C = I.second;
     std::string FileName = I.first.getFileName();
     if (F.count(FileName) ||
-        FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
+        FileName.find(_3COpts.BaseDir) != std::string::npos) {
       if (C->isForValidDecl()) {
         FoundVars.clear();
         getVarsFromConstraint(C, FoundVars, Visited);
@@ -237,10 +237,10 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
 void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
                              bool OnlySummary, bool JsonFormat) {
   if (!OnlySummary && !JsonFormat) {
-    O << "Enable itype propagation:" << _3CGlobalOptions.EnablePropThruIType
+    O << "Enable itype propagation:" << _3COpts.EnablePropThruIType
       << "\n";
     O << "Sound handling of var args functions:"
-      << _3CGlobalOptions.HandleVARARGS << "\n";
+      << _3COpts.HandleVARARGS << "\n";
   }
   std::map<std::string, std::tuple<int, int, int, int, int>> FilesToVars;
   CVarSet InSrcCVars, Visited;
@@ -251,7 +251,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
   for (auto &I : Variables) {
     std::string FileName = I.first.getFileName();
     if (F.count(FileName) ||
-        FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
+        FileName.find(_3COpts.BaseDir) != std::string::npos) {
       int VarC = 0;
       int PC = 0;
       int NtaC = 0;
@@ -356,7 +356,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
     O << "}},\n";
   }
 
-  if (_3CGlobalOptions.AllTypes) {
+  if (_3COpts.AllTypes) {
     if (JsonFormat) {
       O << "\"BoundsStats\":";
     }
@@ -379,7 +379,7 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
 bool ProgramInfo::link() {
   // For every global symbol in all the global symbols that we have found
   // go through and apply rules for whether they are functions or variables.
-  if (_3CGlobalOptions.Verbose)
+  if (_3COpts.Verbose)
     llvm::errs() << "Linking!\n";
 
   // Equate the constraints for all global variables.
@@ -391,7 +391,7 @@ bool ProgramInfo::link() {
       std::set<PVConstraint *>::iterator I = C.begin();
       std::set<PVConstraint *>::iterator J = C.begin();
       ++J;
-      if (_3CGlobalOptions.Verbose)
+      if (_3COpts.Verbose)
         llvm::errs() << "Global variables:" << V.first << "\n";
       while (J != C.end()) {
         constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, this);
@@ -666,7 +666,7 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
       // constrain to WILD even if we don't end up storing this in the map.
       constrainWildIfMacro(PVExternal, PVD->getLocation());
       // If this is "main", constrain its argv parameter to a nested arr
-      if (_3CGlobalOptions.AllTypes && FuncName == "main" && FD->isGlobal() &&
+      if (_3COpts.AllTypes && FuncName == "main" && FD->isGlobal() &&
           I == 1) {
         PVInternal->constrainOuterTo(CS, CS.getArr());
         PVInternal->constrainIdxTo(CS, CS.getNTArr(), 1);
@@ -725,7 +725,7 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
 
 void ProgramInfo::ensureNtCorrect(const QualType &QT, const ASTContext &C,
                                   PointerVariableConstraint *PV) {
-  if (_3CGlobalOptions.AllTypes && !canBeNtArray(QT)) {
+  if (_3COpts.AllTypes && !canBeNtArray(QT)) {
     PV->constrainOuterTo(CS, CS.getArr(), true, true);
   }
 }

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -169,7 +169,8 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
   for (auto &I : Variables) {
     ConstraintVariable *C = I.second;
     std::string FileName = I.first.getFileName();
-    if (F.count(FileName) || FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
+    if (F.count(FileName) ||
+        FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
       if (C->isForValidDecl()) {
         FoundVars.clear();
         getVarsFromConstraint(C, FoundVars, Visited);
@@ -236,8 +237,10 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
 void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
                              bool OnlySummary, bool JsonFormat) {
   if (!OnlySummary && !JsonFormat) {
-    O << "Enable itype propagation:" << _3CGlobalOptions.EnablePropThruIType << "\n";
-    O << "Sound handling of var args functions:" << _3CGlobalOptions.HandleVARARGS << "\n";
+    O << "Enable itype propagation:" << _3CGlobalOptions.EnablePropThruIType
+      << "\n";
+    O << "Sound handling of var args functions:"
+      << _3CGlobalOptions.HandleVARARGS << "\n";
   }
   std::map<std::string, std::tuple<int, int, int, int, int>> FilesToVars;
   CVarSet InSrcCVars, Visited;
@@ -247,7 +250,8 @@ void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
   // First, build the map and perform the aggregation.
   for (auto &I : Variables) {
     std::string FileName = I.first.getFileName();
-    if (F.count(FileName) || FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
+    if (F.count(FileName) ||
+        FileName.find(_3CGlobalOptions.BaseDir) != std::string::npos) {
       int VarC = 0;
       int PC = 0;
       int NtaC = 0;
@@ -662,7 +666,8 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
       // constrain to WILD even if we don't end up storing this in the map.
       constrainWildIfMacro(PVExternal, PVD->getLocation());
       // If this is "main", constrain its argv parameter to a nested arr
-      if (_3CGlobalOptions.AllTypes && FuncName == "main" && FD->isGlobal() && I == 1) {
+      if (_3CGlobalOptions.AllTypes && FuncName == "main" && FD->isGlobal() &&
+          I == 1) {
         PVInternal->constrainOuterTo(CS, CS.getArr());
         PVInternal->constrainIdxTo(CS, CS.getNTArr(), 1);
       }

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -237,10 +237,9 @@ void ProgramInfo::printAggregateStats(const std::set<std::string> &F,
 void ProgramInfo::printStats(const std::set<std::string> &F, raw_ostream &O,
                              bool OnlySummary, bool JsonFormat) {
   if (!OnlySummary && !JsonFormat) {
-    O << "Enable itype propagation:" << _3COpts.EnablePropThruIType
+    O << "Enable itype propagation:" << _3COpts.EnablePropThruIType << "\n";
+    O << "Sound handling of var args functions:" << _3COpts.HandleVARARGS
       << "\n";
-    O << "Sound handling of var args functions:"
-      << _3COpts.HandleVARARGS << "\n";
   }
   std::map<std::string, std::tuple<int, int, int, int, int>> FilesToVars;
   CVarSet InSrcCVars, Visited;
@@ -666,8 +665,7 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
       // constrain to WILD even if we don't end up storing this in the map.
       constrainWildIfMacro(PVExternal, PVD->getLocation());
       // If this is "main", constrain its argv parameter to a nested arr
-      if (_3COpts.AllTypes && FuncName == "main" && FD->isGlobal() &&
-          I == 1) {
+      if (_3COpts.AllTypes && FuncName == "main" && FD->isGlobal() && I == 1) {
         PVInternal->constrainOuterTo(CS, CS.getArr());
         PVInternal->constrainIdxTo(CS, CS.getNTArr(), 1);
       }

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -120,7 +120,8 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
   if (_3CGlobalOptions.Verbose)
     errs() << "Writing files out\n";
 
-  bool StdoutMode = (_3CGlobalOptions.OutputPostfix == "-" && _3CGlobalOptions.OutputDir.empty());
+  bool StdoutMode = (_3CGlobalOptions.OutputPostfix == "-" &&
+                     _3CGlobalOptions.OutputDir.empty());
   SourceManager &SM = C.getSourceManager();
   // Iterate over each modified rewrite buffer.
   for (auto Buffer = R.buffer_begin(); Buffer != R.buffer_end(); ++Buffer) {
@@ -133,7 +134,7 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
       DiagnosticsEngine &DE = C.getDiagnostics();
       DiagnosticsEngine::Level UnwritableChangeDiagnosticLevel =
           _3CGlobalOptions.AllowUnwritableChanges ? DiagnosticsEngine::Warning
-                                 : DiagnosticsEngine::Error;
+                                                  : DiagnosticsEngine::Error;
       auto PrintExtraUnwritableChangeInfo = [&]() {
         // With -dump-unwritable-changes and not -allow-unwritable-changes, we
         // want the -allow-unwritable-changes note before the dump.
@@ -262,7 +263,8 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
         // OK because tryGetCanonicalFilePath should ensure that neither BaseDir
         // nor OutputDir has a trailing separator.
         SmallString<255> Tmp(FeAbsS);
-        llvm::sys::path::replace_path_prefix(Tmp, _3CGlobalOptions.BaseDir, _3CGlobalOptions.OutputDir);
+        llvm::sys::path::replace_path_prefix(Tmp, _3CGlobalOptions.BaseDir,
+                                             _3CGlobalOptions.OutputDir);
         NFile = std::string(Tmp.str());
         EC = llvm::sys::fs::create_directories(sys::path::parent_path(NFile));
         if (EC) {
@@ -594,7 +596,8 @@ void RewriteConsumer::emitRootCauseDiagnostics(ASTContext &Context) {
         // or are in the main file of the TU. Alternatively, don't filter causes
         // if -warn-all-root-cause is passed.
         int PtrCount = I.getNumPtrsAffected(WReason.first);
-        if (_3CGlobalOptions.WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 1) {
+        if (_3CGlobalOptions.WarnAllRootCause || SM.isInMainFile(SL) ||
+            PtrCount > 1) {
           // SL is invalid when the File is not in the current translation unit.
           if (SL.isValid()) {
             EmittedDiagnostics.insert(PSL);
@@ -621,7 +624,8 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
   // Take care of some other rewriting tasks
   std::set<llvm::FoldingSetNodeID> Seen;
   std::map<llvm::FoldingSetNodeID, AnnotationNeeded> NodeMap;
-  CheckedRegionFinder CRF(&Context, R, Info, Seen, NodeMap, _3CGlobalOptions.WarnRootCause);
+  CheckedRegionFinder CRF(&Context, R, Info, Seen, NodeMap,
+                          _3CGlobalOptions.WarnRootCause);
   CheckedRegionAdder CRA(&Context, R, NodeMap, Info);
   CastLocatorVisitor CLV(&Context);
   CastPlacementVisitor ECPV(&Context, Info, R, CLV.getExprsWithCast());

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -120,8 +120,7 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
   if (_3COpts.Verbose)
     errs() << "Writing files out\n";
 
-  bool StdoutMode = (_3COpts.OutputPostfix == "-" &&
-                     _3COpts.OutputDir.empty());
+  bool StdoutMode = (_3COpts.OutputPostfix == "-" && _3COpts.OutputDir.empty());
   SourceManager &SM = C.getSourceManager();
   // Iterate over each modified rewrite buffer.
   for (auto Buffer = R.buffer_begin(); Buffer != R.buffer_end(); ++Buffer) {
@@ -596,8 +595,7 @@ void RewriteConsumer::emitRootCauseDiagnostics(ASTContext &Context) {
         // or are in the main file of the TU. Alternatively, don't filter causes
         // if -warn-all-root-cause is passed.
         int PtrCount = I.getNumPtrsAffected(WReason.first);
-        if (_3COpts.WarnAllRootCause || SM.isInMainFile(SL) ||
-            PtrCount > 1) {
+        if (_3COpts.WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 1) {
           // SL is invalid when the File is not in the current translation unit.
           if (SL.isValid()) {
             EmittedDiagnostics.insert(PSL);

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -96,7 +96,7 @@ void rewriteSourceRange(Rewriter &R, const CharSourceRange &Range,
   // crashing with an assert fail.
   if (!RewriteSuccess) {
     clang::DiagnosticsEngine &DE = R.getSourceMgr().getDiagnostics();
-    bool ReportError = ErrFail && !AllowRewriteFailures;
+    bool ReportError = ErrFail && !_3CGlobalOptions.AllowRewriteFailures;
     reportCustomDiagnostic(
         DE,
         ReportError ? DiagnosticsEngine::Error : DiagnosticsEngine::Warning,
@@ -117,10 +117,10 @@ void rewriteSourceRange(Rewriter &R, const CharSourceRange &Range,
 }
 
 static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
-  if (Verbose)
+  if (_3CGlobalOptions.Verbose)
     errs() << "Writing files out\n";
 
-  bool StdoutMode = (OutputPostfix == "-" && OutputDir.empty());
+  bool StdoutMode = (_3CGlobalOptions.OutputPostfix == "-" && _3CGlobalOptions.OutputDir.empty());
   SourceManager &SM = C.getSourceManager();
   // Iterate over each modified rewrite buffer.
   for (auto Buffer = R.buffer_begin(); Buffer != R.buffer_end(); ++Buffer) {
@@ -132,26 +132,26 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
 
       DiagnosticsEngine &DE = C.getDiagnostics();
       DiagnosticsEngine::Level UnwritableChangeDiagnosticLevel =
-          AllowUnwritableChanges ? DiagnosticsEngine::Warning
+          _3CGlobalOptions.AllowUnwritableChanges ? DiagnosticsEngine::Warning
                                  : DiagnosticsEngine::Error;
       auto PrintExtraUnwritableChangeInfo = [&]() {
         // With -dump-unwritable-changes and not -allow-unwritable-changes, we
         // want the -allow-unwritable-changes note before the dump.
-        if (!DumpUnwritableChanges) {
+        if (!_3CGlobalOptions.DumpUnwritableChanges) {
           reportCustomDiagnostic(
               DE, DiagnosticsEngine::Note,
               "use the -dump-unwritable-changes option to see the new version "
               "of the file",
               SourceLocation());
         }
-        if (!AllowUnwritableChanges) {
+        if (!_3CGlobalOptions.AllowUnwritableChanges) {
           reportCustomDiagnostic(
               DE, DiagnosticsEngine::Note,
               "you can use the -allow-unwritable-changes option to temporarily "
               "downgrade this error to a warning",
               SourceLocation());
         }
-        if (DumpUnwritableChanges) {
+        if (_3CGlobalOptions.DumpUnwritableChanges) {
           errs() << "=== Beginning of new version of " << FE->getName()
                  << " ===\n";
           Buffer->second.write(errs());
@@ -240,7 +240,7 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
       // because stdout mode is handled above. OutputPostfix defaults to "-"
       // when it's not provided, so any other value means that we should use
       // OutputPostfix. Otherwise, we must be in OutputDir mode.
-      if (OutputPostfix != "-") {
+      if (_3CGlobalOptions.OutputPostfix != "-") {
         // That path should be the same as the old one, with a
         // suffix added between the file name and the extension.
         // For example \foo\bar\a.c should become \foo\bar\a.checked.c
@@ -250,19 +250,19 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
         std::string FileName = sys::path::remove_leading_dotslash(PfName).str();
         std::string Ext = sys::path::extension(FileName).str();
         std::string Stem = sys::path::stem(FileName).str();
-        NFile = Stem + "." + OutputPostfix + Ext;
+        NFile = Stem + "." + _3CGlobalOptions.OutputPostfix + Ext;
         if (!DirName.empty())
           NFile = DirName + sys::path::get_separator().str() + NFile;
       } else {
-        assert(!OutputDir.empty());
+        assert(!_3CGlobalOptions.OutputDir.empty());
         // If this does not hold when OutputDir is set, it should have been a
         // fatal error in the _3CInterface constructor.
-        assert(filePathStartsWith(FeAbsS, BaseDir));
+        assert(filePathStartsWith(FeAbsS, _3CGlobalOptions.BaseDir));
         // replace_path_prefix is not smart about separators, but this should be
         // OK because tryGetCanonicalFilePath should ensure that neither BaseDir
         // nor OutputDir has a trailing separator.
         SmallString<255> Tmp(FeAbsS);
-        llvm::sys::path::replace_path_prefix(Tmp, BaseDir, OutputDir);
+        llvm::sys::path::replace_path_prefix(Tmp, _3CGlobalOptions.BaseDir, _3CGlobalOptions.OutputDir);
         NFile = std::string(Tmp.str());
         EC = llvm::sys::fs::create_directories(sys::path::parent_path(NFile));
         if (EC) {
@@ -278,7 +278,7 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
       raw_fd_ostream Out(NFile, EC, sys::fs::F_None);
 
       if (!EC) {
-        if (Verbose)
+        if (_3CGlobalOptions.Verbose)
           errs() << "writing out " << NFile << "\n";
         Buffer->second.write(Out);
       } else {
@@ -594,7 +594,7 @@ void RewriteConsumer::emitRootCauseDiagnostics(ASTContext &Context) {
         // or are in the main file of the TU. Alternatively, don't filter causes
         // if -warn-all-root-cause is passed.
         int PtrCount = I.getNumPtrsAffected(WReason.first);
-        if (WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 1) {
+        if (_3CGlobalOptions.WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 1) {
           // SL is invalid when the File is not in the current translation unit.
           if (SL.isValid()) {
             EmittedDiagnostics.insert(PSL);
@@ -611,7 +611,7 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
 
   Info.getPerfStats().startRewritingTime();
 
-  if (WarnRootCause)
+  if (_3CGlobalOptions.WarnRootCause)
     emitRootCauseDiagnostics(Context);
 
   // Rewrite Variable declarations
@@ -621,7 +621,7 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
   // Take care of some other rewriting tasks
   std::set<llvm::FoldingSetNodeID> Seen;
   std::map<llvm::FoldingSetNodeID, AnnotationNeeded> NodeMap;
-  CheckedRegionFinder CRF(&Context, R, Info, Seen, NodeMap, WarnRootCause);
+  CheckedRegionFinder CRF(&Context, R, Info, Seen, NodeMap, _3CGlobalOptions.WarnRootCause);
   CheckedRegionAdder CRA(&Context, R, NodeMap, Info);
   CastLocatorVisitor CLV(&Context);
   CastPlacementVisitor ECPV(&Context, Info, R, CLV.getExprsWithCast());
@@ -629,7 +629,7 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
   TypeArgumentAdder TPA(&Context, Info, R);
   TranslationUnitDecl *TUD = Context.getTranslationUnitDecl();
   for (const auto &D : TUD->decls()) {
-    if (AddCheckedRegions) {
+    if (_3CGlobalOptions.AddCheckedRegions) {
       // Adding checked regions enabled?
       // TODO: Should checked region finding happen somewhere else? This is
       //       supposed to be rewriting.

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -182,8 +182,8 @@ bool functionHasVarArgs(clang::FunctionDecl *FD) {
 }
 
 bool isFunctionAllocator(std::string FuncName) {
-  return std::find(AllocatorFunctions.begin(), AllocatorFunctions.end(),
-                   FuncName) != AllocatorFunctions.end() ||
+  return std::find(_3CGlobalOptions.AllocatorFunctions.begin(), _3CGlobalOptions.AllocatorFunctions.end(),
+                   FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
          llvm::StringSwitch<bool>(FuncName)
              .Cases("malloc", "calloc", "realloc", true)
              .Default(false);
@@ -372,7 +372,7 @@ bool canWrite(const std::string &FilePath) {
     return true;
   // Get the absolute path of the file and check that
   // the file path starts with the base directory.
-  return filePathStartsWith(FilePath, BaseDir);
+  return filePathStartsWith(FilePath, _3CGlobalOptions.BaseDir);
 }
 
 bool isInSysHeader(clang::Decl *D) {

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -182,7 +182,8 @@ bool functionHasVarArgs(clang::FunctionDecl *FD) {
 }
 
 bool isFunctionAllocator(std::string FuncName) {
-  return std::find(_3CGlobalOptions.AllocatorFunctions.begin(), _3CGlobalOptions.AllocatorFunctions.end(),
+  return std::find(_3CGlobalOptions.AllocatorFunctions.begin(),
+                   _3CGlobalOptions.AllocatorFunctions.end(),
                    FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
          llvm::StringSwitch<bool>(FuncName)
              .Cases("malloc", "calloc", "realloc", true)

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -182,9 +182,9 @@ bool functionHasVarArgs(clang::FunctionDecl *FD) {
 }
 
 bool isFunctionAllocator(std::string FuncName) {
-  return std::find(_3CGlobalOptions.AllocatorFunctions.begin(),
-                   _3CGlobalOptions.AllocatorFunctions.end(),
-                   FuncName) != _3CGlobalOptions.AllocatorFunctions.end() ||
+  return std::find(_3COpts.AllocatorFunctions.begin(),
+                   _3COpts.AllocatorFunctions.end(),
+                   FuncName) != _3COpts.AllocatorFunctions.end() ||
          llvm::StringSwitch<bool>(FuncName)
              .Cases("malloc", "calloc", "realloc", true)
              .Default(false);
@@ -373,7 +373,7 @@ bool canWrite(const std::string &FilePath) {
     return true;
   // Get the absolute path of the file and check that
   // the file path starts with the base directory.
-  return filePathStartsWith(FilePath, _3CGlobalOptions.BaseDir);
+  return filePathStartsWith(FilePath, _3COpts.BaseDir);
 }
 
 bool isInSysHeader(clang::Decl *D) {

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/3C.h"
+#include "clang/3C/3CGlobalOptions.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
@@ -291,11 +292,11 @@ int main(int argc, const char **argv) {
   CcOptions.ConstraintOutputJson = OptConstraintOutputJson.getValue();
   CcOptions.StatsOutputJson = OptStatsOutputJson.getValue();
   CcOptions.WildPtrInfoJson = OptWildPtrInfoJson.getValue();
-  CcOptions.PerPtrInfoJson = OptPerPtrWILDInfoJson.getValue();
+  CcOptions.PerWildPtrInfoJson = OptPerPtrWILDInfoJson.getValue();
   CcOptions.AddCheckedRegions = OptAddCheckedRegions;
-  CcOptions.EnableAllTypes = OptAllTypes;
+  CcOptions.AllTypes = OptAllTypes;
   CcOptions.EnableCCTypeChecker = OptEnableCCTypeChecker;
-  CcOptions.WarnRootCause = OptWarnRootCause;
+  CcOptions.WarnRootCause = OptWarnRootCause || OptWarnAllRootCause;
   CcOptions.WarnAllRootCause = OptWarnAllRootCause;
   CcOptions.DumpUnwritableChanges = OptDumpUnwritableChanges;
   CcOptions.AllowUnwritableChanges = OptAllowUnwritableChanges;

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -296,7 +296,7 @@ int main(int argc, const char **argv) {
   CcOptions.AddCheckedRegions = OptAddCheckedRegions;
   CcOptions.AllTypes = OptAllTypes;
   CcOptions.EnableCCTypeChecker = OptEnableCCTypeChecker;
-  CcOptions.WarnRootCause = OptWarnRootCause || OptWarnAllRootCause;
+  CcOptions.WarnRootCause = OptWarnRootCause;
   CcOptions.WarnAllRootCause = OptWarnAllRootCause;
   CcOptions.DumpUnwritableChanges = OptDumpUnwritableChanges;
   CcOptions.AllowUnwritableChanges = OptAllowUnwritableChanges;


### PR DESCRIPTION
We previously used the `_3COptions` structure to store command line options immediately after they were parsed, but later copied the option value out of this structure and into global variables to use in the rest of the program. This pull request deletes the global variables, and replaces them with a global `_3COptions` structure.