### PR TITLE
mkString fixes (mostly moved from the multi-decl overhaul)

### DIFF
--- a/clang/include/clang/3C/ConstraintVariables.h
+++ b/clang/include/clang/3C/ConstraintVariables.h
@@ -42,8 +42,15 @@ typedef std::set<ConstraintKey> CVars;
 // Holds Atoms, one for each of the pointer (*) declared in the program.
 typedef std::vector<Atom *> CAtoms;
 
+// Options for ConstraintVariable::mkString, using the code pattern described in
+// clang/include/clang/3C/OptionalParams.h. Use the MKSTRING_OPTS macro to
+// generate a MkStringOpts instance at a call site.
 struct MkStringOpts {
+  // True when the generated string should include
+  // the name of the variable, false for just the type.
   bool EmitName = true;
+  // True when the generated string is expected
+  // to be used inside an itype.
   bool ForItype = false;
   bool EmitPointee = false;
   bool UnmaskTypedef = false;
@@ -113,11 +120,12 @@ protected:
                          qtyToStr(QT, N == RETVAR ? "" : N)) {}
 
 public:
-  // Create a "for-rewriting" representation of this ConstraintVariable.
-  // The 'emitName' parameter is true when the generated string should include
-  // the name of the variable, false for just the type.
-  // The 'forIType' parameter is true when the generated string is expected
-  // to be used inside an itype.
+  // Generate source code for the type and (in certain cases) the name of the
+  // variable or function represented by this ConstraintVariable that reflects
+  // any changes made by 3C and is suitable to insert during rewriting.
+  //
+  // This method is used in several contexts with special requirements, which
+  // are addressed by the options in MkStringOpts; see the comments there.
   virtual std::string mkString(Constraints &CS,
                                const MkStringOpts &Opts = {}) const = 0;
 

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -852,9 +852,6 @@ PointerVariableConstraint::mkString(Constraints &CS,
     case Atom::A_Ptr:
       getQualString(TypeIdx, Ss);
 
-      // We need to check and see if this level of variable
-      // is constrained by a bounds safe interface. If it is,
-      // then we shouldn't re-write it.
       EmittedBase = false;
       Ss << "_Ptr<";
       EndStrs.push_front(">");
@@ -868,22 +865,16 @@ PointerVariableConstraint::mkString(Constraints &CS,
       // we should substitute [K].
       if (emitArraySize(ConstArrs, TypeIdx, K))
         break;
-      // We need to check and see if this level of variable
-      // is constrained by a bounds safe interface. If it is,
-      // then we shouldn't re-write it.
       EmittedBase = false;
       Ss << "_Array_ptr<";
       EndStrs.push_front(">");
       break;
     case Atom::A_NTArr:
-      if (emitArraySize(ConstArrs, TypeIdx, K))
-        break;
       // If this is an NTArray.
       getQualString(TypeIdx, Ss);
+      if (emitArraySize(ConstArrs, TypeIdx, K))
+        break;
 
-      // We need to check and see if this level of variable
-      // is constrained by a bounds safe interface. If it is,
-      // then we shouldn't re-write it.
       EmittedBase = false;
       Ss << "_Nt_array_ptr<";
       EndStrs.push_front(">");
@@ -894,8 +885,8 @@ PointerVariableConstraint::mkString(Constraints &CS,
       if (emitArraySize(ConstArrs, TypeIdx, K))
         break;
       // FIXME: This code emits wild pointer levels with the outermost on the
-      // left. The outermost should be on the right (item 6 of
-      // https://github.com/correctcomputation/checkedc-clang/issues/703).
+      // left. The outermost should be on the right
+      // (https://github.com/correctcomputation/checkedc-clang/issues/161).
       if (FV != nullptr) {
         FptrInner << "*";
         getQualString(TypeIdx, FptrInner);

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -848,8 +848,11 @@ PointerVariableConstraint::mkString(Constraints &CS,
     // parameter list. The function pointer code knows to emit the name before
     // EndStrs.
     //
-    // This passes the current regression tests but feels very ad-hoc.
-    // REVIEW: Help me redesign this code!
+    // This feels very ad-hoc but currently helps a number of the more complex
+    // regression tests and makes mkString correct in some additional cases in
+    // which 3C currently doesn't use it but might use it in the future. We hope
+    // to eventually overhaul this code
+    // (https://github.com/correctcomputation/checkedc-clang/issues/703).
     if (PrevArr && ArrSizes.at(TypeIdx).first != O_SizedArray && !EmittedName) {
       if (K != Atom::A_Wild || FV != nullptr) {
         addArrayAnnotations(ConstArrs, EndStrs);

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -917,23 +917,17 @@ PointerVariableConstraint::mkString(Constraints &CS,
     }
   }
 
-  // If we have a function pointer, we need to transfer any pending array
-  // levels to EndStrs before the FV code below reads EndStrs. It doesn't hurt
-  // to transfer pending array levels here unconditionally.
-  addArrayAnnotations(ConstArrs, EndStrs);
-
   if (!EmittedBase) {
     // If we have a FV pointer, then our "base" type is a function pointer type.
     if (FV) {
-      if (Ss.str().empty()) {
-        if (!EmittedName) {
-          FptrInner << UseName;
-          EmittedName = true;
-        }
-        for (std::string Str : EndStrs)
-          FptrInner << Str;
-        EndStrs.clear();
+      if (!EmittedName) {
+        FptrInner << UseName;
+        EmittedName = true;
       }
+      std::deque<std::string> FptrEndStrs;
+      addArrayAnnotations(ConstArrs, FptrEndStrs);
+      for (std::string Str : FptrEndStrs)
+        FptrInner << Str;
       bool EmitFVName = !FptrInner.str().empty();
       if (EmitFVName)
         Ss << FV->mkString(CS, MKSTRING_OPTS(UseName = FptrInner.str(),
@@ -959,6 +953,7 @@ PointerVariableConstraint::mkString(Constraints &CS,
   }
 
   // Add closing elements to type
+  addArrayAnnotations(ConstArrs, EndStrs);
   for (std::string Str : EndStrs) {
     Ss << Str;
   }

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -1001,7 +1001,7 @@ PointerVariableConstraint::mkString(Constraints &CS,
       Ss << Str;
   }
 
-  if (IsReturn && !ForItype)
+  if (IsReturn && !ForItype && !StringRef(Ss.str()).endswith("*"))
     Ss << " ";
 
   return Ss.str();

--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -833,10 +833,31 @@ PointerVariableConstraint::mkString(Constraints &CS,
     if (!ForItype && InferredGenericIndex == -1 && isVoidPtr())
       K = Atom::A_Wild;
 
+    // In a case like `_Ptr<T> g[1]`, we need to push the ` g` onto EndStrs
+    // before we can push the `>` and start drilling into T.
+    //
+    // Exception: In a case like `int *g[1]`, we don't want an extra space after
+    // the `*` but we don't yet know whether we have a `*`, so we skip emitting
+    // the name. We have to also skip the addArrayAnnotations because it would
+    // cause the array annotations to be emitted before the name.
+    //
+    // Exception to the exception: In a case like `void (*fs[2])()`, we still
+    // want to avoid emitting the name (which would add an extra space after the
+    // `*`), but we _do_ need to call addArrayAnnotations so the array
+    // annotations end up with the variable name rather than after the function
+    // parameter list. The function pointer code knows to emit the name before
+    // EndStrs.
+    //
+    // This passes the current regression tests but feels very ad-hoc.
+    // REVIEW: Help me redesign this code!
     if (PrevArr && ArrSizes.at(TypeIdx).first != O_SizedArray && !EmittedName) {
-      EmittedName = true;
-      addArrayAnnotations(ConstArrs, EndStrs);
-      EndStrs.push_front(" " + UseName);
+      if (K != Atom::A_Wild || FV != nullptr) {
+        addArrayAnnotations(ConstArrs, EndStrs);
+      }
+      if (K != Atom::A_Wild) {
+        EmittedName = true;
+        EndStrs.push_front(" " + UseName);
+      }
     }
     PrevArr = ArrSizes.at(TypeIdx).first == O_SizedArray;
 
@@ -926,6 +947,8 @@ PointerVariableConstraint::mkString(Constraints &CS,
   // the the stack array type.
   if (PrevArr && !EmittedName && AllArrays) {
     EmittedName = true;
+    // Note: If the whole type is an array, we can't have a "*", so we don't
+    // need to worry about an extra space.
     EndStrs.push_front(" " + UseName);
   }
 

--- a/clang/test/3C/compound_literal.c
+++ b/clang/test/3C/compound_literal.c
@@ -67,7 +67,7 @@ void lists() {
 
   int *d[2] = (int *[2]){&x, (int *)1};
   //CHECK_NOALL: int *d[2] = (int *[2]){&x, (int *)1};
-  //CHECK_ALL: int * d _Checked[2] = (int * _Checked[2]){&x, (int *)1};
+  //CHECK_ALL: int *d _Checked[2] = (int * _Checked[2]){&x, (int *)1};
   int *d0 = d[0];
   //CHECK: int *d0 = d[0];
 

--- a/clang/test/3C/definedType.c
+++ b/clang/test/3C/definedType.c
@@ -57,6 +57,8 @@ baz **f[1];
 // CHECK_ALL: _Ptr<_Ptr<baz>> f _Checked[1] = {((void *)0)};
 baz (*g)[1];
 // CHECK_ALL: _Ptr<baz _Checked[1]> g = ((void *)0);
+baz *(*g2)[1];
+// CHECK_ALL: _Ptr<_Ptr<baz> _Checked[1]> g2 = ((void *)0);
 baz h[1][1];
 // CHECK_ALL: baz h _Checked[1] _Checked[1];
 

--- a/clang/test/3C/fptr_array.c
+++ b/clang/test/3C/fptr_array.c
@@ -9,7 +9,7 @@
 
 void (*fs[2])(int *);
 void (*f)(int *);
-//CHECK_NOALL: void (* fs[2])(_Ptr<int>) = {((void *)0)};
+//CHECK_NOALL: void (*fs[2])(_Ptr<int>) = {((void *)0)};
 //CHECK_NOALL: void (*f)(_Ptr<int>) = ((void *)0);
 //CHECK_ALL: _Ptr<void (_Ptr<int>)> fs _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<void (_Ptr<int>)> f = ((void *)0);
@@ -17,7 +17,7 @@ void (*f)(int *);
 void (*gs[2])(int *);
 void g_impl(int *x) { x = 1; }
 void (*g)(int *) = g_impl;
-//CHECK_NOALL: void (* gs[2])(int * : itype(_Ptr<int>)) = {((void *)0)};
+//CHECK_NOALL: void (*gs[2])(int * : itype(_Ptr<int>)) = {((void *)0)};
 //CHECK_NOALL: void g_impl(int *x : itype(_Ptr<int>)) { x = 1; }
 //CHECK_NOALL: void (*g)(int * : itype(_Ptr<int>)) = g_impl;
 
@@ -30,21 +30,21 @@ void (*h)(void *);
 
 int *(*is[2])(void);
 int *(*i)(void);
-//CHECK_NOALL: _Ptr<int> (* is[2])(void) = {((void *)0)};
+//CHECK_NOALL: _Ptr<int> (*is[2])(void) = {((void *)0)};
 //CHECK_NOALL: _Ptr<int> (*i)(void) = ((void *)0);
 //CHECK_ALL: _Ptr<_Ptr<int> (void)> is _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<_Ptr<int> (void)> i = ((void *)0);
 
 int *(**js[2])(void);
 int *(**j)(void);
-//CHECK_NOALL: _Ptr<int> (** js[2])(void) = {((void *)0)};
+//CHECK_NOALL: _Ptr<int> (**js[2])(void) = {((void *)0)};
 //CHECK_NOALL: _Ptr<int> (**j)(void) = ((void *)0);
 //CHECK_ALL: _Ptr<_Ptr<_Ptr<int> (void)>> js _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<_Ptr<_Ptr<int> (void)>> j = ((void *)0);
 
 int *(*ks[2][2])(void);
 int *(*k)(void);
-//CHECK_NOALL: _Ptr<int> (* ks[2][2])(void) = {((void *)0)};
+//CHECK_NOALL: _Ptr<int> (*ks[2][2])(void) = {((void *)0)};
 //CHECK_NOALL: _Ptr<int> (*k)(void) = ((void *)0);
 //CHECK_ALL: _Ptr<_Ptr<int> (void)> ks _Checked[2] _Checked[2] = {((void *)0)};
 //CHECK_ALL: _Ptr<_Ptr<int> (void)> k = ((void *)0);

--- a/clang/test/3C/fptr_array.c
+++ b/clang/test/3C/fptr_array.c
@@ -53,6 +53,9 @@ void (* const l)(int *);
 //CHECK_NOALL: void (*const l)(_Ptr<int>) = ((void *)0);
 //CHECK_ALL: const _Ptr<void (_Ptr<int>)> l = ((void *)0);
 
+#define UNWRITABLE_MS_DECL void (*ms[2])(int *)
+UNWRITABLE_MS_DECL;
+
 void test(void){
   fs[1] = f;
   gs[1] = g;
@@ -63,4 +66,11 @@ void test(void){
   void (* const ls[1])(int *) = {l};
   //CHECK_NOALL: void (*const ls[1])(_Ptr<int>) = {l};
   //CHECK_ALL: const _Ptr<void (_Ptr<int>)> ls _Checked[1] = {l};
+
+  void (*(*pms)[2])(int *) = &ms;
+  //CHECK: _Ptr<void (*[2])(int *)> pms = &ms;
+
+  void (*(*apms[1])[2])(int *) = {&ms};
+  //CHECK_NOALL: void (*(*apms[1])[2])(int *) = {&ms};
+  //CHECK_ALL: _Ptr<void (*[2])(int *)> apms _Checked[1] = {&ms};
 }

--- a/clang/test/3C/itype_typedef.c
+++ b/clang/test/3C/itype_typedef.c
@@ -34,7 +34,7 @@ void test2(td2 a) {
 typedef int *td3;
 td3 test3() {
 //CHECK: typedef _Ptr<int> td3;
-//CHECK: int * test3(void) : itype(td3) {
+//CHECK: int *test3(void) : itype(td3) {
   return (int*) 1;
 }
 

--- a/clang/test/3C/itypes_for_extern.c
+++ b/clang/test/3C/itypes_for_extern.c
@@ -30,14 +30,19 @@ int *baz(int *a, int len, int *b) {
   return a;
 }
 
+// REVIEW: The problem described in the following comment has been fixed roughly
+// in the "first way": the canonical form of the type from mkString no longer
+// has the space, so the test will pass as long as the original code didn't have
+// the space either. If we still want to pursue the second fix, do we want to
+// note that somehow, e.g., by filing an issue?
 // FIXME: The space between after the first star is needed for the idempotence
 //        test to pass. If there isn't a space there, 3c will add one when
 //        re-run on its original output. This should be fixed ideally in two
 //        ways.  First, the space shouldn't be added when not present in the
 //        original source, and second, the second conversion should not rewrite
 //        the declaration.
-void buz(int * (*f)(int *, int *)) {}
-//CHECK: void buz(int * ((*f)(int *, int *)) : itype(_Ptr<_Ptr<int> (_Ptr<int>, _Ptr<int>)>)) _Checked {}
+void buz(int *(*f)(int *, int *)) {}
+//CHECK: void buz(int *((*f)(int *, int *)) : itype(_Ptr<_Ptr<int> (_Ptr<int>, _Ptr<int>)>)) _Checked {}
 
 typedef int * int_star;
 void typedef_test(int_star p) {}

--- a/clang/test/3C/itypes_for_extern.c
+++ b/clang/test/3C/itypes_for_extern.c
@@ -30,17 +30,6 @@ int *baz(int *a, int len, int *b) {
   return a;
 }
 
-// REVIEW: The problem described in the following comment has been fixed roughly
-// in the "first way": the canonical form of the type from mkString no longer
-// has the space, so the test will pass as long as the original code didn't have
-// the space either. If we still want to pursue the second fix, do we want to
-// note that somehow, e.g., by filing an issue?
-// FIXME: The space between after the first star is needed for the idempotence
-//        test to pass. If there isn't a space there, 3c will add one when
-//        re-run on its original output. This should be fixed ideally in two
-//        ways.  First, the space shouldn't be added when not present in the
-//        original source, and second, the second conversion should not rewrite
-//        the declaration.
 void buz(int *(*f)(int *, int *)) {}
 //CHECK: void buz(int *((*f)(int *, int *)) : itype(_Ptr<_Ptr<int> (_Ptr<int>, _Ptr<int>)>)) _Checked {}
 

--- a/clang/test/3C/ptr_array.c
+++ b/clang/test/3C/ptr_array.c
@@ -28,7 +28,7 @@ void test1(int *a) {
 
   int *b[1] = {a};
   //CHECK_NOALL: int *b[1] = {a};
-  //CHECK_ALL: int * b _Checked[1] = {a};
+  //CHECK_ALL: int *b _Checked[1] = {a};
 }
 
 /* Example from from the issue */
@@ -40,7 +40,7 @@ int *foo() {
   int z = 3;
   int *ptrs[4] = {&x, &y, &z, (int *)5};
   //CHECK_NOALL: int *ptrs[4] = {&x, &y, &z, (int *)5};
-  //CHECK_ALL: int * ptrs _Checked[4] = {&x, &y, &z, (int *)5};
+  //CHECK_ALL: int *ptrs _Checked[4] = {&x, &y, &z, (int *)5};
   int *ret;
   //CHECK: int *ret;
   for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
Most of these fixes are ones that were previously needed in #657 when it switched all unchanged multi-decl members from `Decl::print` to `mkString`, in order to prevent 3C's output from getting worse on some unchanged multi-decl members in the regression tests. The fixes are no longer needed for that reason, but Mike still asked me to submit them. See the commit messages for additional information.

This PR addresses several of the sub-issues of #703.