### PR TITLE
Reduce minimum number of affected pointers for `-warn-root-cause`

### DIFF
--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -593,7 +593,7 @@ void RewriteConsumer::emitRootCauseDiagnostics(ASTContext &Context) {
         // or are in the main file of the TU. Alternatively, don't filter causes
         // if -warn-all-root-cause is passed.
         int PtrCount = I.getNumPtrsAffected(WReason.first);
-        if (_3COpts.WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 1) {
+        if (_3COpts.WarnAllRootCause || SM.isInMainFile(SL) || PtrCount > 0) {
           // SL is invalid when the File is not in the current translation unit.
           if (SL.isValid()) {
             EmittedDiagnostics.insert(PSL);

--- a/clang/test/3C/root_cause.c
+++ b/clang/test/3C/root_cause.c
@@ -106,5 +106,9 @@ void test_conflict() {
 // expected-note@#as_ptr {{Operand of address-of has PTR lower bound}}
 // expected-note@#as_nt {{Assigning from c to s}}
 
-
-
+#include "root_cause.h"
+void undef_caller() {
+  int *p;
+  undefined(p);
+  // unwritable-expected-warning@-1 {{0 unchecked pointers: Source code in non-writable file}}
+}

--- a/clang/test/3C/root_cause.h
+++ b/clang/test/3C/root_cause.h
@@ -1,0 +1,7 @@
+// Test that root cause errors are reported correctly in include header files.
+// Included by root_cause.c
+
+void undefined(int *p);
+// expected-warning@-1 {{1 unchecked pointer: Unchecked pointer in parameter or return of undefined function undefined}}
+// unwritable-expected-warning@-2 {{0 unchecked pointers: Source code in non-writable file}}
+// unwritable-expected-warning@-3 {{0 unchecked pointers: Unchecked pointer in parameter or return of undefined function undefined}}


### PR DESCRIPTION
I've found that this change would be useful for the libjpeg tutorial, and matt has previously found that would be useful for the tiny-bignum tutorual. Fixes correctcomputation/checkedc-clang#685.